### PR TITLE
fix: update aiDevSkills type to {skill, lifecycleGroup} objects from API

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -232,7 +232,7 @@ export default function HomePage() {
 
       // AI Dev Skills filter
       if (selectedAiDevSkills.length > 0) {
-        if (!selectedAiDevSkills.every(s => (repo.aiDevSkills ?? []).includes(s))) return false;
+        if (!selectedAiDevSkills.every(s => (repo.aiDevSkills ?? []).some(a => a.skill === s))) return false;
       }
       // PM Skills filter
       if (selectedPmSkills.length > 0) {

--- a/src/app/wiki/skills/[skill]/page.tsx
+++ b/src/app/wiki/skills/[skill]/page.tsx
@@ -143,7 +143,7 @@ export default async function SkillPage({ params }: { params: Promise<{ skill: s
 
   const skillTags = AI_DEV_SKILLS[skillName];
   const repos = data.repos
-    .filter(r => (r.aiDevSkills ?? []).includes(skillName))
+    .filter(r => (r.aiDevSkills ?? []).some(a => a.skill === skillName))
     .sort((a, b) => (b.parentStats?.stars ?? 0) - (a.parentStats?.stars ?? 0));
 
   const gapEntry = data.gapAnalysis?.gaps?.find(g => g.skill === skillName || g.category === skillName);

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -10,37 +10,6 @@ const SYSTEM_TAGS = new Set(['Active', 'Forked', 'Built by Me', 'Inactive', 'Arc
 /** Own-account logins — don't render as "builder" since the Built/Forked badge already shows ownership */
 const OWN_LOGINS = new Set(['perditioinc']);
 
-/** Maps each of the 28 AI Dev skill areas to its lifecycle group */
-const LIFECYCLE_GROUPS: Record<string, string> = {
-  'Foundation Model Architecture': 'Foundation & Training',
-  'Fine-tuning & Alignment': 'Foundation & Training',
-  'Data Engineering': 'Foundation & Training',
-  'Synthetic Data': 'Foundation & Training',
-  'Inference & Serving': 'Inference & Deployment',
-  'Model Compression': 'Inference & Deployment',
-  'Edge AI': 'Inference & Deployment',
-  'Agents & Orchestration': 'LLM Application Layer',
-  'RAG & Retrieval': 'LLM Application Layer',
-  'Context Engineering': 'LLM Application Layer',
-  'Tool Use': 'LLM Application Layer',
-  'Structured Output': 'LLM Application Layer',
-  'Prompt Engineering': 'LLM Application Layer',
-  'Knowledge Graphs': 'LLM Application Layer',
-  'Evaluation': 'Eval / Safety / Ops',
-  'Security & Guardrails': 'Eval / Safety / Ops',
-  'Observability': 'Eval / Safety / Ops',
-  'MLOps': 'Eval / Safety / Ops',
-  'AI Governance': 'Eval / Safety / Ops',
-  'Computer Vision': 'Modality-Specific',
-  'Speech & Audio': 'Modality-Specific',
-  'Generative Media': 'Modality-Specific',
-  'NLP': 'Modality-Specific',
-  'Multimodal': 'Modality-Specific',
-  'Coding Assistants': 'Applied AI',
-  'Robotics': 'Applied AI',
-  'AI for Science': 'Applied AI',
-  'Recommendation Systems': 'Applied AI',
-};
 
 /** Normalize stale category names to current taxonomy names */
 const CATEGORY_NAME_ALIASES: Record<string, string> = {
@@ -317,14 +286,13 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
 
       {/* AI Dev Skills — grouped by lifecycle, capped at 6 badges */}
       {repo.aiDevSkills && repo.aiDevSkills.length > 0 && (() => {
-        const allSkills = [...new Set(repo.aiDevSkills)];
-        const displayed = allSkills.slice(0, 6);
-        const overflow = allSkills.length - displayed.length;
+        const allSkills = (repo.aiDevSkills || []).slice(0, 6);
+        const overflow = (repo.aiDevSkills || []).length - allSkills.length;
 
-        // Group displayed skills by lifecycle group
-        const groupMap = new Map<string, string[]>();
-        for (const skill of displayed) {
-          const group = LIFECYCLE_GROUPS[skill] ?? 'Other';
+        // Group displayed skills by lifecycle group (comes directly from each object)
+        const groupMap = new Map<string, typeof allSkills>();
+        for (const skill of allSkills) {
+          const group = skill.lifecycleGroup ?? 'Other';
           if (!groupMap.has(group)) groupMap.set(group, []);
           groupMap.get(group)!.push(skill);
         }
@@ -341,18 +309,18 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
                   {skills.map(skill =>
                     onTagClick ? (
                       <button
-                        key={skill}
-                        onClick={() => onTagClick(skill)}
+                        key={skill.skill}
+                        onClick={() => onTagClick(skill.skill)}
                         className="rounded-full bg-sky-900/30 border border-sky-700/30 px-2 py-0.5 text-xs text-sky-400 hover:bg-sky-800/40 hover:text-sky-300 transition-colors"
                       >
-                        {skill}
+                        {skill.skill}
                       </button>
                     ) : (
                       <span
-                        key={skill}
+                        key={skill.skill}
                         className="rounded-full bg-sky-900/30 border border-sky-700/30 px-2 py-0.5 text-xs text-sky-400"
                       >
-                        {skill}
+                        {skill.skill}
                       </span>
                     )
                   )}

--- a/src/lib/buildTaxonomy.ts
+++ b/src/lib/buildTaxonomy.ts
@@ -232,10 +232,11 @@ export function buildSkillStats(
 ): SkillStats[] {
   const map = new Map<string, { count: number; repos: string[] }>();
   for (const repo of repos) {
-    for (const skill of (repo[field] ?? [])) {
-      const existing = map.get(skill);
+    for (const item of (repo[field] ?? [])) {
+      const skillKey = typeof item === 'string' ? item : item.skill;
+      const existing = map.get(skillKey);
       if (!existing) {
-        map.set(skill, { count: 1, repos: [repo.name] });
+        map.set(skillKey, { count: 1, repos: [repo.name] });
       } else {
         existing.count++;
         if (existing.repos.length < 3) existing.repos.push(repo.name);

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -206,7 +206,7 @@ export interface EnrichedRepo {
 
   latestRelease: LatestRelease | null;
 
-  aiDevSkills: string[];
+  aiDevSkills: { skill: string; lifecycleGroup: string }[];
   pmSkills: string[];
   industries: string[];
   programmingLanguages: string[];

--- a/tests/unit/filterLogic.test.ts
+++ b/tests/unit/filterLogic.test.ts
@@ -48,7 +48,7 @@ describe('filter logic', () => {
           if (!(repo.builders ?? []).some(b => filters.builders!.includes(b.login))) return false;
         }
         if (filters.aiDevSkills?.length) {
-          if (!filters.aiDevSkills.every(s => (repo.aiDevSkills ?? []).includes(s))) return false;
+          if (!filters.aiDevSkills.every(s => (repo.aiDevSkills ?? []).some(a => a.skill === s))) return false;
         }
         return true;
       });


### PR DESCRIPTION
## Summary
- Updated `EnrichedRepo.aiDevSkills` in `src/types/repo.ts` from `string[]` to `{ skill: string; lifecycleGroup: string }[]`
- Removed the client-side `LIFECYCLE_GROUPS` lookup map in `RepoCard.tsx`; now reads `lifecycleGroup` directly from each object
- Updated pill display and `onTagClick` in `RepoCard.tsx` to use `skill.skill` instead of treating the item as a string
- Fixed all downstream usages: `page.tsx` filter, wiki skill page filter, `buildTaxonomy.ts` `buildSkillStats`, and `filterLogic.test.ts`

## Test plan
- [ ] `npm run type-check` passes with no errors
- [ ] RepoCard renders AI Dev Skills pills correctly, grouped by lifecycle group
- [ ] Filtering by AI Dev Skills works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)