### PR TITLE
release: semantic search UI + repo detail pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
-import { createDataProvider } from '@/lib/dataProvider';
+import { createDataProvider, SearchMode } from '@/lib/dataProvider';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? 'https://reporium-api-573778300586.us-central1.run.app';
 
@@ -28,6 +28,9 @@ export default function HomePage() {
 
   // Filter state
   const [search, setSearch] = useState('');
+  const [searchMode, setSearchMode] = useState<SearchMode>('keyword');
+  const [semanticResults, setSemanticResults] = useState<EnrichedRepo[] | null>(null);
+  const [isSearchingSemantic, setIsSearchingSemantic] = useState(false);
   const [selectedType, setSelectedType] = useState<'all' | 'built' | 'forked'>('all');
   const [selectedLanguage, setSelectedLanguage] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -103,6 +106,46 @@ export default function HomePage() {
     return () => { cancelled = true; };
   }, []);  // no dependencies — loads once
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function runSemanticSearch() {
+      if (!data || searchMode !== 'semantic' || !search.trim()) {
+        setSemanticResults(null);
+        setIsSearchingSemantic(false);
+        return;
+      }
+
+      setIsSearchingSemantic(true);
+      try {
+        const rawResults = await provider.searchRepos(search.trim(), 'semantic');
+        if (cancelled) return;
+
+        const repoMap = new Map(data.repos.map((repo) => [repo.name, repo]));
+        const merged = rawResults.reduce<EnrichedRepo[]>((acc, result) => {
+          const existing = repoMap.get(result.name);
+          if (!existing) return acc;
+          acc.push({
+            ...existing,
+            similarity: result.similarity,
+          });
+          return acc;
+        }, []);
+
+        setSemanticResults(merged);
+      } catch {
+        if (!cancelled) setSemanticResults([]);
+      } finally {
+        if (!cancelled) setIsSearchingSemantic(false);
+      }
+    }
+
+    runSemanticSearch();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, search, searchMode]);
+
   const allLanguages = useMemo(() => data?.stats.languages ?? [], [data]);
 
   /** Map stale DB category names → current taxonomy names.
@@ -170,9 +213,14 @@ export default function HomePage() {
   const filteredAndSortedRepos = useMemo<EnrichedRepo[]>(() => {
     if (!data) return [];
 
-    const filtered = data.repos.filter((repo) => {
+    const sourceRepos =
+      searchMode === 'semantic' && search.trim()
+        ? (semanticResults ?? [])
+        : data.repos;
+
+    const filtered = sourceRepos.filter((repo) => {
       // Text search — name and description only, never tags
-      if (search) {
+      if (search && searchMode === 'keyword') {
         const q = search.toLowerCase();
         const matchesSearch =
           repo.name.toLowerCase().includes(q) ||
@@ -274,10 +322,12 @@ export default function HomePage() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedIndustries, selectedBuilders]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedIndustries, selectedBuilders]);
 
   function clearFilters() {
     setSearch('');
+    setSearchMode('keyword');
+    setSemanticResults(null);
     setSelectedType('all');
     setSelectedLanguage('');
     setSelectedTags([]);
@@ -379,9 +429,18 @@ export default function HomePage() {
               <SearchBar
                 value={search}
                 onChange={setSearch}
+                searchMode={searchMode}
+                onSearchModeChange={setSearchMode}
                 resultCount={filteredAndSortedRepos.length}
                 totalCount={data.repos.length}
               />
+              {searchMode === 'semantic' && search.trim() && (
+                <p className="text-xs text-zinc-500">
+                  {isSearchingSemantic
+                    ? 'Running semantic search against repo embeddings...'
+                    : 'Showing semantic matches ranked by cosine similarity.'}
+                </p>
+              )}
               <FilterBar
                 languages={allLanguages}
                 allTags={allTags}

--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -1,0 +1,517 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { CATEGORIES } from '@/lib/buildCategories';
+import type { EnrichedRepo } from '@/types/repo';
+
+const API_URL =
+  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
+  'https://reporium-api-573778300586.us-central1.run.app';
+
+const SKILL_LIFECYCLE_GROUPS: Record<string, string> = {
+  'Model Training & Fine-tuning': 'Foundation & Training',
+  'Inference & Serving': 'Inference & Deployment',
+  'Structured Output & Reliability': 'LLM Application Layer',
+  'AI Agents & Orchestration': 'LLM Application Layer',
+  'RAG & Knowledge': 'LLM Application Layer',
+  'Context Engineering': 'LLM Application Layer',
+  'Observability & Monitoring': 'Eval / Safety / Ops',
+  'Evals & Benchmarking': 'Eval / Safety / Ops',
+  'Security & Safety': 'Eval / Safety / Ops',
+  'MLOps & Data': 'Eval / Safety / Ops',
+  'Multimodal & Vision': 'Modality-Specific',
+  'Coding Assistants & Dev Tools': 'Applied AI',
+  'Reasoning Models': 'Applied AI',
+};
+
+interface RepoDetail {
+  id: string;
+  name: string;
+  owner: string;
+  description: string | null;
+  is_fork: boolean;
+  forked_from: string | null;
+  primary_language: string | null;
+  github_url: string;
+  fork_sync_state: string | null;
+  behind_by: number;
+  ahead_by: number;
+  upstream_created_at: string | null;
+  forked_at: string | null;
+  your_last_push_at: string | null;
+  upstream_last_push_at: string | null;
+  parent_stars: number | null;
+  parent_forks: number | null;
+  parent_is_archived: boolean;
+  stargazers_count: number | null;
+  open_issues_count: number;
+  commits_last_7_days: number;
+  commits_last_30_days: number;
+  commits_last_90_days: number;
+  readme_summary: string | null;
+  activity_score: number;
+  ingested_at: string;
+  updated_at: string;
+  github_updated_at: string | null;
+  tags: string[];
+  categories: { category_id: string; category_name: string; is_primary: boolean }[];
+  allCategories: string[];
+  builders: {
+    login: string;
+    display_name: string | null;
+    org_category: string | null;
+    is_known_org: boolean;
+  }[];
+  ai_dev_skills: string[];
+  pm_skills: string[];
+  languages: { language: string; bytes: number; percentage: number }[];
+  commits: {
+    sha: string;
+    message: string;
+    author: string | null;
+    committed_at: string;
+    url: string | null;
+  }[];
+}
+
+function formatRelativeDate(value: string | null): string {
+  if (!value) return 'Unclear';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unclear';
+
+  const days = Math.floor((Date.now() - date.getTime()) / 86400000);
+  if (days < 0) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  if (days === 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 30) return `${days} days ago`;
+  if (days < 365) return `${Math.floor(days / 30)} months ago`;
+  return `${Math.floor(days / 365)} years ago`;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Unclear';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unclear';
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatCount(value: number | null | undefined): string {
+  return (value ?? 0).toLocaleString();
+}
+
+function getCategoryMeta(name: string) {
+  return CATEGORIES.find((category) => category.name === name) ?? null;
+}
+
+function groupSkills(skills: string[]) {
+  const groups = new Map<string, string[]>();
+  for (const skill of skills) {
+    const group = SKILL_LIFECYCLE_GROUPS[skill] ?? 'Unmapped';
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push(skill);
+  }
+  return [...groups.entries()];
+}
+
+async function getRepoDetail(name: string): Promise<RepoDetail | null> {
+  try {
+    const response = await fetch(`${API_URL}/repos/${encodeURIComponent(name)}`, {
+      next: { revalidate: 300 },
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`API error ${response.status}`);
+    return (await response.json()) as RepoDetail;
+  } catch {
+    try {
+      const data = JSON.parse(
+        readFileSync(join(process.cwd(), 'public', 'data', 'library.json'), 'utf-8')
+      ) as { repos: EnrichedRepo[] };
+      const repo = data.repos.find((item) => item.name === name);
+      if (!repo) return null;
+
+      return {
+        id: String(repo.id),
+        name: repo.name,
+        owner: repo.fullName.split('/')[0] ?? 'unknown',
+        description: repo.description,
+        is_fork: repo.isFork,
+        forked_from: repo.forkedFrom,
+        primary_language: repo.language,
+        github_url: repo.url,
+        fork_sync_state: repo.forkSync?.state ?? null,
+        behind_by: repo.forkSync?.behindBy ?? 0,
+        ahead_by: repo.forkSync?.aheadBy ?? 0,
+        upstream_created_at: repo.upstreamCreatedAt,
+        forked_at: repo.forkedAt,
+        your_last_push_at: repo.yourLastPushAt,
+        upstream_last_push_at: repo.upstreamLastPushAt,
+        parent_stars: repo.parentStats?.stars ?? repo.stars,
+        parent_forks: repo.parentStats?.forks ?? repo.forks,
+        parent_is_archived: repo.parentStats?.isArchived ?? repo.isArchived,
+        stargazers_count: repo.stars,
+        open_issues_count: (repo as EnrichedRepo & { openIssuesCount?: number }).openIssuesCount ?? repo.parentStats?.openIssues ?? 0,
+        commits_last_7_days: repo.commitStats?.last7Days ?? 0,
+        commits_last_30_days: repo.commitStats?.last30Days ?? 0,
+        commits_last_90_days: repo.commitStats?.last90Days ?? 0,
+        readme_summary: repo.readmeSummary,
+        activity_score: 0,
+        ingested_at: repo.lastUpdated,
+        updated_at: repo.lastUpdated,
+        github_updated_at: repo.lastUpdated,
+        tags: repo.enrichedTags ?? [],
+        categories: (repo.allCategories ?? []).map((categoryName) => ({
+          category_id: categoryName.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+          category_name: categoryName,
+          is_primary: categoryName === repo.primaryCategory,
+        })),
+        allCategories: repo.allCategories ?? [],
+        builders: (repo.builders ?? []).map((builder) => ({
+          login: builder.login,
+          display_name: builder.name,
+          org_category: builder.orgCategory,
+          is_known_org: builder.isKnownOrg,
+        })),
+        ai_dev_skills: (repo.aiDevSkills ?? []).map((skill) => skill.skill),
+        pm_skills: repo.pmSkills ?? [],
+        languages: Object.entries(repo.languagePercentages ?? {}).map(([language, percentage]) => ({
+          language,
+          bytes: repo.languageBreakdown?.[language] ?? 0,
+          percentage,
+        })),
+        commits: (repo.recentCommits ?? []).map((commit) => ({
+          sha: commit.sha,
+          message: commit.message,
+          author: commit.author,
+          committed_at: commit.date,
+          url: commit.url,
+        })),
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export async function generateStaticParams() {
+  try {
+    const data = JSON.parse(
+      readFileSync(join(process.cwd(), 'public', 'data', 'library.json'), 'utf-8')
+    ) as { repos: Array<{ name: string }> };
+    return data.repos.map((repo) => ({ name: repo.name }));
+  } catch {
+    return [];
+  }
+}
+
+function StatCard({ label, value, note }: { label: string; value: string; note?: string }) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/70 px-4 py-3">
+      <p className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-zinc-100">{value}</p>
+      {note && <p className="mt-1 text-xs text-zinc-500">{note}</p>}
+    </div>
+  );
+}
+
+export default async function RepoDetailPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  const repo = await getRepoDetail(decodeURIComponent(name));
+  if (!repo) notFound();
+
+  const skillGroups = groupSkills(repo.ai_dev_skills ?? []);
+  const stars = repo.is_fork ? repo.parent_stars : repo.stargazers_count;
+  const forks = repo.is_fork ? repo.parent_forks : 0;
+  const builder = repo.builders?.[0] ?? null;
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title={repo.name} />
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-8 md:px-8">
+        <section className="rounded-[28px] border border-zinc-800 bg-gradient-to-br from-zinc-900 via-zinc-950 to-zinc-950 p-6 shadow-2xl shadow-black/25">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+                <Link href="/" className="hover:text-zinc-300 transition-colors">
+                  Library
+                </Link>
+                <span>/</span>
+                <span className="text-zinc-300">{repo.name}</span>
+                <span className={`rounded-full px-2 py-0.5 font-medium ${repo.is_fork ? 'bg-violet-900/50 text-violet-300' : 'bg-emerald-900/50 text-emerald-300'}`}>
+                  {repo.is_fork ? 'Forked' : 'Built'}
+                </span>
+                {repo.parent_is_archived && (
+                  <span className="rounded-full bg-red-900/50 px-2 py-0.5 font-medium text-red-300">
+                    Archived upstream
+                  </span>
+                )}
+              </div>
+
+              <div>
+                <p className="text-sm text-zinc-500">{repo.owner}/{repo.name}</p>
+                <h1 className="mt-1 text-3xl font-semibold tracking-tight text-white md:text-4xl">
+                  {repo.name}
+                </h1>
+                {repo.description && (
+                  <p className="mt-3 max-w-3xl text-sm leading-7 text-zinc-300 md:text-base">
+                    {repo.description}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <a
+                  href={repo.github_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full bg-blue-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-400"
+                >
+                  <span>View on GitHub</span>
+                  <span>↗</span>
+                </a>
+                {repo.forked_from && (
+                  <a
+                    href={`https://github.com/${repo.forked_from}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-full border border-zinc-700 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+                  >
+                    <span>Upstream {repo.forked_from}</span>
+                    <span>↗</span>
+                  </a>
+                )}
+              </div>
+            </div>
+
+            <div className="w-full max-w-sm rounded-[24px] border border-zinc-800 bg-zinc-900/70 p-4">
+              <p className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">Builder</p>
+              {builder ? (
+                <div className="mt-3 flex items-center gap-3">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={`https://github.com/${builder.login}.png?size=48`}
+                    alt={builder.display_name ?? builder.login}
+                    className="h-12 w-12 rounded-full border border-zinc-700"
+                  />
+                  <div>
+                    <p className="text-sm font-medium text-zinc-100">
+                      {builder.display_name ?? builder.login}
+                    </p>
+                    <p className="text-xs text-zinc-500">
+                      {builder.login}
+                      {builder.org_category ? ` • ${builder.org_category}` : ''}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <p className="mt-3 text-sm text-zinc-500">Unclear</p>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <StatCard label="Stars" value={formatCount(stars)} note={repo.is_fork ? 'Using upstream star count' : 'Repository stars'} />
+          <StatCard label="Forks" value={formatCount(forks)} note={repo.is_fork ? 'Using upstream fork count' : 'Repository forks'} />
+          <StatCard label="Open Issues" value={formatCount(repo.open_issues_count)} />
+          <StatCard label="Activity Score" value={`${repo.activity_score}/100`} note={`${repo.commits_last_30_days} commits in 30d`} />
+          <StatCard label="Created" value={formatDate(repo.upstream_created_at)} note={repo.upstream_created_at ? 'Project creation date' : 'Unclear in current API contract'} />
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[1.5fr,1fr]">
+          <div className="space-y-6">
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">README Summary</h2>
+              <p className="mt-3 text-sm leading-7 text-zinc-300">
+                {repo.readme_summary ?? 'Unclear'}
+              </p>
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">AI Dev Skills</h2>
+              {skillGroups.length > 0 ? (
+                <div className="mt-4 space-y-4">
+                  {skillGroups.map(([group, skills]) => (
+                    <div key={group}>
+                      <p className="mb-2 text-xs uppercase tracking-[0.18em] text-zinc-500">{group}</p>
+                      <div className="flex flex-wrap gap-2">
+                        {skills.map((skill) => (
+                          <span
+                            key={skill}
+                            className="rounded-full border border-sky-700/30 bg-sky-900/30 px-3 py-1 text-xs font-medium text-sky-300"
+                          >
+                            {skill}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-3 text-sm text-zinc-500">No AI dev skills recorded.</p>
+              )}
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">Tags</h2>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {(repo.tags ?? []).map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-zinc-800 px-3 py-1 text-xs text-zinc-300"
+                  >
+                    {tag}
+                  </span>
+                ))}
+                {(repo.tags ?? []).length === 0 && (
+                  <p className="text-sm text-zinc-500">No tags recorded.</p>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-zinc-100">Recent Activity</h2>
+                <p className="text-xs text-zinc-500">Updated {formatRelativeDate(repo.github_updated_at ?? repo.updated_at)}</p>
+              </div>
+              <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <StatCard label="7 Days" value={String(repo.commits_last_7_days)} />
+                <StatCard label="30 Days" value={String(repo.commits_last_30_days)} />
+                <StatCard label="90 Days" value={String(repo.commits_last_90_days)} />
+              </div>
+              {repo.commits.length > 0 && (
+                <div className="mt-5 space-y-3">
+                  {repo.commits.slice(0, 8).map((commit) => (
+                    <a
+                      key={commit.sha}
+                      href={commit.url ?? repo.github_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block rounded-2xl border border-zinc-800 bg-zinc-950/80 px-4 py-3 transition-colors hover:border-zinc-700"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-zinc-200">{commit.message}</p>
+                          <p className="mt-1 text-xs text-zinc-500">
+                            {commit.author ?? 'Unknown author'} • {formatDate(commit.committed_at)}
+                          </p>
+                        </div>
+                        <span className="text-xs text-zinc-600">{commit.sha.slice(0, 7)}</span>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+
+          <div className="space-y-6">
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">Categories</h2>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {(repo.categories ?? []).map((category) => {
+                  const meta = getCategoryMeta(category.category_name);
+                  return (
+                    <span
+                      key={category.category_id}
+                      className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs"
+                      style={{
+                        borderColor: meta?.color ?? '#3f3f46',
+                        backgroundColor: `${meta?.color ?? '#27272a'}1a`,
+                        color: meta?.color ?? '#d4d4d8',
+                      }}
+                    >
+                      {meta?.icon ? <span>{meta.icon}</span> : null}
+                      <span>{category.category_name}</span>
+                      {category.is_primary ? <span className="text-[10px] uppercase tracking-[0.16em] opacity-70">Primary</span> : null}
+                    </span>
+                  );
+                })}
+                {(repo.categories ?? []).length === 0 && (
+                  <p className="text-sm text-zinc-500">No categories recorded.</p>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">PM Skills</h2>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {(repo.pm_skills ?? []).map((skill) => (
+                  <span
+                    key={skill}
+                    className="rounded-full border border-indigo-700/40 bg-indigo-900/30 px-3 py-1 text-xs font-medium text-indigo-300"
+                  >
+                    {skill}
+                  </span>
+                ))}
+                {(repo.pm_skills ?? []).length === 0 && (
+                  <p className="text-sm text-zinc-500">No PM skills recorded.</p>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">Languages</h2>
+              <div className="mt-4 space-y-3">
+                {(repo.languages ?? []).map((language) => (
+                  <div key={language.language}>
+                    <div className="mb-1 flex items-center justify-between text-xs text-zinc-400">
+                      <span>{language.language}</span>
+                      <span>{language.percentage.toFixed(1)}%</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-zinc-800">
+                      <div
+                        className="h-2 rounded-full bg-sky-400"
+                        style={{ width: `${Math.max(language.percentage, 4)}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+                {(repo.languages ?? []).length === 0 && (
+                  <p className="text-sm text-zinc-500">No language breakdown recorded.</p>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <h2 className="text-lg font-semibold text-zinc-100">Timeline</h2>
+              <dl className="mt-4 space-y-3 text-sm">
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-zinc-500">Project created</dt>
+                  <dd className="text-zinc-200">{formatDate(repo.upstream_created_at)}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-zinc-500">Forked</dt>
+                  <dd className="text-zinc-200">{formatDate(repo.forked_at)}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-zinc-500">Your last push</dt>
+                  <dd className="text-zinc-200">{formatRelativeDate(repo.your_last_push_at)}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-zinc-500">Upstream last push</dt>
+                  <dd className="text-zinc-200">{formatRelativeDate(repo.upstream_last_push_at)}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-zinc-500">Tracked since</dt>
+                  <dd className="text-zinc-200">{formatDate(repo.ingested_at)}</dd>
+                </div>
+              </dl>
+            </section>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -131,6 +131,11 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
           {repo.name}
         </a>
         <div className="flex items-center gap-1.5 shrink-0">
+          {typeof repo.similarity === 'number' && (
+            <span className="rounded-full bg-sky-900/40 border border-sky-700/40 px-2 py-0.5 text-xs font-medium text-sky-300">
+              {Math.round(repo.similarity * 100)}% match
+            </span>
+          )}
           {repo.isFork && ps?.isArchived && (
             <span className="rounded-full bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">
               archived

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,16 +1,44 @@
 'use client';
 
+import type { SearchMode } from '@/lib/dataProvider';
+
 interface SearchBarProps {
   value: string;
   onChange: (v: string) => void;
   resultCount: number;
   totalCount: number;
+  searchMode: SearchMode;
+  onSearchModeChange: (mode: SearchMode) => void;
 }
 
-/** Full-text search across repo names and descriptions */
-export function SearchBar({ value, onChange, resultCount, totalCount }: SearchBarProps) {
+/** Search input with keyword/semantic mode toggle. */
+export function SearchBar({
+  value,
+  onChange,
+  resultCount,
+  totalCount,
+  searchMode,
+  onSearchModeChange,
+}: SearchBarProps) {
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-col gap-3 md:flex-row md:items-center">
+      <div className="inline-flex w-fit rounded-xl border border-zinc-800 bg-zinc-900 p-1">
+        {(['keyword', 'semantic'] as const).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onSearchModeChange(mode)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+              searchMode === mode
+                ? 'bg-sky-900/40 text-sky-300'
+                : 'text-zinc-500 hover:text-zinc-200'
+            }`}
+          >
+            {mode === 'keyword' ? 'Keyword' : 'Semantic'}
+          </button>
+        ))}
+      </div>
+
       <div className="relative flex-1">
         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">
           🔍
@@ -19,10 +47,11 @@ export function SearchBar({ value, onChange, resultCount, totalCount }: SearchBa
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="Search repos..."
+          placeholder={searchMode === 'semantic' ? 'Search by meaning...' : 'Search repos...'}
           className="w-full rounded-xl border border-zinc-800 bg-zinc-900 py-2.5 pl-9 pr-4 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600"
         />
       </div>
+
       <span className="shrink-0 text-xs text-zinc-500">
         {resultCount} of {totalCount}
       </span>

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -8,6 +8,7 @@
 import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
+export type SearchMode = 'keyword' | 'semantic'
 
 export interface DataProvider {
   mode: DataMode
@@ -16,7 +17,7 @@ export interface DataProvider {
   getTrends(): Promise<TrendData | null>
   getGaps(): Promise<GapAnalysis | null>
   getRepo(name: string): Promise<EnrichedRepo | null>
-  searchRepos(query: string): Promise<EnrichedRepo[]>
+  searchRepos(query: string, mode?: SearchMode): Promise<EnrichedRepo[]>
 }
 
 export function createDataProvider(): DataProvider {
@@ -136,8 +137,13 @@ class ApiDataProvider implements DataProvider {
     catch { return this.fallback.getRepo(name) }
   }
 
-  async searchRepos(query: string): Promise<EnrichedRepo[]> {
-    try { return await this.apiFetch<EnrichedRepo[]>(`/search?q=${encodeURIComponent(query)}`) }
+  async searchRepos(query: string, mode: SearchMode = 'keyword'): Promise<EnrichedRepo[]> {
+    try {
+      const path = mode === 'semantic'
+        ? `/search/semantic?q=${encodeURIComponent(query)}`
+        : `/search?q=${encodeURIComponent(query)}`
+      return await this.apiFetch<EnrichedRepo[]>(path)
+    }
     catch { return this.fallback.searchRepos(query) }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -212,6 +212,7 @@ export interface EnrichedRepo {
   industries: string[];
   programmingLanguages: string[];
   builders: Builder[];
+  similarity?: number;
 }
 
 /** Summary statistics for a user's library */


### PR DESCRIPTION
## Summary
- Semantic search mode toggle — keyword vs semantic, calls GET /search/semantic, shows similarity % badges on results
- /repo/[name] detail pages — full repo profile with grouped skills, taxonomy, commits, metadata
- RepoCard similarity badge for search results
- Static prerender for all ~1,400 repo detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)