### PR TITLE
fix: prefix data fetches with NEXT_PUBLIC_BASE_PATH for GitHub Pages …

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,8 @@ export default function HomePage() {
       setError(null);
       setData(null);
       try {
-        const res = await fetch('/data/library.json');
+        const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+        const res = await fetch(`${basePath}/data/library.json`);
         if (!res.ok) {
           if (res.status === 404) {
             if (!cancelled) setError('Library data not found. Run `npm run generate` to generate it.');
@@ -73,7 +74,7 @@ export default function HomePage() {
         const d = (await res.json()) as LibraryData;
         if (!cancelled) setData(d);
         // Fetch trends.json non-blocking
-        fetch('/data/trends.json')
+        fetch(`${basePath}/data/trends.json`)
           .then(r => r.ok ? r.json() : null)
           .then(t => { if (!cancelled && t) setTrends(t as TrendData); })
           .catch(() => {}); // trends are optional


### PR DESCRIPTION
…subdirectory

Fetches to /data/library.json and /data/trends.json now resolve correctly under /reporium/ when deployed to GitHub Pages.

## Description
<!-- What does this PR do? -->

## Changes
<!-- List key changes -->

## Checklist
- [ ] Tests added or updated
- [ ] JSDoc updated for any changed exported functions
- [ ] CHANGELOG.md updated
- [ ] No secrets or personal data committed
- [ ] `.env.local` remains gitignored
