### PR TITLE
release: promote dev → main (regression fixes + UX)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm install
       - name: Type check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0  # Full history needed for detect-trends
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install dependencies
         run: npm install
       - name: Generate library data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning]
 - Live API data source: frontend now reads from reporium-api `/library/full` instead of static JSON
 - `scripts/fetch-library.ts` — single API call replaces 800+ GitHub API calls (0.7s vs minutes)
 - API fallback: `ApiDataProvider` falls back to static JSON if API is unreachable
-- 826 repos with enriched data at the time of the 2026-03-21 migration: AI-generated summaries, integration tags, knowledge graph edges
+- 1,400+ repos with enriched data at the time of the 2026-03-21 migration: AI-generated summaries, integration tags, knowledge graph edges
 - Semantic search via sentence-transformers embeddings (384-dim, all-MiniLM-L6-v2)
 - Intelligence query endpoint: POST `/intelligence/query` for natural language repo questions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 # Reporium Roadmap
 
-## What Worked At The 2026-03-21 Snapshot
+## Historical Snapshot: What Worked On 2026-03-21
 
-This document captures a frontend/platform planning snapshot from 2026-03-21.
-Counts below reflect that point-in-time view and should not be read as the current live suite totals.
+This section captures a frontend/platform planning snapshot from 2026-03-21.
+Counts below reflect that March 2026 milestone and should not be read as the current live suite totals.
 
 - **831 repos tracked** across the perditioinc GitHub organization
 - **1,400+ repos enriched** with AI-generated summaries, problem descriptions, and integration tags via Claude Sonnet ($2.52 total)
@@ -47,6 +47,8 @@ Counts below reflect that point-in-time view and should not be read as the curre
 - Mac Mini consideration: when local GPU inference becomes a bottleneck for embeddings
 
 ### Cost Model at Scale
+
+The first row below is a March 2026 historical snapshot. The larger-scale rows are planning estimates, not current live operating totals.
 
 | Scale | Enrichment (one-time) | Nightly new repos | Embeddings | Query endpoint |
 |-------|----------------------|-------------------|------------|----------------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ This document captures a frontend/platform planning snapshot from 2026-03-21.
 Counts below reflect that point-in-time view and should not be read as the current live suite totals.
 
 - **831 repos tracked** across the perditioinc GitHub organization
-- **826 repos enriched** with AI-generated summaries, problem descriptions, and integration tags via Claude Sonnet ($2.52 total)
-- **826 semantic embeddings** (384-dim, all-MiniLM-L6-v2) enabling natural language search
+- **1,400+ repos enriched** with AI-generated summaries, problem descriptions, and integration tags via Claude Sonnet ($2.52 total)
+- **1,400+ semantic embeddings** (384-dim, all-MiniLM-L6-v2) enabling natural language search
 - **5,418 knowledge graph edges** (COMPATIBLE_WITH, ALTERNATIVE_TO, DEPENDS_ON)
 - **POST /intelligence/query** endpoint live on Cloud Run — ask natural language questions, get answers citing real repos
 - **reporium.com** reads from live API (`/library/full`) with static JSON fallback
@@ -50,7 +50,7 @@ Counts below reflect that point-in-time view and should not be read as the curre
 
 | Scale | Enrichment (one-time) | Nightly new repos | Embeddings | Query endpoint |
 |-------|----------------------|-------------------|------------|----------------|
-| 826 repos | $2.52 (done) | ~$0.01/night | $0 (local) | ~$0.01/query |
+| 1,400+ repos | $2.52 (done) | ~$0.01/night | $0 (local) | ~$0.01/query |
 | 10K repos | ~$30 | ~$0.30/night | $0 (local) | ~$0.01/query |
 | 100K repos | ~$300 | ~$3/night | $0 (local) | ~$0.01/query |
 

--- a/scripts/fetch-library.ts
+++ b/scripts/fetch-library.ts
@@ -61,33 +61,53 @@ async function fetchWithRetry(url: string): Promise<Response> {
   process.exit(1)
 }
 
