### PR TITLE
fix: add configure-pages and generate step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -32,6 +35,12 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Generate library data
+        run: npm run generate
+        env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Build static export
         run: npm run build


### PR DESCRIPTION
- Add actions/configure-pages@v4 before build
- Run npm run generate (with GH_TOKEN + GH_USERNAME) before build so public/data/library.json exists when Next.js static export runs

## Description
<!-- What does this PR do? -->

## Changes
<!-- List key changes -->

## Checklist
- [ ] Tests added or updated
- [ ] JSDoc updated for any changed exported functions
- [ ] CHANGELOG.md updated
- [ ] No secrets or personal data committed
- [ ] `.env.local` remains gitignored
