### PR TITLE
feat: add cross-dimension analytics dashboard widget

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
 import { PortfolioInsightsWidget } from '@/components/PortfolioInsightsWidget';
+import { CrossDimensionWidget } from '@/components/CrossDimensionWidget';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode } from '@/lib/dataProvider';
 
@@ -27,6 +28,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null);
   const [trends, setTrends] = useState<TrendData | null>(null);
   const [portfolioInsights, setPortfolioInsights] = useState<Awaited<ReturnType<typeof provider.getPortfolioInsights>>>(null);
+  const [crossDimensionAnalytics, setCrossDimensionAnalytics] = useState<Awaited<ReturnType<typeof provider.getCrossDimensionAnalytics>>>(null);
 
   // Filter state
   const [search, setSearch] = useState('');
@@ -104,6 +106,9 @@ export default function HomePage() {
           .catch(() => {});
         provider.getPortfolioInsights()
           .then(insights => { if (!cancelled) setPortfolioInsights(insights); })
+          .catch(() => {});
+        provider.getCrossDimensionAnalytics('industry', 'ai_trend')
+          .then(analytics => { if (!cancelled) setCrossDimensionAnalytics(analytics); })
           .catch(() => {});
         provider.getGaps().catch(() => {});
       } catch (e) {
@@ -510,6 +515,8 @@ export default function HomePage() {
             insights={portfolioInsights}
             onRepoClick={handleRepoClick}
           />
+
+          <CrossDimensionWidget analytics={crossDimensionAnalytics} />
 
           {/* Stats */}
           {data && (

--- a/src/components/CrossDimensionWidget.tsx
+++ b/src/components/CrossDimensionWidget.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { CrossDimensionAnalytics } from '@/types/repo';
+
+interface CrossDimensionWidgetProps {
+  analytics: CrossDimensionAnalytics | null;
+}
+
+function label(value: string): string {
+  return value.replaceAll('_', ' ');
+}
+
+export function CrossDimensionWidget({ analytics }: CrossDimensionWidgetProps) {
+  if (!analytics || analytics.pairs.length === 0) return null;
+
+  const peak = Math.max(...analytics.pairs.map((pair) => pair.repo_count), 1);
+
+  return (
+    <section className="rounded-2xl border border-fuchsia-900/40 bg-gradient-to-br from-fuchsia-950/40 via-zinc-950 to-zinc-950 p-4 md:p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-300">Cross-Dimension Analytics</p>
+          <h2 className="mt-1 text-lg font-semibold text-zinc-100">
+            {label(analytics.dim1)} × {label(analytics.dim2)}
+          </h2>
+        </div>
+        <p className="text-xs text-zinc-500">Top {analytics.pairs.length} pairings</p>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {analytics.pairs.map((pair) => (
+          <div key={`${pair.dim1_value}:${pair.dim2_value}`} className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-zinc-200">{pair.dim1_value}</p>
+                <p className="truncate text-xs text-zinc-500">{pair.dim2_value}</p>
+              </div>
+              <span className="rounded-full border border-fuchsia-700/40 bg-fuchsia-900/30 px-2 py-0.5 text-xs text-fuchsia-300">
+                {pair.repo_count}
+              </span>
+            </div>
+            <div className="mt-3 h-2 rounded-full bg-zinc-800">
+              <div
+                className="h-2 rounded-full bg-gradient-to-r from-fuchsia-500 to-sky-400"
+                style={{ width: `${Math.max((pair.repo_count / peak) * 100, 8)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -5,7 +5,7 @@
  * Falls back to JSON if API is unreachable.
  */
 
-import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, PortfolioInsights, TaxonomyValueOption } from '@/types/repo'
+import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, PortfolioInsights, TaxonomyValueOption, CrossDimensionAnalytics } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
 export type SearchMode = 'keyword' | 'semantic'
@@ -20,6 +20,7 @@ export interface DataProvider {
   searchRepos(query: string, mode?: SearchMode): Promise<EnrichedRepo[]>
   getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]>
   getPortfolioInsights(): Promise<PortfolioInsights | null>
+  getCrossDimensionAnalytics(dim1: string, dim2: string, limit?: number): Promise<CrossDimensionAnalytics | null>
 }
 
 export function createDataProvider(): DataProvider {
@@ -172,6 +173,35 @@ class JsonDataProvider implements DataProvider {
       ].filter(Boolean),
     }
   }
+
+  async getCrossDimensionAnalytics(dim1: string, dim2: string, limit = 10): Promise<CrossDimensionAnalytics | null> {
+    const library = await this.getLibrary()
+    const counts = new Map<string, number>()
+
+    for (const repo of library.repos) {
+      const dim1Values = [...new Set((repo.taxonomy ?? []).filter((entry) => entry.dimension === dim1).map((entry) => entry.value))]
+      const dim2Values = [...new Set((repo.taxonomy ?? []).filter((entry) => entry.dimension === dim2).map((entry) => entry.value))]
+      for (const left of dim1Values) {
+        for (const right of dim2Values) {
+          const key = `${left}|||${right}`
+          counts.set(key, (counts.get(key) ?? 0) + 1)
+        }
+      }
+    }
+
+    return {
+      dim1,
+      dim2,
+      limit,
+      pairs: [...counts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, limit)
+        .map(([key, repo_count]) => {
+          const [dim1_value, dim2_value] = key.split('|||')
+          return { dim1_value, dim2_value, repo_count }
+        }),
+    }
+  }
 }
 
 class ApiDataProvider implements DataProvider {
@@ -256,6 +286,16 @@ class ApiDataProvider implements DataProvider {
       return await this.apiFetch<PortfolioInsights>('/intelligence/portfolio-insights')
     } catch {
       return this.fallback.getPortfolioInsights()
+    }
+  }
+
+  async getCrossDimensionAnalytics(dim1: string, dim2: string, limit = 10): Promise<CrossDimensionAnalytics | null> {
+    try {
+      return await this.apiFetch<CrossDimensionAnalytics>(
+        `/analytics/cross-dimension?dim1=${encodeURIComponent(dim1)}&dim2=${encodeURIComponent(dim2)}&limit=${limit}`
+      )
+    } catch {
+      return this.fallback.getCrossDimensionAnalytics(dim1, dim2, limit)
     }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -132,6 +132,19 @@ export interface PortfolioInsights {
   summary: string[];
 }
 
+export interface CrossDimensionCell {
+  dim1_value: string;
+  dim2_value: string;
+  repo_count: number;
+}
+
+export interface CrossDimensionAnalytics {
+  dim1: string;
+  dim2: string;
+  limit: number;
+  pairs: CrossDimensionCell[];
+}
+
 export type GapSeverity = 'missing' | 'weak' | 'moderate' | 'strong';
 
 export interface GapEssentialRepo {


### PR DESCRIPTION
## Changes
- fetch GET /analytics/cross-dimension?dim1=industry&dim2=ai_trend&limit=10
- add a dashboard widget below portfolio insights for top industry × AI trend pairings
- include JSON fallback computation in the data provider so static builds keep working

## Validation
- 
px next build --webpack

## Notes
- the widget intentionally stays lightweight and heatmap-like rather than adding a charting dependency