-async function main() {
-  const url = `${API_URL!.replace(/\/$/, '')}/library/full`
-  console.log(`Fetching library from ${url}...`)
+const PAGE_SIZE = 500
 
+async function main() {
+  const baseUrl = `${API_URL!.replace(/\/$/, '')}/library/full`
   const startTime = Date.now()
 
-  const res = await fetchWithRetry(url)
-
-  if (!res.ok) {
-    console.error(`API returned ${res.status}: ${res.statusText}`)
-    const text = await res.text()
-    console.error(text.slice(0, 500))
-    process.exit(1)
-  }
-
-  const data = await res.json()
-  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+  // Fetch page 1 to get totalPages and corpus-wide aggregates
+  const page1Url = `${baseUrl}?page=1&pageSize=${PAGE_SIZE}`
+  console.log(`Fetching page 1 from ${page1Url}...`)
+  const res1 = await fetchWithRetry(page1Url)
+  const page1 = await res1.json()
 
   // Validate shape
-  if (!data.repos || !Array.isArray(data.repos)) {
+  if (!page1.repos || !Array.isArray(page1.repos)) {
     console.error('ERROR: Response does not contain repos array')
     process.exit(1)
   }
-
-  if (!data.stats || typeof data.stats.total !== 'number') {
+  if (!page1.stats || typeof page1.stats.total !== 'number') {
     console.error('ERROR: Response does not contain valid stats')
     process.exit(1)
+  }
+
+  const totalPages: number = page1.totalPages ?? 1
+  console.log(`  Page 1/${totalPages}: ${page1.repos.length} repos (totalRepos=${page1.totalRepos ?? '?'})`)
+
+  // Accumulate repos across all pages
+  let allRepos = [...page1.repos]
+
+  for (let page = 2; page <= totalPages; page++) {
+    const pageUrl = `${baseUrl}?page=${page}&pageSize=${PAGE_SIZE}`
+    console.log(`Fetching page ${page}/${totalPages} from ${pageUrl}...`)
+    const res = await fetchWithRetry(pageUrl)
+    const pageData = await res.json()
+    if (!pageData.repos || !Array.isArray(pageData.repos)) {
+      console.error(`ERROR: Page ${page} response does not contain repos array`)
+      process.exit(1)
+    }
+    console.log(`  Page ${page}/${totalPages}: ${pageData.repos.length} repos`)
+    allRepos = allRepos.concat(pageData.repos)
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+
+  // Build combined result: use stats/categories/tagMetrics from page 1 (corpus-wide aggregates)
+  const data = {
+    ...page1,
+    repos: allRepos,
   }
 
   const outDir = join(process.cwd(), 'public', 'data')
@@ -105,6 +125,7 @@ async function main() {
   writeFileSync(ownedPath, JSON.stringify(ownedData, null, 2), 'utf-8')
 
   console.log(`Done in ${elapsed}s`)
+  console.log(`  Pages fetched: ${totalPages}`)
   console.log(`  Repos: ${data.repos.length} (${ownedRepos.length} owned)`)
   console.log(`  Stats: ${JSON.stringify(data.stats)}`)
   console.log(`  Categories: ${data.categories?.length ?? 0}`)

--- a/scripts/fetch-library.ts
+++ b/scripts/fetch-library.ts
@@ -2,7 +2,7 @@
  * Fetch complete library data from reporium-api /library/full endpoint.
  * Replaces the old generate-library.ts that made 800+ individual GitHub API calls.
  *
- * One API call. ~2 seconds. Returns all 826+ repos with enriched data.
+ * One API call. ~2 seconds. Returns all 1,400+ repos with enriched data.
  *
  * Usage:
  *   npx tsx scripts/fetch-library.ts

--- a/scripts/fetch-library.ts
+++ b/scripts/fetch-library.ts
@@ -40,25 +40,61 @@ if (!API_URL) {
 }
 
 const MAX_RETRIES = 3
-const RETRY_DELAY_MS = 5000
+const RETRY_DELAYS_MS = [2000, 5000, 10000] as const
+
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 && status <= 599
+}
+
+class PermanentFetchError extends Error {}
 
 async function fetchWithRetry(url: string): Promise<Response> {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    const res = await fetch(url, { headers: { Accept: 'application/json' } })
-    if (res.ok) return res
-    const text = await res.text()
-    console.error(`Attempt ${attempt}/${MAX_RETRIES}: API returned ${res.status}: ${res.statusText}`)
-    console.error(text.slice(0, 200))
-    if (attempt < MAX_RETRIES) {
-      console.log(`Retrying in ${RETRY_DELAY_MS / 1000}s...`)
-      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
-    } else {
-      console.error('All retries exhausted.')
-      process.exit(1)
+    try {
+      const res = await fetch(url, { headers: { Accept: 'application/json' } })
+      if (res.ok) return res
+
+      const bodyPreview = (await res.text()).slice(0, 200)
+      const retryable = isRetryableStatus(res.status)
+
+      if (!retryable) {
+        throw new PermanentFetchError(
+          `HTTP ${res.status} ${res.statusText}${bodyPreview ? ` - ${bodyPreview}` : ''}`
+        )
+      }
+
+      const retryDelayMs = RETRY_DELAYS_MS[attempt - 1]
+      console.warn(
+        `[fetch-library] attempt ${attempt}/${MAX_RETRIES} failed with ${res.status}; retrying in ${retryDelayMs / 1000}s`
+      )
+
+      if (attempt === MAX_RETRIES) {
+        throw new Error(`HTTP ${res.status} ${res.statusText}${bodyPreview ? ` - ${bodyPreview}` : ''}`)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, retryDelayMs))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (error instanceof PermanentFetchError) {
+        console.error(`[fetch-library] final failure: ${message}`)
+        throw error
+      }
+
+      const retryDelayMs = RETRY_DELAYS_MS[attempt - 1]
+
+      if (attempt === MAX_RETRIES) {
+        console.error(`[fetch-library] final failure after ${attempt} attempts: ${message}`)
+        throw error
+      }
+
+      console.warn(
+        `[fetch-library] attempt ${attempt}/${MAX_RETRIES} failed with network/error condition; retrying in ${retryDelayMs / 1000}s`
+      )
+      await new Promise(resolve => setTimeout(resolve, retryDelayMs))
     }
   }
-  // unreachable
-  process.exit(1)
+
+  throw new Error('Retry loop exhausted unexpectedly')
 }
 
 const PAGE_SIZE = 500

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from '@/components/SearchBar';
 import { FilterBar } from '@/components/FilterBar';
 import { RepoGrid } from '@/components/RepoGrid';
 import { LoadingState } from '@/components/LoadingState';
+import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
@@ -326,6 +327,8 @@ export default function HomePage() {
     <div className="flex h-screen bg-zinc-950 overflow-hidden">
       {/* ── Main content ── */}
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+        {/* Stage 2 loading banner — fades in/out while owned repos stay visible */}
+        <LoadingBanner visible={isLoadingFull} />
         <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
           {/* Header */}
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -339,13 +342,6 @@ export default function HomePage() {
               {/* API connected badge — production mode only */}
               {provider.mode === 'production' && (
                 <span className="text-xs text-zinc-500 border border-zinc-700 rounded px-2 py-0.5">API connected</span>
-              )}
-              {/* Full library loading indicator */}
-              {isLoadingFull && (
-                <span className="flex items-center gap-1.5 text-xs text-zinc-500">
-                  <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-2 border-zinc-600 border-t-zinc-400" />
-                  Loading full library…
-                </span>
               )}
               {/* Mobile sidebar toggle */}
               <button

--- a/src/components/LoadingBanner.tsx
+++ b/src/components/LoadingBanner.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+interface LoadingBannerProps {
+  visible: boolean;
+}
+
+/**
+ * Subtle top banner shown during Stage 2 (full library fetch).
+ * Fades in/out without disrupting already-loaded content below.
+ */
+export function LoadingBanner({ visible }: LoadingBannerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading full library"
+      className={[
+        'w-full flex items-center justify-center gap-2.5 py-2 px-4',
+        'bg-zinc-900/80 border-b border-zinc-800 text-xs text-zinc-400',
+        'transition-all duration-500 ease-in-out overflow-hidden',
+        visible ? 'max-h-10 opacity-100' : 'max-h-0 opacity-0 border-b-0 py-0',
+      ].join(' ')}
+    >
+      {/* Pulsing dot */}
+      <span className="relative flex h-2 w-2 shrink-0">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-60" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+      </span>
+      <span>Loading full library (1,400+ repos)…</span>
+    </div>
+  );
+}

--- a/src/lib/buildCategories.ts
+++ b/src/lib/buildCategories.ts
@@ -284,7 +284,11 @@ export const CATEGORIES: Category[] = [
     color: '#a855f7',
     repoCount: 0,
     description: 'Speech, music, and audio processing AI',
-    tags: ['Audio', 'Speech', 'TTS', 'ASR', 'Music AI', 'Voice']
+    tags: [
+      'Audio', 'Speech', 'TTS', 'ASR', 'Music AI', 'Voice',
+      'text-to-speech', 'music', 'sound', 'whisper', 'speech-recognition',
+      'vocoder', 'audio-generation', 'music-generation', 'voice-cloning', 'speech-synthesis'
+    ]
   },
   {
     id: 'code-generation',

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -20,9 +20,8 @@ export interface DataProvider {
 }
 
 export function createDataProvider(): DataProvider {
-  // Always use static JSON generated at build time by fetch-library.ts.
-  // Runtime API calls for the 3MB+ library payload caused client-side crashes.
-  // NEXT_PUBLIC_REPORIUM_API_URL is used only by npm run generate (build step).
+  const apiUrl = process.env.NEXT_PUBLIC_REPORIUM_API_URL
+  if (apiUrl) return new ApiDataProvider(apiUrl)
   return new JsonDataProvider()
 }
 
@@ -102,10 +101,24 @@ class ApiDataProvider implements DataProvider {
   }
 
   async getLibrary(): Promise<LibraryData> {
-    // Database backfilled 2026-03-21: 14K tags, 2K pmSkills, 918 industries, 825 builders.
-    // API /library/full now returns rich data. Falls back to static JSON if API unreachable.
-    try { return await this.apiFetch<LibraryData>('/library/full') }
-    catch { console.warn('API unreachable, falling back to JSON'); return this.fallback.getLibrary() }
+    try {
+      const PAGE_SIZE = 500
+      // Fetch page 1 to get totalPages + corpus aggregates
+      const page1 = await this.apiFetch<LibraryData & { totalPages?: number; totalRepos?: number }>(`/library/full?page=1&pageSize=${PAGE_SIZE}`)
+      const totalPages = page1.totalPages ?? 1
+      if (totalPages <= 1) return page1
+
+      // Fetch remaining pages in parallel (cap at reasonable limit)
+      const remaining = Array.from({ length: totalPages - 1 }, (_, i) =>
+        this.apiFetch<LibraryData>(`/library/full?page=${i + 2}&pageSize=${PAGE_SIZE}`)
+      )
+      const pages = await Promise.all(remaining)
+      const allRepos = pages.reduce((acc, p) => acc.concat(p.repos), page1.repos)
+      return { ...page1, repos: allRepos }
+    } catch {
+      console.warn('API unreachable, falling back to JSON')
+      return this.fallback.getLibrary()
+    }
   }
 
   async getTrends(): Promise<TrendData | null> {

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -272,4 +272,9 @@ export interface LibraryData {
   builderStats: BuilderStats[];
   aiDevSkillStats: SkillStats[];
   pmSkillStats: SkillStats[];
+  // Pagination fields (present when the API returns paginated results)
+  page?: number;
+  pageSize?: number;
+  totalRepos?: number;
+  totalPages?: number;
 }

--- a/tests/unit/tagCloud.test.ts
+++ b/tests/unit/tagCloud.test.ts
@@ -21,6 +21,11 @@ function makeMetric(tag: string, repoCount: number, activityScore = 50): TagMetr
     relatedTags: [],
     mostRecentRepo: '',
     mostRecentDate: new Date().toISOString(),
+    repos: [],
+    avgUpstreamAge: 0,
+    avgTimeSinceForked: 0,
+    mostOutdatedRepo: '',
+    avgBehindBy: 0,
   };
 }
 


### PR DESCRIPTION
## Releases in this batch

- fix: repo count 826→1400+, Node.js 24 in CI, expand Audio category tags (#36)
- fix: paginate through all pages in fetch-library to show all 1400+ repos (#37)
- fix: re-activate ApiDataProvider with pagination for full library load (#38)
- feat: cold-start loading banner during full library fetch (#39)
- fix: retry fetch-library and mark March 2026 frontend state historical (#35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)