### PR TITLE
feat: add semantic search mode to frontend

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
-import { createDataProvider } from '@/lib/dataProvider';
+import { createDataProvider, SearchMode } from '@/lib/dataProvider';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? 'https://reporium-api-573778300586.us-central1.run.app';
 
@@ -28,6 +28,9 @@ export default function HomePage() {
 
   // Filter state
   const [search, setSearch] = useState('');
+  const [searchMode, setSearchMode] = useState<SearchMode>('keyword');
+  const [semanticResults, setSemanticResults] = useState<EnrichedRepo[] | null>(null);
+  const [isSearchingSemantic, setIsSearchingSemantic] = useState(false);
   const [selectedType, setSelectedType] = useState<'all' | 'built' | 'forked'>('all');
   const [selectedLanguage, setSelectedLanguage] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -103,6 +106,46 @@ export default function HomePage() {
     return () => { cancelled = true; };
   }, []);  // no dependencies — loads once
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function runSemanticSearch() {
+      if (!data || searchMode !== 'semantic' || !search.trim()) {
+        setSemanticResults(null);
+        setIsSearchingSemantic(false);
+        return;
+      }
+
+      setIsSearchingSemantic(true);
+      try {
+        const rawResults = await provider.searchRepos(search.trim(), 'semantic');
+        if (cancelled) return;
+
+        const repoMap = new Map(data.repos.map((repo) => [repo.name, repo]));
+        const merged = rawResults.reduce<EnrichedRepo[]>((acc, result) => {
+          const existing = repoMap.get(result.name);
+          if (!existing) return acc;
+          acc.push({
+            ...existing,
+            similarity: result.similarity,
+          });
+          return acc;
+        }, []);
+
+        setSemanticResults(merged);
+      } catch {
+        if (!cancelled) setSemanticResults([]);
+      } finally {
+        if (!cancelled) setIsSearchingSemantic(false);
+      }
+    }
+
+    runSemanticSearch();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, search, searchMode]);
+
   const allLanguages = useMemo(() => data?.stats.languages ?? [], [data]);
 
   /** Map stale DB category names → current taxonomy names.
@@ -170,9 +213,14 @@ export default function HomePage() {
   const filteredAndSortedRepos = useMemo<EnrichedRepo[]>(() => {
     if (!data) return [];
 
-    const filtered = data.repos.filter((repo) => {
+    const sourceRepos =
+      searchMode === 'semantic' && search.trim()
+        ? (semanticResults ?? [])
+        : data.repos;
+
+    const filtered = sourceRepos.filter((repo) => {
       // Text search — name and description only, never tags
-      if (search) {
+      if (search && searchMode === 'keyword') {
         const q = search.toLowerCase();
         const matchesSearch =
           repo.name.toLowerCase().includes(q) ||
@@ -274,10 +322,12 @@ export default function HomePage() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedIndustries, selectedBuilders]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedIndustries, selectedBuilders]);
 
   function clearFilters() {
     setSearch('');
+    setSearchMode('keyword');
+    setSemanticResults(null);
     setSelectedType('all');
     setSelectedLanguage('');
     setSelectedTags([]);
@@ -379,9 +429,18 @@ export default function HomePage() {
               <SearchBar
                 value={search}
                 onChange={setSearch}
+                searchMode={searchMode}
+                onSearchModeChange={setSearchMode}
                 resultCount={filteredAndSortedRepos.length}
                 totalCount={data.repos.length}
               />
+              {searchMode === 'semantic' && search.trim() && (
+                <p className="text-xs text-zinc-500">
+                  {isSearchingSemantic
+                    ? 'Running semantic search against repo embeddings...'
+                    : 'Showing semantic matches ranked by cosine similarity.'}
+                </p>
+              )}
               <FilterBar
                 languages={allLanguages}
                 allTags={allTags}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -131,6 +131,11 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
           {repo.name}
         </a>
         <div className="flex items-center gap-1.5 shrink-0">
+          {typeof repo.similarity === 'number' && (
+            <span className="rounded-full bg-sky-900/40 border border-sky-700/40 px-2 py-0.5 text-xs font-medium text-sky-300">
+              {Math.round(repo.similarity * 100)}% match
+            </span>
+          )}
           {repo.isFork && ps?.isArchived && (
             <span className="rounded-full bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">
               archived

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,16 +1,44 @@
 'use client';
 
+import type { SearchMode } from '@/lib/dataProvider';
+
 interface SearchBarProps {
   value: string;
   onChange: (v: string) => void;
   resultCount: number;
   totalCount: number;
+  searchMode: SearchMode;
+  onSearchModeChange: (mode: SearchMode) => void;
 }
 
-/** Full-text search across repo names and descriptions */
-export function SearchBar({ value, onChange, resultCount, totalCount }: SearchBarProps) {
+/** Search input with keyword/semantic mode toggle. */
+export function SearchBar({
+  value,
+  onChange,
+  resultCount,
+  totalCount,
+  searchMode,
+  onSearchModeChange,
+}: SearchBarProps) {
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-col gap-3 md:flex-row md:items-center">
+      <div className="inline-flex w-fit rounded-xl border border-zinc-800 bg-zinc-900 p-1">
+        {(['keyword', 'semantic'] as const).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onSearchModeChange(mode)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+              searchMode === mode
+                ? 'bg-sky-900/40 text-sky-300'
+                : 'text-zinc-500 hover:text-zinc-200'
+            }`}
+          >
+            {mode === 'keyword' ? 'Keyword' : 'Semantic'}
+          </button>
+        ))}
+      </div>
+
       <div className="relative flex-1">
         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">
           🔍
@@ -19,10 +47,11 @@ export function SearchBar({ value, onChange, resultCount, totalCount }: SearchBa
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="Search repos..."
+          placeholder={searchMode === 'semantic' ? 'Search by meaning...' : 'Search repos...'}
           className="w-full rounded-xl border border-zinc-800 bg-zinc-900 py-2.5 pl-9 pr-4 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600"
         />
       </div>
+
       <span className="shrink-0 text-xs text-zinc-500">
         {resultCount} of {totalCount}
       </span>

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -8,6 +8,7 @@
 import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
+export type SearchMode = 'keyword' | 'semantic'
 
 export interface DataProvider {
   mode: DataMode
@@ -16,7 +17,7 @@ export interface DataProvider {
   getTrends(): Promise<TrendData | null>
   getGaps(): Promise<GapAnalysis | null>
   getRepo(name: string): Promise<EnrichedRepo | null>
-  searchRepos(query: string): Promise<EnrichedRepo[]>
+  searchRepos(query: string, mode?: SearchMode): Promise<EnrichedRepo[]>
 }
 
 export function createDataProvider(): DataProvider {
@@ -136,8 +137,13 @@ class ApiDataProvider implements DataProvider {
     catch { return this.fallback.getRepo(name) }
   }
 
-  async searchRepos(query: string): Promise<EnrichedRepo[]> {
-    try { return await this.apiFetch<EnrichedRepo[]>(`/search?q=${encodeURIComponent(query)}`) }
+  async searchRepos(query: string, mode: SearchMode = 'keyword'): Promise<EnrichedRepo[]> {
+    try {
+      const path = mode === 'semantic'
+        ? `/search/semantic?q=${encodeURIComponent(query)}`
+        : `/search?q=${encodeURIComponent(query)}`
+      return await this.apiFetch<EnrichedRepo[]>(path)
+    }
     catch { return this.fallback.searchRepos(query) }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -211,6 +211,7 @@ export interface EnrichedRepo {
   industries: string[];
   programmingLanguages: string[];
   builders: Builder[];
+  similarity?: number;
 }
 
 /** Summary statistics for a user's library */


### PR DESCRIPTION
## Changes
- add keyword vs semantic search mode toggle to the main search bar
- call `GET /search/semantic` when semantic mode is active
- merge semantic results back onto the loaded library so result cards keep their rich taxonomy/builder metadata
- display `NN% match` badges on repo cards using the API similarity score

## Validation
- `npm run build`

## Notes
- keyword mode keeps the existing client-side filtering behavior
- semantic mode uses API-ranked matches and still flows through the existing repo card/grid UI
