### PR TITLE
feat(ux): cold-start loading banner during full library fetch (#29)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from '@/components/SearchBar';
 import { FilterBar } from '@/components/FilterBar';
 import { RepoGrid } from '@/components/RepoGrid';
 import { LoadingState } from '@/components/LoadingState';
+import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
@@ -326,6 +327,8 @@ export default function HomePage() {
     <div className="flex h-screen bg-zinc-950 overflow-hidden">
       {/* ── Main content ── */}
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+        {/* Stage 2 loading banner — fades in/out while owned repos stay visible */}
+        <LoadingBanner visible={isLoadingFull} />
         <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
           {/* Header */}
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -339,13 +342,6 @@ export default function HomePage() {
               {/* API connected badge — production mode only */}
               {provider.mode === 'production' && (
                 <span className="text-xs text-zinc-500 border border-zinc-700 rounded px-2 py-0.5">API connected</span>
-              )}
-              {/* Full library loading indicator */}
-              {isLoadingFull && (
-                <span className="flex items-center gap-1.5 text-xs text-zinc-500">
-                  <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-2 border-zinc-600 border-t-zinc-400" />
-                  Loading full library…
-                </span>
               )}
               {/* Mobile sidebar toggle */}
               <button

--- a/src/components/LoadingBanner.tsx
+++ b/src/components/LoadingBanner.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+interface LoadingBannerProps {
+  visible: boolean;
+}
+
+/**
+ * Subtle top banner shown during Stage 2 (full library fetch).
+ * Fades in/out without disrupting already-loaded content below.
+ */
+export function LoadingBanner({ visible }: LoadingBannerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading full library"
+      className={[
+        'w-full flex items-center justify-center gap-2.5 py-2 px-4',
+        'bg-zinc-900/80 border-b border-zinc-800 text-xs text-zinc-400',
+        'transition-all duration-500 ease-in-out overflow-hidden',
+        visible ? 'max-h-10 opacity-100' : 'max-h-0 opacity-0 border-b-0 py-0',
+      ].join(' ')}
+    >
+      {/* Pulsing dot */}
+      <span className="relative flex h-2 w-2 shrink-0">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-60" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+      </span>
+      <span>Loading full library (1,400+ repos)…</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `LoadingBanner` component: a subtle top bar with a pulsing blue dot and "Loading full library (1,400+ repos)…" text
- Wires it into `page.tsx` via `isLoadingFull` — renders above the scrollable content area so it doesn't shift or hide already-loaded owned repos
- Banner fades in/out smoothly using Tailwind `transition-all` / `max-h` + `opacity` animation; disappears automatically when Stage 2 completes

## Test plan
- [ ] On cold start, Stage 1 owned repos appear immediately with the banner visible at the top
- [ ] Owned repo cards remain visible and interactive (search, filter, click) while banner is shown
- [ ] Banner disappears smoothly once full library finishes loading
- [ ] No banner shown when `isLoadingFull=false` (e.g., after full load or on error)
- [ ] `aria-live="polite"` ensures screen readers announce the status change

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)