### PR TITLE
fix: skip generate step if library.json already exists in deploy work…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,12 @@ jobs:
         run: npm test
 
       - name: Generate library data
-        run: npm run generate
+        run: |
+          if [ ! -f public/data/library.json ]; then
+            npm run generate
+          else
+            echo 'library.json already exists, skipping generate'
+          fi
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
…flow

## Description
<!-- What does this PR do? -->

## Changes
<!-- List key changes -->

## Checklist
- [ ] Tests added or updated
- [ ] JSDoc updated for any changed exported functions
- [ ] CHANGELOG.md updated
- [ ] No secrets or personal data committed
- [ ] `.env.local` remains gitignored
