### PR TITLE
feat: add repo license badges and filters

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ export default function HomePage() {
   const [isSearchingSemantic, setIsSearchingSemantic] = useState(false);
   const [selectedType, setSelectedType] = useState<'all' | 'built' | 'forked'>('all');
   const [selectedLanguage, setSelectedLanguage] = useState('');
+  const [selectedLicense, setSelectedLicense] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedActivity, setSelectedActivity] = useState<'all' | 'active' | 'inactive'>('all');
   const [selectedSyncStatus, setSelectedSyncStatus] = useState<'all' | 'up-to-date' | 'behind' | 'behind-100' | 'ahead' | 'diverged'>('all');
@@ -244,6 +245,15 @@ export default function HomePage() {
     return counts;
   }, [data]);
 
+  const licenseCounts = useMemo(() => {
+    if (!data) return new Map<string, number>();
+    const counts = new Map<string, number>();
+    for (const repo of data.repos) {
+      if (repo.licenseSpdx) counts.set(repo.licenseSpdx, (counts.get(repo.licenseSpdx) ?? 0) + 1);
+    }
+    return counts;
+  }, [data]);
+
   const allTags = useMemo(() => {
     if (!data) return [];
     const counts = new Map<string, number>();
@@ -285,6 +295,7 @@ export default function HomePage() {
 
       // Language filter
       if (selectedLanguage && repo.language !== selectedLanguage) return false;
+      if (selectedLicense && repo.licenseSpdx !== selectedLicense) return false;
 
       // Tag filter — strictly against enrichedTags only
       if (selectedTags.length > 0) {
@@ -394,7 +405,7 @@ export default function HomePage() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders]);
 
   function clearFilters() {
     setSearch('');
@@ -402,6 +413,7 @@ export default function HomePage() {
     setSemanticResults(null);
     setSelectedType('all');
     setSelectedLanguage('');
+    setSelectedLicense('');
     setSelectedTags([]);
     setSelectedActivity('all');
     setSelectedSyncStatus('all');
@@ -544,6 +556,7 @@ export default function HomePage() {
                 tagMetrics={data.tagMetrics ?? []}
                 selectedType={selectedType}
                 selectedLanguage={selectedLanguage}
+                selectedLicense={selectedLicense}
                 selectedTags={selectedTags}
                 selectedActivity={selectedActivity}
                 selectedSyncStatus={selectedSyncStatus}
@@ -553,6 +566,7 @@ export default function HomePage() {
                 onCategoryChange={setSelectedCategory}
                 onTypeChange={setSelectedType}
                 onLanguageChange={setSelectedLanguage}
+                onLicenseChange={setSelectedLicense}
                 onTagToggle={toggleTag}
                 onTagRemove={removeTag}
                 onActivityChange={setSelectedActivity}
@@ -586,6 +600,7 @@ export default function HomePage() {
                 onBuilderToggle={toggleBuilder}
                 industryStats={industryStats}
                 languageCounts={languageCounts}
+                licenseCounts={licenseCounts}
               />
             </>
           )}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -11,6 +11,7 @@ interface FilterBarProps {
   selectedCategory: string;
   selectedType: 'all' | 'built' | 'forked';
   selectedLanguage: string;
+  selectedLicense?: string;
   selectedTags: string[];
   selectedActivity: 'all' | 'active' | 'inactive';
   selectedSyncStatus: 'all' | 'up-to-date' | 'behind' | 'behind-100' | 'ahead' | 'diverged';
@@ -19,6 +20,7 @@ interface FilterBarProps {
   onCategoryChange: (id: string) => void;
   onTypeChange: (v: 'all' | 'built' | 'forked') => void;
   onLanguageChange: (v: string) => void;
+  onLicenseChange?: (v: string) => void;
   onTagToggle: (tag: string) => void;
   onTagRemove: (tag: string) => void;
   onActivityChange: (v: 'all' | 'active' | 'inactive') => void;
@@ -39,6 +41,7 @@ interface FilterBarProps {
   onBuilderToggle?: (builder: string) => void;
   industryStats?: { industry: string; count: number }[];
   languageCounts?: Map<string, number>;
+  licenseCounts?: Map<string, number>;
   aiTrendValues?: TaxonomyValueOption[];
   industryValues?: TaxonomyValueOption[];
   useCaseValues?: TaxonomyValueOption[];
@@ -82,7 +85,8 @@ type TabId =
   | 'ai-dev-skills'
   | 'pm-skills'
   | 'builders'
-  | 'languages';
+  | 'languages'
+  | 'licenses';
 
 /** Filter and sort controls for the repo library */
 export function FilterBar({
@@ -93,6 +97,7 @@ export function FilterBar({
   selectedCategory,
   selectedType,
   selectedLanguage,
+  selectedLicense = '',
   selectedTags,
   selectedActivity,
   selectedSyncStatus,
@@ -101,6 +106,7 @@ export function FilterBar({
   onCategoryChange,
   onTypeChange,
   onLanguageChange,
+  onLicenseChange,
   onTagToggle,
   onTagRemove,
   onActivityChange,
@@ -124,6 +130,7 @@ export function FilterBar({
   onBuilderToggle,
   industryStats,
   languageCounts,
+  licenseCounts,
   aiTrendValues = [],
   industryValues = [],
   useCaseValues = [],
@@ -156,6 +163,7 @@ export function FilterBar({
     selectedCategory !== '' ||
     selectedType !== 'all' ||
     selectedLanguage !== '' ||
+    selectedLicense !== '' ||
     selectedTags.length > 0 ||
     selectedActivity !== 'all' ||
     selectedSyncStatus !== 'all' ||
@@ -179,6 +187,7 @@ export function FilterBar({
     { id: 'pm-skills', label: 'PM Skills' },
     { id: 'builders', label: 'Builders' },
     { id: 'languages', label: 'Languages' },
+    { id: 'licenses', label: 'Licenses' },
   ];
 
   // Group builders by category
@@ -639,6 +648,31 @@ export function FilterBar({
                 </button>
               );
             })}
+          </div>
+        )}
+
+        {activeTab === 'licenses' && (
+          <div className="flex flex-wrap gap-1.5">
+            {[...(licenseCounts?.entries() ?? [])]
+              .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+              .map(([license, count]) => {
+                const isSelected = selectedLicense === license;
+                return (
+                  <button
+                    key={license}
+                    onClick={() => onLicenseChange?.(isSelected ? '' : license)}
+                    className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                      isSelected ? 'bg-zinc-600 text-white' : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                    }`}
+                  >
+                    <span>{license}</span>
+                    <span className={isSelected ? 'text-zinc-200' : 'text-zinc-600'}>{count}</span>
+                  </button>
+                );
+              })}
+            {(licenseCounts?.size ?? 0) === 0 && (
+              <p className="text-xs text-zinc-600">No license data returned yet.</p>
+            )}
           </div>
         )}
 

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -189,6 +189,14 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
         <p className="line-clamp-2 text-xs text-zinc-400">{repo.description}</p>
       )}
 
+      {repo.licenseSpdx && (
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-zinc-700 bg-zinc-900/70 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
+            {repo.licenseSpdx}
+          </span>
+        </div>
+      )}
+
       {/* Forked from */}
       {repo.isFork && repo.forkedFrom && (
         <p className="text-xs text-zinc-500">

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -225,6 +225,7 @@ export interface EnrichedRepo {
   stars: number;
   forks: number;
   openIssuesCount?: number;
+  licenseSpdx?: string | null;
   lastUpdated: string;
   url: string;
   isArchived: boolean;


### PR DESCRIPTION
## Changes
- surface SPDX license badges on repo cards
- add a license tab to the sidebar filters
- filter the repo grid by `licenseSpdx`

## Validation
- `npx next build --webpack`