### PR TITLE
feat: add proactive portfolio insights widget

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { LoadingState } from '@/components/LoadingState';
 import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
+import { PortfolioInsightsWidget } from '@/components/PortfolioInsightsWidget';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode } from '@/lib/dataProvider';
 
@@ -25,6 +26,7 @@ export default function HomePage() {
   const [isLoadingFull, setIsLoadingFull] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [trends, setTrends] = useState<TrendData | null>(null);
+  const [portfolioInsights, setPortfolioInsights] = useState<Awaited<ReturnType<typeof provider.getPortfolioInsights>>>(null);
 
   // Filter state
   const [search, setSearch] = useState('');
@@ -99,6 +101,9 @@ export default function HomePage() {
         // Non-blocking extras
         provider.getTrends()
           .then(t => { if (!cancelled && t) setTrends(t); })
+          .catch(() => {});
+        provider.getPortfolioInsights()
+          .then(insights => { if (!cancelled) setPortfolioInsights(insights); })
           .catch(() => {});
         provider.getGaps().catch(() => {});
       } catch (e) {
@@ -500,6 +505,11 @@ export default function HomePage() {
 
           {/* Ask / Intelligence query */}
           <AskBar apiUrl={API_URL} />
+
+          <PortfolioInsightsWidget
+            insights={portfolioInsights}
+            onRepoClick={handleRepoClick}
+          />
 
           {/* Stats */}
           {data && (

--- a/src/components/PortfolioInsightsWidget.tsx
+++ b/src/components/PortfolioInsightsWidget.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import type { PortfolioInsights } from '@/types/repo';
+
+interface PortfolioInsightsWidgetProps {
+  insights: PortfolioInsights | null;
+  onRepoClick: (name: string) => void;
+}
+
+function percent(similarity: number): string {
+  return `${Math.round(similarity * 100)}%`;
+}
+
+function repoNameFromFull(fullName: string): string {
+  return fullName.split('/').slice(-1)[0] ?? fullName;
+}
+
+export function PortfolioInsightsWidget({ insights, onRepoClick }: PortfolioInsightsWidgetProps) {
+  if (!insights) return null;
+
+  const hasSignals =
+    insights.summary.length > 0 ||
+    insights.taxonomy_gaps.length > 0 ||
+    insights.stale_repos.length > 0 ||
+    insights.velocity_leaders.length > 0 ||
+    insights.near_duplicate_clusters.length > 0;
+
+  if (!hasSignals) return null;
+
+  return (
+    <section className="rounded-2xl border border-sky-900/40 bg-gradient-to-br from-sky-950/50 via-zinc-950 to-zinc-950 p-4 md:p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">Portfolio Insights</p>
+          <h2 className="mt-1 text-lg font-semibold text-zinc-100">Proactive intelligence feed</h2>
+        </div>
+        <p className="text-xs text-zinc-500">
+          Updated {new Date(insights.generated_at).toLocaleString()}
+        </p>
+      </div>
+
+      {insights.summary.length > 0 && (
+        <div className="mt-4 grid gap-2 md:grid-cols-2">
+          {insights.summary.map((item) => (
+            <div key={item} className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2 text-sm text-zinc-300">
+              {item}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Emerging Taxonomy Gaps</p>
+          <div className="mt-2 space-y-2">
+            {insights.taxonomy_gaps.slice(0, 4).map((gap) => (
+              <div key={`${gap.dimension}:${gap.value}`} className="flex items-start justify-between gap-3 text-sm">
+                <div>
+                  <p className="font-medium text-zinc-200">{gap.value}</p>
+                  <p className="text-xs text-zinc-500">{gap.dimension.replaceAll('_', ' ')} · {gap.repo_count} repos</p>
+                </div>
+                <span className="rounded-full border border-sky-700/40 bg-sky-900/30 px-2 py-0.5 text-xs text-sky-300">
+                  {gap.trending_score.toFixed(1)}
+                </span>
+              </div>
+            ))}
+            {insights.taxonomy_gaps.length === 0 && (
+              <p className="text-sm text-zinc-500">No rising taxonomy gaps surfaced right now.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Velocity Leaders</p>
+          <div className="mt-2 space-y-2">
+            {insights.velocity_leaders.slice(0, 4).map((repo) => (
+              <div key={`${repo.owner}/${repo.repo_name}`} className="flex items-start justify-between gap-3 text-sm">
+                <button
+                  onClick={() => onRepoClick(repo.repo_name)}
+                  className="text-left font-medium text-zinc-200 hover:text-sky-300"
+                >
+                  {repo.owner}/{repo.repo_name}
+                </button>
+                <span className="text-xs text-emerald-400">{repo.commits_last_30_days} commits / 30d</span>
+              </div>
+            ))}
+            {insights.velocity_leaders.length === 0 && (
+              <p className="text-sm text-zinc-500">No velocity leaders available.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Stale Repos</p>
+          <div className="mt-2 space-y-2">
+            {insights.stale_repos.slice(0, 4).map((repo) => (
+              <div key={`${repo.owner}/${repo.repo_name}`} className="flex items-start justify-between gap-3 text-sm">
+                <button
+                  onClick={() => onRepoClick(repo.repo_name)}
+                  className="text-left font-medium text-zinc-200 hover:text-sky-300"
+                >
+                  {repo.owner}/{repo.repo_name}
+                </button>
+                <span className="text-xs text-amber-400">{repo.stale_days}d stale</span>
+              </div>
+            ))}
+            {insights.stale_repos.length === 0 && (
+              <p className="text-sm text-zinc-500">No stale repos passed the threshold.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Near-Duplicate Clusters</p>
+          <div className="mt-2 space-y-2">
+            {insights.near_duplicate_clusters.slice(0, 4).map((cluster) => (
+              <div key={cluster.repos.join('|')} className="text-sm text-zinc-300">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="space-x-1">
+                    {cluster.repos.map((repo) => (
+                      <button
+                        key={repo}
+                        onClick={() => onRepoClick(repoNameFromFull(repo))}
+                        className="font-medium text-zinc-200 hover:text-sky-300"
+                      >
+                        {repo}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="rounded-full border border-fuchsia-700/40 bg-fuchsia-900/30 px-2 py-0.5 text-xs text-fuchsia-300">
+                    {percent(cluster.similarity)} match
+                  </span>
+                </div>
+              </div>
+            ))}
+            {insights.near_duplicate_clusters.length === 0 && (
+              <p className="text-sm text-zinc-500">No high-similarity duplicate clusters detected in the current snapshot.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -5,7 +5,7 @@
  * Falls back to JSON if API is unreachable.
  */
 
-import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, TaxonomyValueOption } from '@/types/repo'
+import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, PortfolioInsights, TaxonomyValueOption } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
 export type SearchMode = 'keyword' | 'semantic'
@@ -19,6 +19,7 @@ export interface DataProvider {
   getRepo(name: string): Promise<EnrichedRepo | null>
   searchRepos(query: string, mode?: SearchMode): Promise<EnrichedRepo[]>
   getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]>
+  getPortfolioInsights(): Promise<PortfolioInsights | null>
 }
 
 export function createDataProvider(): DataProvider {
@@ -29,6 +30,14 @@ export function createDataProvider(): DataProvider {
 
 class JsonDataProvider implements DataProvider {
   mode: DataMode = 'lite'
+
+  private estimateActivityScore(repo: EnrichedRepo): number {
+    const last7 = repo.commitStats?.last7Days ?? 0
+    const last30 = repo.commitStats?.last30Days ?? 0
+    const last90 = repo.commitStats?.last90Days ?? 0
+    const weighted = Math.min(last7 * 12 + last30 * 2 + last90, 100)
+    return Math.round(weighted)
+  }
 
   async getOwnedLibrary(): Promise<LibraryData | null> {
     try {
@@ -96,6 +105,72 @@ class JsonDataProvider implements DataProvider {
         name,
         repo_count,
       }))
+  }
+
+  async getPortfolioInsights(): Promise<PortfolioInsights | null> {
+    const library = await this.getLibrary()
+    const taxonomyCounts = new Map<string, { dimension: string; count: number }>()
+    for (const repo of library.repos) {
+      for (const entry of repo.taxonomy ?? []) {
+        const key = `${entry.dimension}:${entry.value}`
+        const current = taxonomyCounts.get(key)
+        taxonomyCounts.set(key, {
+          dimension: entry.dimension,
+          count: (current?.count ?? 0) + 1,
+        })
+      }
+    }
+
+    const taxonomyGaps = [...taxonomyCounts.entries()]
+      .filter(([, value]) => value.dimension !== 'skill_area' && value.count <= 3)
+      .sort((a, b) => a[1].count - b[1].count || a[0].localeCompare(b[0]))
+      .slice(0, 5)
+      .map(([key, value]) => ({
+        dimension: value.dimension,
+        value: key.split(':').slice(1).join(':'),
+        repo_count: value.count,
+        trending_score: 0,
+      }))
+
+    const staleRepos = [...library.repos]
+      .map((repo) => ({
+        repo_name: repo.name,
+        owner: repo.fullName.split('/')[0] ?? '',
+        github_url: repo.url,
+        parent_stars: repo.parentStats?.stars ?? repo.stars,
+        activity_score: this.estimateActivityScore(repo),
+        last_updated_at: repo.lastUpdated,
+        stale_days: Math.floor((Date.now() - new Date(repo.lastUpdated).getTime()) / 86400000),
+      }))
+      .filter((repo) => repo.stale_days >= 180)
+      .sort((a, b) => b.stale_days - a.stale_days)
+      .slice(0, 5)
+
+    const velocityLeaders = [...library.repos]
+      .map((repo) => ({
+        repo_name: repo.name,
+        owner: repo.fullName.split('/')[0] ?? '',
+        github_url: repo.url,
+        commits_last_7_days: repo.commitStats?.last7Days ?? 0,
+        commits_last_30_days: repo.commitStats?.last30Days ?? 0,
+        activity_score: this.estimateActivityScore(repo),
+      }))
+      .filter((repo) => repo.commits_last_30_days > 0)
+      .sort((a, b) => b.commits_last_30_days - a.commits_last_30_days || b.commits_last_7_days - a.commits_last_7_days)
+      .slice(0, 5)
+
+    return {
+      generated_at: new Date().toISOString(),
+      taxonomy_gaps: taxonomyGaps,
+      stale_repos: staleRepos,
+      velocity_leaders: velocityLeaders,
+      near_duplicate_clusters: [],
+      summary: [
+        taxonomyGaps[0] ? `${taxonomyGaps[0].value} is underrepresented in the current taxonomy coverage.` : '',
+        staleRepos[0] ? `${staleRepos[0].owner}/${staleRepos[0].repo_name} is the stalest repo in the fallback dataset.` : '',
+        velocityLeaders[0] ? `${velocityLeaders[0].owner}/${velocityLeaders[0].repo_name} is leading recent commit velocity.` : '',
+      ].filter(Boolean),
+    }
   }
 }
 
@@ -173,6 +248,14 @@ class ApiDataProvider implements DataProvider {
       return response.values ?? []
     } catch {
       return this.fallback.getTaxonomyValues(dimension)
+    }
+  }
+
+  async getPortfolioInsights(): Promise<PortfolioInsights | null> {
+    try {
+      return await this.apiFetch<PortfolioInsights>('/intelligence/portfolio-insights')
+    } catch {
+      return this.fallback.getPortfolioInsights()
     }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -91,6 +91,47 @@ export interface TrendData {
   insights: string[];
 }
 
+export interface TaxonomyGapInsight {
+  dimension: string;
+  value: string;
+  repo_count: number;
+  trending_score: number;
+  description?: string | null;
+}
+
+export interface StaleRepoInsight {
+  repo_name: string;
+  owner: string;
+  github_url: string;
+  parent_stars?: number | null;
+  activity_score: number;
+  last_updated_at?: string | null;
+  stale_days: number;
+}
+
+export interface VelocityLeaderInsight {
+  repo_name: string;
+  owner: string;
+  github_url: string;
+  commits_last_7_days: number;
+  commits_last_30_days: number;
+  activity_score: number;
+}
+
+export interface DuplicateClusterInsight {
+  similarity: number;
+  repos: string[];
+}
+
+export interface PortfolioInsights {
+  generated_at: string;
+  taxonomy_gaps: TaxonomyGapInsight[];
+  stale_repos: StaleRepoInsight[];
+  velocity_leaders: VelocityLeaderInsight[];
+  near_duplicate_clusters: DuplicateClusterInsight[];
+  summary: string[];
+}
+
 export type GapSeverity = 'missing' | 'weak' | 'moderate' | 'strong';
 
 export interface GapEssentialRepo {


### PR DESCRIPTION
## Changes
- add a dashboard widget for portfolio insights on the main library page
- fetch proactive signals from /intelligence/portfolio-insights with JSON fallback support
- render taxonomy gaps, stale repos, velocity leaders, and near-duplicate clusters

## Validation
- npm run build