### PR TITLE
fix: normalize stale category names in filter bar

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,6 +17,15 @@
 
 ## What Is Next
 
+### Taxonomy Expansion — 12 → 28 Skill Areas (Issue #17)
+- **Branch**: `feature/taxonomy-expansion`
+- **Spec**: [docs/TAXONOMY.md](docs/TAXONOMY.md)
+- **Goal**: Expand from 12 AI Dev Coverage badges to 28 skill areas (6 lifecycle groups), 58 categories, ~200 curated tags
+- **Phase 1** (Week 1): DB schema migration — add `lifecycleGroup`, expand `skillAreas` enum
+- **Phase 2** (Week 2): Re-enrich all 1,406 repos with updated Claude prompt (~$4.20)
+- **Phase 3** (Week 3): Frontend — 28-badge grid grouped by lifecycle, 58-category sidebar, curated tag cloud
+- **Phase 4** (Week 4): Prune ~440 noise tags, update API endpoints, add tests, deploy to production
+
 ### Public Query UI
 - Add a search box to reporium.com that calls `/intelligence/query`
 - Requires prompt injection protection before exposing to public traffic

--- a/docs/TAXONOMY.md
+++ b/docs/TAXONOMY.md
@@ -1,0 +1,197 @@
+# AI Knowledge Graph Taxonomy
+
+> Version: 2.0 — Taxonomy Expansion (Issue #17)
+> Replaces: 12 AI Dev Coverage badges → 28 Skill Areas
+
+## Overview
+
+This document defines the canonical AI taxonomy for Reporium: 28 skill areas organized into 6 lifecycle groups, 58 categories for sidebar navigation, and ~200 curated AI-specific tags.
+
+---
+
+## Level 1: Skill Areas (28 total, 6 lifecycle groups)
+
+### Group 1 — Foundation & Training
+| Skill Area | Description |
+|---|---|
+| Foundation Model Architecture | Transformer variants, attention mechanisms, model pre-training, scaling laws |
+| Fine-tuning & Alignment | SFT, RLHF, DPO, LoRA, PEFT, instruction tuning, RLAIF |
+| Data Engineering | Dataset curation, cleaning pipelines, data versioning, feature stores |
+| Synthetic Data | LLM-generated datasets, data augmentation, simulation, distillation |
+
+### Group 2 — Inference & Deployment
+| Skill Area | Description |
+|---|---|
+| Inference & Serving | vLLM, TensorRT, batching, KV cache, serving frameworks, model APIs |
+| Model Compression | Quantization, pruning, distillation, sparsity, mixed precision |
+| Edge AI | On-device inference, mobile ML, embedded AI, WASM/WebGPU |
+
+### Group 3 — LLM Application Layer
+| Skill Area | Description |
+|---|---|
+| Agents & Orchestration | Agent loops, multi-agent systems, task planners, LangGraph, AutoGen |
+| RAG & Retrieval | Vector search, hybrid retrieval, chunking strategies, re-ranking |
+| Context Engineering | Context windows, long-context, memory systems, context compression |
+| Tool Use | Function calling, code execution, browser use, MCP, plugin systems |
+| Structured Output | JSON mode, schema enforcement, constrained decoding, extraction |
+| Prompt Engineering | System prompts, chain-of-thought, few-shot, prompt optimization |
+| Knowledge Graphs | Entity extraction, graph construction, ontologies, GraphRAG |
+
+### Group 4 — Eval / Safety / Ops
+| Skill Area | Description |
+|---|---|
+| Evaluation | Benchmarks, LLM-as-judge, evals frameworks, regression testing |
+| Security & Guardrails | Jailbreak defense, content moderation, red teaming, prompt injection |
+| Observability | Tracing, logging, dashboards, cost tracking, latency monitoring |
+| MLOps | Experiment tracking, model registry, CI/CD for ML, deployment automation |
+| AI Governance | Bias detection, compliance, model cards, audit logging, fairness |
+
+### Group 5 — Modality-Specific
+| Skill Area | Description |
+|---|---|
+| Computer Vision | Image classification, object detection, segmentation, vision transformers |
+| Speech & Audio | ASR, TTS, audio generation, speaker diarization, audio LLMs |
+| Generative Media | Image/video generation, diffusion models, creative AI, 3D generation |
+| NLP | Text classification, NER, summarization, translation, classical NLP |
+| Multimodal | Vision-language models, audio-visual, document understanding, VLMs |
+
+### Group 6 — Applied AI
+| Skill Area | Description |
+|---|---|
+| Coding Assistants | Code generation, completion, review, debugging, test generation |
+| Robotics | Embodied AI, robot learning, sim-to-real, manipulation, navigation |
+| AI for Science | Protein folding, drug discovery, climate, materials science, math |
+| Recommendation Systems | Collaborative filtering, content-based, LLM recommendations |
+
+---
+
+## Level 2: Categories (58 total)
+
+### Foundation & Training Categories
+- Transformer Architecture
+- Attention Mechanisms
+- Pre-training & Scaling
+- Fine-tuning Methods (LoRA, QLoRA, PEFT)
+- RLHF & Alignment
+- DPO & Preference Learning
+- Dataset Curation
+- Data Pipelines
+- Synthetic Dataset Generation
+- Data Augmentation
+
+### Inference & Deployment Categories
+- Inference Engines (vLLM, TGI)
+- Serving Infrastructure
+- KV Cache Optimization
+- Quantization (GPTQ, AWQ, GGUF)
+- Model Pruning
+- Knowledge Distillation
+- On-Device Inference
+- Mobile & Edge ML
+- WebGPU / WASM Inference
+
+### LLM Application Layer Categories
+- Agent Frameworks
+- Multi-Agent Systems
+- RAG Pipelines
+- Vector Databases
+- Chunking & Embedding
+- Memory Systems
+- Function Calling
+- MCP Servers & Clients
+- Browser Automation
+- JSON / Structured Extraction
+- Prompt Optimization
+- Chain-of-Thought
+- Graph Databases
+- Entity Extraction
+
+### Eval / Safety / Ops Categories
+- Eval Frameworks
+- Benchmarking
+- LLM-as-Judge
+- Content Moderation
+- Red Teaming
+- Prompt Injection Defense
+- LLM Tracing & Logging
+- Cost & Latency Monitoring
+- Experiment Tracking
+- Model Registry
+- ML CI/CD
+- Bias & Fairness
+- Model Cards & Compliance
+
+### Modality-Specific Categories
+- Image Classification
+- Object Detection
+- Semantic Segmentation
+- Vision Transformers
+- Speech Recognition (ASR)
+- Text-to-Speech (TTS)
+- Audio Generation
+- Diffusion Models
+- Image Generation
+- Video Generation
+- Text Classification
+- Named Entity Recognition
+- Machine Translation
+- Vision-Language Models
+- Document Understanding
+
+### Applied AI Categories
+- Code Generation
+- Code Review & Analysis
+- Robot Learning
+- Simulation & Sim-to-Real
+- Protein Structure Prediction
+- Drug Discovery
+- Collaborative Filtering
+
+---
+
+## Level 3: Tag Curation Rules (~200 tags)
+
+### Keep (AI-specific, high signal)
+Tags to retain: transformer, attention, llm, rag, fine-tuning, lora, qlora, peft, rlhf, dpo, quantization, distillation, pruning, vllm, tgi, inference, embeddings, vector-search, langchain, langgraph, autogen, openai, anthropic, claude, gpt, gemini, llama, mistral, phi, mixtral, mcp, function-calling, structured-output, json-schema, prompt-engineering, chain-of-thought, agent, multi-agent, tool-use, rag-pipeline, chunking, re-ranking, faiss, qdrant, weaviate, pinecone, chroma, guardrails, red-teaming, jailbreak, content-moderation, evals, benchmarks, openai-evals, lm-evaluation-harness, mlflow, wandb, dvc, mlops, diffusion, stable-diffusion, flux, comfyui, controlnet, whisper, tts, asr, vision-language, clip, sam, yolo, detectron, segment-anything, protein-folding, alphafold, drug-discovery, robotics, ros, sim-to-real, recommendation, collaborative-filtering, knowledge-graph, graphrag, neo4j, edge-ai, mobile-ml, onnx, tensorrt, webgpu, synthetic-data, data-augmentation, dataset
+
+### Remove (noise — not AI-specific)
+Tags to prune: python, javascript, typescript, rust, go, java, c++, react, nextjs, nodejs, express, fastapi, flask, django, postgresql, mysql, mongodb, redis, docker, kubernetes, aws, gcp, azure, terraform, nginx, linux, macos, windows, git, github, api, rest, graphql, grpc, websocket, cli, sdk, library, framework, tutorial, example, demo, template, boilerplate, starter, awesome, list, collection, open-source, free, fast, simple, easy, lightweight, minimal
+
+### Curation Policy
+1. A tag must describe an AI/ML concept, tool, or technique — not a general programming language or infrastructure term
+2. Repo-specific tags (one-off names, version numbers) are removed automatically
+3. Tags appearing on fewer than 3 repos are candidates for removal unless highly specific (e.g., `alphafold`)
+4. Aliases are collapsed: `gpt-4` → `gpt`, `claude-3` → `claude`, `llama-2` → `llama`
+
+---
+
+## Migration Plan
+
+### Phase 1 — Schema (Week 1)
+- Update `skillAreas` enum in DB schema from 12 to 28 values
+- Add `lifecycleGroup` field to category model
+- Run migration on staging
+
+### Phase 2 — Re-enrichment (Week 2)
+- Update Claude enrichment prompt with new taxonomy
+- Re-enrich all 1,406 repos (estimated ~$4.20 at current token costs)
+- Validate category distribution — target no skill area with >15% of repos
+
+### Phase 3 — Frontend (Week 3)
+- Update badge grid from 12 → 28 skill areas
+- Group badges by lifecycle group (collapsible sections)
+- Update sidebar category filter to 58 categories
+- Tag cloud shows only curated ~200 tags
+
+### Phase 4 — Cleanup (Week 4)
+- Prune ~440 noise tags from DB
+- Update API `/categories` and `/tags` endpoints
+- Add unit tests for taxonomy validation
+- Deploy to production + verify on reporium.com
+
+---
+
+## References
+- Based on: MAD 2025, HuggingFace Hub categories, Papers with Code taxonomy, a16z AI stack
+- Research doc: `ai-development-taxonomy.md` (internal)
+- GitHub Issue: [#17](https://github.com/perditioinc/reporium/issues/17)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,29 @@ export default function HomePage() {
 
   const allLanguages = useMemo(() => data?.stats.languages ?? [], [data]);
 
+  /** Map stale DB category names → current taxonomy names.
+   *  Keeps the filter bar clean until the DB/API backfill corrects the source data. */
+  const CATEGORY_ALIASES: Record<string, string> = {
+    'Audio':       'Industry: Audio & Music',
+    'Fine Tuning': 'Model Training',
+    'Evaluation':  'Evals & Benchmarking',
+    'Deployment':  'MLOps & Infrastructure',
+  };
+
+  /** Categories with stale names merged into their canonical equivalents. */
+  const normalizedCategories = useMemo(() => {
+    if (!data?.categories) return [];
+    const catMap = new Map(data.categories.map(c => ({ ...c })).map(c => [c.name, c]));
+    for (const [stale, canonical] of Object.entries(CATEGORY_ALIASES)) {
+      const staleEntry = catMap.get(stale);
+      if (!staleEntry) continue;
+      catMap.delete(stale);
+      const canonicalEntry = catMap.get(canonical);
+      if (canonicalEntry) canonicalEntry.repoCount += staleEntry.repoCount;
+    }
+    return Array.from(catMap.values());
+  }, [data]);
+
   const industryStats = useMemo(() => {
     if (!data) return [];
     const counts = new Map<string, number>();
@@ -178,10 +201,13 @@ export default function HomePage() {
         if (!repo.forkSync || repo.forkSync.behindBy === 0) return false;
       }
 
-      // Category filter
+      // Category filter — normalize stale allCategories names before comparing
       if (selectedCategory) {
-        const categoryName = data.categories.find(c => c.id === selectedCategory)?.name;
-        if (categoryName && !repo.allCategories.includes(categoryName)) return false;
+        const categoryName = normalizedCategories.find(c => c.id === selectedCategory)?.name;
+        if (categoryName) {
+          const normalizedRepoCats = repo.allCategories.map(c => CATEGORY_ALIASES[c] ?? c);
+          if (!normalizedRepoCats.includes(categoryName)) return false;
+        }
       }
 
       // AI Dev Skills filter
@@ -341,7 +367,7 @@ export default function HomePage() {
                 selectedActivity={selectedActivity}
                 selectedSyncStatus={selectedSyncStatus}
                 sortBy={sortBy}
-                categories={data.categories ?? []}
+                categories={normalizedCategories}
                 selectedCategory={selectedCategory}
                 onCategoryChange={setSelectedCategory}
                 onTypeChange={setSelectedType}


### PR DESCRIPTION
## Problem

The filter bar shows separate entries for legacy category names that no longer exist in the taxonomy:
- **Audio** (1 repo) — should be merged into **Industry: Audio & Music**
- **Deployment** (2 repos) — should be merged into **MLOps & Infrastructure**  
- **Fine Tuning** (1 repo) — should be merged into **Model Training**
- **Evaluation** (1 repo) — should be merged into **Evals & Benchmarking**

These persist because the DB stores old category names in `repos.allCategories`, and the API's `_build_category_metrics()` passes them through as-is.

## Fix

`normalizedCategories` useMemo in `page.tsx`:
- Merges stale category entries into their canonical equivalents, adding `repoCount`
- Removes the stale entries from the categories list
- `FilterBar` receives clean categories with no legacy entries

Filter predicate also normalizes `repo.allCategories` before comparing, so repos with old DB names still match the correct canonical filter.

## Root cause (tracked separately)

The API's `_build_category_metrics()` should normalize category names at source. This is a frontend guard until that DB/API fix lands.

## Tests

- TypeScript: no errors
- 1534 unit tests passing