### PR TITLE
fix: pass normalizedCategories to MetricsSidebar (#19)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const config = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   testMatch: ['**/tests/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/.claude/worktrees/'],
 };
 
 module.exports = config;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -411,7 +411,7 @@ export default function HomePage() {
           {/* Desktop sidebar */}
           <aside className="hidden lg:flex flex-col w-[380px] shrink-0 border-l border-zinc-800 bg-zinc-950">
             <MetricsSidebar
-              data={data}
+              data={{ ...data, categories: normalizedCategories }}
               selectedTags={selectedTags}
               tagMetrics={data.tagMetrics ?? []}
               intersectionMetrics={intersectionMetrics}
@@ -437,7 +437,7 @@ export default function HomePage() {
               />
               <div className="w-[340px] border-l border-zinc-800 bg-zinc-950 overflow-y-auto">
                 <MetricsSidebar
-                  data={data}
+                  data={{ ...data, categories: normalizedCategories }}
                   selectedTags={selectedTags}
                   tagMetrics={data.tagMetrics ?? []}
                   intersectionMetrics={intersectionMetrics}


### PR DESCRIPTION
## Summary
- Fixes issue #19: LIBRARY BY CATEGORY sidebar showing stale entries (Audio:1, Deployment:2)
- Passes `{ ...data, categories: normalizedCategories }` to both MetricsSidebar instances (desktop + mobile)
- Same normalization already applied to FilterBar now applies to sidebar — no API/DB change needed
- Also adds `testPathIgnorePatterns` for `.claude/worktrees/` to prevent stale agent test files from polluting CI

## Test plan
- [ ] Verify sidebar LIBRARY BY CATEGORY no longer shows Audio or Deployment entries
- [ ] Verify canonical categories (Industry: Audio & Music, MLOps & Infrastructure) have correct combined counts
- [ ] All 197 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)