### PR TITLE
Fixing Windows-only Tailwind binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-optional
       - name: Type check
         run: npm run type-check
       - name: Run tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-optional
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-optional
       - name: Generate library data
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-optional=true

--- a/scripts/generate-library.ts
+++ b/scripts/generate-library.ts
@@ -9,8 +9,8 @@
  * Or via npm: npm run generate
  *
  * Required env vars:
- *   GITHUB_USERNAME - whose repos to fetch (default: perditioinc)
- *   GITHUB_TOKEN    - GitHub PAT for 5000 req/hour rate limit
+ *   GH_USERNAME - whose repos to fetch (default: perditioinc)
+ *   GH_TOKEN    - GitHub PAT for 5000 req/hour rate limit
  */
 
 import * as fs from 'fs';
@@ -51,8 +51,8 @@ import { buildBuilder, assignDimension, buildBuilderStats, buildSkillStats, AI_D
 import { batchFetch } from '../src/lib/rateLimit';
 import { LibraryData, LibraryStats, EnrichedRepo } from '../src/types/repo';
 
-const username = process.env.GITHUB_USERNAME || 'perditioinc';
-const token = process.env.GITHUB_TOKEN || undefined;
+const username = process.env.GH_USERNAME || 'perditioinc';
+const token = process.env.GH_TOKEN || undefined;
 
 /** Calculate percentage breakdown from bytes map */
 function computePercentages(breakdown: Record<string, number>): Record<string, number> {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 export const config = {
-  githubUsername: process.env.GITHUB_USERNAME || process.env.NEXT_PUBLIC_GITHUB_USERNAME || 'perditioinc',
-  githubToken: process.env.GITHUB_TOKEN || '',
+  githubUsername: process.env.GH_USERNAME || process.env.NEXT_PUBLIC_GITHUB_USERNAME || 'perditioinc',
+  githubToken: process.env.GH_TOKEN || '',
   appTitle: process.env.NEXT_PUBLIC_APP_TITLE || 'Reporium',
   appDescription: process.env.NEXT_PUBLIC_APP_DESCRIPTION || 'Your GitHub Knowledge Library',
   cacheTtlSeconds: 7200,


### PR DESCRIPTION
The problem is package-lock.json was generated on Windows and includes a Windows-only Tailwind binary that can't install on Linux (where GitHub Actions runs).

## Description
<!-- What does this PR do? -->

## Changes
<!-- List key changes -->

## Checklist
- [ ] Tests added or updated
- [ ] JSDoc updated for any changed exported functions
- [ ] CHANGELOG.md updated
- [ ] No secrets or personal data committed
- [ ] `.env.local` remains gitignored
