### PR TITLE
feat: add taxonomy dimension filters to sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,16 @@ export default function HomePage() {
   const [selectedAiDevSkills, setSelectedAiDevSkills] = useState<string[]>([]);
   const [selectedPmSkills, setSelectedPmSkills] = useState<string[]>([]);
   const [selectedIndustries, setSelectedIndustries] = useState<string[]>([]);
+  const [selectedAiTrends, setSelectedAiTrends] = useState<string[]>([]);
+  const [selectedUseCases, setSelectedUseCases] = useState<string[]>([]);
+  const [selectedModalities, setSelectedModalities] = useState<string[]>([]);
+  const [selectedDeploymentContexts, setSelectedDeploymentContexts] = useState<string[]>([]);
   const [selectedBuilders, setSelectedBuilders] = useState<string[]>([]);
+  const [aiTrendValues, setAiTrendValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
+  const [industryValues, setIndustryValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
+  const [useCaseValues, setUseCaseValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
+  const [modalityValues, setModalityValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
+  const [deploymentContextValues, setDeploymentContextValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
 
   // Mobile sidebar toggle
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -146,6 +155,43 @@ export default function HomePage() {
     };
   }, [data, search, searchMode]);
 
+  useEffect(() => {
+    if (!data) return;
+
+    let cancelled = false;
+
+    async function loadTaxonomyValues() {
+      try {
+        const [aiTrends, industries, useCases, modalities, deploymentContexts] = await Promise.all([
+          provider.getTaxonomyValues('ai_trend'),
+          provider.getTaxonomyValues('industry'),
+          provider.getTaxonomyValues('use_case'),
+          provider.getTaxonomyValues('modality'),
+          provider.getTaxonomyValues('deployment_context'),
+        ]);
+
+        if (cancelled) return;
+        setAiTrendValues(aiTrends);
+        setIndustryValues(industries);
+        setUseCaseValues(useCases);
+        setModalityValues(modalities);
+        setDeploymentContextValues(deploymentContexts);
+      } catch {
+        if (cancelled) return;
+        setAiTrendValues([]);
+        setIndustryValues([]);
+        setUseCaseValues([]);
+        setModalityValues([]);
+        setDeploymentContextValues([]);
+      }
+    }
+
+    loadTaxonomyValues();
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
   const allLanguages = useMemo(() => data?.stats.languages ?? [], [data]);
 
   /** Map stale DB category names → current taxonomy names.
@@ -175,7 +221,7 @@ export default function HomePage() {
     if (!data) return [];
     const counts = new Map<string, number>();
     for (const repo of data.repos) {
-      for (const ind of (repo.industries ?? [])) {
+      for (const ind of (repo.taxonomy ?? []).filter((entry) => entry.dimension === 'industry').map((entry) => entry.value)) {
         counts.set(ind, (counts.get(ind) ?? 0) + 1);
       }
     }
@@ -286,9 +332,30 @@ export default function HomePage() {
       if (selectedPmSkills.length > 0) {
         if (!selectedPmSkills.every(s => (repo.pmSkills ?? []).includes(s))) return false;
       }
-      // Industries filter
+      const taxonomyByDimension = (dimension: string) =>
+        (repo.taxonomy ?? [])
+          .filter((entry) => entry.dimension === dimension)
+          .map((entry) => entry.value);
+      // Taxonomy dimension filters
+      if (selectedAiTrends.length > 0) {
+        const repoAiTrends = taxonomyByDimension('ai_trend');
+        if (!selectedAiTrends.every((value) => repoAiTrends.includes(value))) return false;
+      }
       if (selectedIndustries.length > 0) {
-        if (!selectedIndustries.every(s => (repo.industries ?? []).includes(s))) return false;
+        const repoIndustries = taxonomyByDimension('industry');
+        if (!selectedIndustries.every((value) => repoIndustries.includes(value))) return false;
+      }
+      if (selectedUseCases.length > 0) {
+        const repoUseCases = taxonomyByDimension('use_case');
+        if (!selectedUseCases.every((value) => repoUseCases.includes(value))) return false;
+      }
+      if (selectedModalities.length > 0) {
+        const repoModalities = taxonomyByDimension('modality');
+        if (!selectedModalities.every((value) => repoModalities.includes(value))) return false;
+      }
+      if (selectedDeploymentContexts.length > 0) {
+        const repoDeploymentContexts = taxonomyByDimension('deployment_context');
+        if (!selectedDeploymentContexts.every((value) => repoDeploymentContexts.includes(value))) return false;
       }
       // Builders filter
       if (selectedBuilders.length > 0) {
@@ -322,7 +389,7 @@ export default function HomePage() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedIndustries, selectedBuilders]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders]);
 
   function clearFilters() {
     setSearch('');
@@ -338,7 +405,11 @@ export default function HomePage() {
     setSelectedCategory('');
     setSelectedAiDevSkills([]);
     setSelectedPmSkills([]);
+    setSelectedAiTrends([]);
     setSelectedIndustries([]);
+    setSelectedUseCases([]);
+    setSelectedModalities([]);
+    setSelectedDeploymentContexts([]);
     setSelectedBuilders([]);
   }
 
@@ -362,6 +433,22 @@ export default function HomePage() {
 
   function toggleIndustry(industry: string) {
     setSelectedIndustries(prev => prev.includes(industry) ? prev.filter(s => s !== industry) : [...prev, industry]);
+  }
+
+  function toggleAiTrend(value: string) {
+    setSelectedAiTrends(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+  }
+
+  function toggleUseCase(value: string) {
+    setSelectedUseCases(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+  }
+
+  function toggleModality(value: string) {
+    setSelectedModalities(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+  }
+
+  function toggleDeploymentContext(value: string) {
+    setSelectedDeploymentContexts(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
   }
 
   function toggleBuilder(builder: string) {
@@ -466,13 +553,26 @@ export default function HomePage() {
                 aiDevSkillStats={data.aiDevSkillStats ?? []}
                 pmSkillStats={data.pmSkillStats ?? []}
                 builderStats={data.builderStats ?? []}
+                aiTrendValues={aiTrendValues}
+                industryValues={industryValues}
+                useCaseValues={useCaseValues}
+                modalityValues={modalityValues}
+                deploymentContextValues={deploymentContextValues}
+                selectedAiTrends={selectedAiTrends}
                 selectedAiDevSkills={selectedAiDevSkills}
                 selectedPmSkills={selectedPmSkills}
                 selectedIndustries={selectedIndustries}
+                selectedUseCases={selectedUseCases}
+                selectedModalities={selectedModalities}
+                selectedDeploymentContexts={selectedDeploymentContexts}
                 selectedBuilders={selectedBuilders}
+                onAiTrendToggle={toggleAiTrend}
                 onAiDevSkillToggle={toggleAiDevSkill}
                 onPmSkillToggle={togglePmSkill}
                 onIndustryToggle={toggleIndustry}
+                onUseCaseToggle={toggleUseCase}
+                onModalityToggle={toggleModality}
+                onDeploymentContextToggle={toggleDeploymentContext}
                 onBuilderToggle={toggleBuilder}
                 industryStats={industryStats}
                 languageCounts={languageCounts}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { TagMetrics, SortOption, Category, SkillStats, BuilderStats } from '@/types/repo';
+import { TagMetrics, SortOption, Category, SkillStats, BuilderStats, TaxonomyValueOption } from '@/types/repo';
 
 interface FilterBarProps {
   categories: Category[];
@@ -39,6 +39,19 @@ interface FilterBarProps {
   onBuilderToggle?: (builder: string) => void;
   industryStats?: { industry: string; count: number }[];
   languageCounts?: Map<string, number>;
+  aiTrendValues?: TaxonomyValueOption[];
+  industryValues?: TaxonomyValueOption[];
+  useCaseValues?: TaxonomyValueOption[];
+  modalityValues?: TaxonomyValueOption[];
+  deploymentContextValues?: TaxonomyValueOption[];
+  selectedAiTrends?: string[];
+  selectedUseCases?: string[];
+  selectedModalities?: string[];
+  selectedDeploymentContexts?: string[];
+  onAiTrendToggle?: (value: string) => void;
+  onUseCaseToggle?: (value: string) => void;
+  onModalityToggle?: (value: string) => void;
+  onDeploymentContextToggle?: (value: string) => void;
 }
 
 /** Activity indicator dot based on score */
@@ -59,7 +72,17 @@ const SORT_LABELS: Record<SortOption, string> = {
   'fork-newest': 'Forked: Newest',
 };
 
-type TabId = 'categories' | 'ai-dev-skills' | 'pm-skills' | 'industries' | 'builders' | 'languages';
+type TabId =
+  | 'categories'
+  | 'ai-trends'
+  | 'industries'
+  | 'use-cases'
+  | 'modalities'
+  | 'deployment-context'
+  | 'ai-dev-skills'
+  | 'pm-skills'
+  | 'builders'
+  | 'languages';
 
 /** Filter and sort controls for the repo library */
 export function FilterBar({
@@ -91,12 +114,25 @@ export function FilterBar({
   selectedPmSkills = [],
   selectedIndustries = [],
   selectedBuilders = [],
+  selectedAiTrends = [],
+  selectedUseCases = [],
+  selectedModalities = [],
+  selectedDeploymentContexts = [],
   onAiDevSkillToggle,
   onPmSkillToggle,
   onIndustryToggle,
   onBuilderToggle,
   industryStats,
   languageCounts,
+  aiTrendValues = [],
+  industryValues = [],
+  useCaseValues = [],
+  modalityValues = [],
+  deploymentContextValues = [],
+  onAiTrendToggle,
+  onUseCaseToggle,
+  onModalityToggle,
+  onDeploymentContextToggle,
 }: FilterBarProps) {
   const [showAllTags, setShowAllTags] = useState(false);
   const [activeTab, setActiveTab] = useState<TabId>('categories');
@@ -123,16 +159,24 @@ export function FilterBar({
     selectedTags.length > 0 ||
     selectedActivity !== 'all' ||
     selectedSyncStatus !== 'all' ||
+    selectedAiTrends.length > 0 ||
     selectedAiDevSkills.length > 0 ||
     selectedPmSkills.length > 0 ||
     selectedIndustries.length > 0 ||
+    selectedUseCases.length > 0 ||
+    selectedModalities.length > 0 ||
+    selectedDeploymentContexts.length > 0 ||
     selectedBuilders.length > 0;
 
   const tabs: { id: TabId; label: string }[] = [
     { id: 'categories', label: 'Categories' },
+    { id: 'ai-trends', label: 'AI Trends' },
+    { id: 'industries', label: 'Industries' },
+    { id: 'use-cases', label: 'Use Cases' },
+    { id: 'modalities', label: 'Modalities' },
+    { id: 'deployment-context', label: 'Deployment' },
     { id: 'ai-dev-skills', label: 'AI Dev Skills' },
     { id: 'pm-skills', label: 'PM Skills' },
-    { id: 'industries', label: 'Industries' },
     { id: 'builders', label: 'Builders' },
     { id: 'languages', label: 'Languages' },
   ];
@@ -188,6 +232,12 @@ export function FilterBar({
               </button>
             </span>
           ))}
+          {selectedAiTrends.map(trend => (
+            <span key={trend} className="flex items-center gap-1 rounded-full bg-sky-900/30 border border-sky-700/50 px-2.5 py-1 text-xs font-medium text-sky-300">
+              {trend}
+              <button onClick={() => onAiTrendToggle?.(trend)} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          ))}
           {/* AI Dev Skill pills */}
           {selectedAiDevSkills.map(skill => (
             <span key={skill} className="flex items-center gap-1 rounded-full bg-emerald-900/30 border border-emerald-700/50 px-2.5 py-1 text-xs font-medium text-emerald-300">
@@ -207,6 +257,24 @@ export function FilterBar({
             <span key={ind} className="flex items-center gap-1 rounded-full bg-amber-900/30 border border-amber-700/50 px-2.5 py-1 text-xs font-medium text-amber-300">
               {ind}
               <button onClick={() => onIndustryToggle?.(ind)} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          ))}
+          {selectedUseCases.map(value => (
+            <span key={value} className="flex items-center gap-1 rounded-full bg-fuchsia-900/30 border border-fuchsia-700/50 px-2.5 py-1 text-xs font-medium text-fuchsia-300">
+              {value}
+              <button onClick={() => onUseCaseToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          ))}
+          {selectedModalities.map(value => (
+            <span key={value} className="flex items-center gap-1 rounded-full bg-teal-900/30 border border-teal-700/50 px-2.5 py-1 text-xs font-medium text-teal-300">
+              {value}
+              <button onClick={() => onModalityToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          ))}
+          {selectedDeploymentContexts.map(value => (
+            <span key={value} className="flex items-center gap-1 rounded-full bg-orange-900/30 border border-orange-700/50 px-2.5 py-1 text-xs font-medium text-orange-300">
+              {value}
+              <button onClick={() => onDeploymentContextToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
             </span>
           ))}
           {/* Builder pills */}
@@ -342,6 +410,29 @@ export function FilterBar({
           </>
         )}
 
+        {activeTab === 'ai-trends' && (
+          <div className="flex flex-wrap gap-1.5">
+            {aiTrendValues.map((value) => {
+              const isSelected = selectedAiTrends.includes(value.name);
+              return (
+                <button
+                  key={value.id}
+                  onClick={() => onAiTrendToggle?.(value.name)}
+                  className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                    isSelected ? 'bg-sky-700 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                  }`}
+                >
+                  <span>{value.name}</span>
+                  <span className={isSelected ? 'text-sky-200' : 'text-zinc-600'}>{value.repo_count}</span>
+                </button>
+              );
+            })}
+            {aiTrendValues.length === 0 && (
+              <p className="text-xs text-zinc-600">No AI trend values returned by the taxonomy API.</p>
+            )}
+          </div>
+        )}
+
         {/* AI Dev Skills tab */}
         {activeTab === 'ai-dev-skills' && (
           <div className="flex flex-wrap gap-1.5">
@@ -395,16 +486,14 @@ export function FilterBar({
         {/* Industries tab */}
         {activeTab === 'industries' && (
           <div className="flex flex-wrap gap-1.5">
-            {(industryStats && industryStats.length > 0
-              ? industryStats
-              : ['Healthcare & Medicine', 'Finance & FinTech', 'Audio & Music', 'Gaming & Entertainment',
-                 'Robotics & Manufacturing', 'Spatial & Immersive', 'Developer Tools', 'Research & Academia']
-                  .map(ind => ({ industry: ind, count: 0 }))
-            ).map(({ industry: ind, count }) => {
+            {(industryValues.length > 0
+              ? industryValues.map(value => ({ industry: value.name, count: value.repo_count, id: value.id }))
+              : (industryStats ?? []).map(({ industry, count }, index) => ({ industry, count, id: index + 1 }))
+            ).map(({ industry: ind, count, id }) => {
               const isSelected = selectedIndustries.includes(ind);
               return (
                 <button
-                  key={ind}
+                  key={id}
                   onClick={() => onIndustryToggle?.(ind)}
                   className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
                     isSelected ? 'bg-amber-700 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
@@ -415,6 +504,78 @@ export function FilterBar({
                 </button>
               );
             })}
+            {industryValues.length === 0 && (!industryStats || industryStats.length === 0) && (
+              <p className="text-xs text-zinc-600">No industry values returned by the taxonomy API.</p>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'use-cases' && (
+          <div className="flex flex-wrap gap-1.5">
+            {useCaseValues.map((value) => {
+              const isSelected = selectedUseCases.includes(value.name);
+              return (
+                <button
+                  key={value.id}
+                  onClick={() => onUseCaseToggle?.(value.name)}
+                  className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                    isSelected ? 'bg-fuchsia-700 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                  }`}
+                >
+                  <span>{value.name}</span>
+                  <span className={isSelected ? 'text-fuchsia-200' : 'text-zinc-600'}>{value.repo_count}</span>
+                </button>
+              );
+            })}
+            {useCaseValues.length === 0 && (
+              <p className="text-xs text-zinc-600">No use case values returned by the taxonomy API.</p>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'modalities' && (
+          <div className="flex flex-wrap gap-1.5">
+            {modalityValues.map((value) => {
+              const isSelected = selectedModalities.includes(value.name);
+              return (
+                <button
+                  key={value.id}
+                  onClick={() => onModalityToggle?.(value.name)}
+                  className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                    isSelected ? 'bg-teal-700 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                  }`}
+                >
+                  <span>{value.name}</span>
+                  <span className={isSelected ? 'text-teal-200' : 'text-zinc-600'}>{value.repo_count}</span>
+                </button>
+              );
+            })}
+            {modalityValues.length === 0 && (
+              <p className="text-xs text-zinc-600">No modality values returned by the taxonomy API.</p>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'deployment-context' && (
+          <div className="flex flex-wrap gap-1.5">
+            {deploymentContextValues.map((value) => {
+              const isSelected = selectedDeploymentContexts.includes(value.name);
+              return (
+                <button
+                  key={value.id}
+                  onClick={() => onDeploymentContextToggle?.(value.name)}
+                  className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                    isSelected ? 'bg-orange-700 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                  }`}
+                >
+                  <span>{value.name}</span>
+                  <span className={isSelected ? 'text-orange-200' : 'text-zinc-600'}>{value.repo_count}</span>
+                </button>
+              );
+            })}
+            {deploymentContextValues.length === 0 && (
+              <p className="text-xs text-zinc-600">No deployment context values returned by the taxonomy API.</p>
+            )}
           </div>
         )}
 

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -5,7 +5,7 @@
  * Falls back to JSON if API is unreachable.
  */
 
-import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis } from '@/types/repo'
+import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, TaxonomyValueOption } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
 export type SearchMode = 'keyword' | 'semantic'
@@ -18,6 +18,7 @@ export interface DataProvider {
   getGaps(): Promise<GapAnalysis | null>
   getRepo(name: string): Promise<EnrichedRepo | null>
   searchRepos(query: string, mode?: SearchMode): Promise<EnrichedRepo[]>
+  getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]>
 }
 
 export function createDataProvider(): DataProvider {
@@ -76,6 +77,25 @@ class JsonDataProvider implements DataProvider {
       r.description?.toLowerCase().includes(q) ||
       r.enrichedTags.some(t => t.toLowerCase().includes(q))
     )
+  }
+
+  async getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]> {
+    const library = await this.getLibrary()
+    const counts = new Map<string, number>()
+    for (const repo of library.repos) {
+      for (const entry of repo.taxonomy ?? []) {
+        if (entry.dimension !== dimension) continue
+        counts.set(entry.value, (counts.get(entry.value) ?? 0) + 1)
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, repo_count], index) => ({
+        id: index + 1,
+        dimension,
+        name,
+        repo_count,
+      }))
   }
 }
 
@@ -145,5 +165,14 @@ class ApiDataProvider implements DataProvider {
       return await this.apiFetch<EnrichedRepo[]>(path)
     }
     catch { return this.fallback.searchRepos(query) }
+  }
+
+  async getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]> {
+    try {
+      const response = await this.apiFetch<{ values: TaxonomyValueOption[] }>(`/taxonomy/${encodeURIComponent(dimension)}`)
+      return response.values ?? []
+    } catch {
+      return this.fallback.getTaxonomyValues(dimension)
+    }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -7,6 +7,25 @@ export interface Builder {
   orgCategory: string | null
 }
 
+export interface TaxonomyEntry {
+  dimension: string
+  value: string
+  similarityScore?: number | null
+  assignedBy?: string
+}
+
+export interface TaxonomyValueOption {
+  id: number
+  dimension: string
+  name: string
+  description?: string | null
+  repo_count: number
+  trending_score?: number | null
+  first_seen_at?: string | null
+  last_active_at?: string | null
+  created_at?: string | null
+}
+
 export interface BuilderStats {
   login: string
   displayName: string
@@ -213,6 +232,7 @@ export interface EnrichedRepo {
   programmingLanguages: string[];
   builders: Builder[];
   similarity?: number;
+  taxonomy?: TaxonomyEntry[];
 }
 
 /** Summary statistics for a user's library */


### PR DESCRIPTION
## Changes
- add AI Trends, Industries, Use Cases, Modalities, and Deployment Context filter sections to the sidebar
- fetch taxonomy dimension values from the API on load with JSON fallback support
- filter repo results against repo taxonomy entries and show per-value repo counts

## Validation
- npm run build

## Jira
- KAN-6