### PR TITLE
feat: surface quality signals in repo UI

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -2,9 +2,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { QualityBadge } from '@/components/QualityBadge';
 import { WikiNavBar } from '@/components/WikiNavBar';
 import { CATEGORIES } from '@/lib/buildCategories';
-import type { EnrichedRepo } from '@/types/repo';
+import type { EnrichedRepo, QualitySignals } from '@/types/repo';
 
 const API_URL =
   process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
@@ -52,6 +53,7 @@ interface RepoDetail {
   commits_last_90_days: number;
   readme_summary: string | null;
   activity_score: number;
+  quality_signals: QualitySignals | null;
   ingested_at: string;
   updated_at: string;
   github_updated_at: string | null;
@@ -203,6 +205,7 @@ async function getRepoDetail(name: string): Promise<RepoDetail | null> {
         commits_last_90_days: repo.commitStats?.last90Days ?? 0,
         readme_summary: repo.readmeSummary,
         activity_score: 0,
+        quality_signals: repo.qualitySignals ?? repo.quality_signals ?? null,
         ingested_at: repo.lastUpdated,
         updated_at: repo.lastUpdated,
         github_updated_at: repo.lastUpdated,
@@ -493,6 +496,35 @@ export default async function RepoDetailPage({
           </div>
 
           <div className="space-y-6">
+            <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-zinc-100">Quality</h2>
+                <QualityBadge quality={repo.quality_signals} />
+              </div>
+              {repo.quality_signals ? (
+                <dl className="mt-4 space-y-3 text-sm">
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-zinc-500">Has tests</dt>
+                    <dd className="text-zinc-200">{repo.quality_signals.has_tests ? 'Yes' : 'No'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-zinc-500">Has CI</dt>
+                    <dd className="text-zinc-200">{repo.quality_signals.has_ci ? 'Yes' : 'No'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-zinc-500">Commit velocity (30d)</dt>
+                    <dd className="text-zinc-200">{repo.quality_signals.commit_velocity_30d.toFixed(1)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-zinc-500">Overall score</dt>
+                    <dd className="text-zinc-200">{Math.round(repo.quality_signals.overall_score)}/100</dd>
+                  </div>
+                </dl>
+              ) : (
+                <p className="mt-3 text-sm text-zinc-500">Quality signals are not available for this repo yet.</p>
+              )}
+            </section>
+
             <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
               <h2 className="text-lg font-semibold text-zinc-100">Categories</h2>
               <div className="mt-4 flex flex-wrap gap-2">

--- a/src/components/QualityBadge.tsx
+++ b/src/components/QualityBadge.tsx
@@ -1,0 +1,20 @@
+import type { QualitySignals } from '@/types/repo';
+
+function badgeClasses(score: number): string {
+  if (score >= 80) return 'border-emerald-700/40 bg-emerald-900/40 text-emerald-300';
+  if (score >= 50) return 'border-amber-700/40 bg-amber-900/40 text-amber-300';
+  return 'border-red-700/40 bg-red-900/40 text-red-300';
+}
+
+export function QualityBadge({ quality }: { quality: QualitySignals | null | undefined }) {
+  if (!quality || typeof quality.overall_score !== 'number') return null;
+
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${badgeClasses(quality.overall_score)}`}
+      title={`Overall quality score: ${quality.overall_score}`}
+    >
+      Quality {Math.round(quality.overall_score)}
+    </span>
+  );
+}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { EnrichedRepo } from '@/types/repo';
 import { CATEGORIES } from '@/lib/buildCategories';
+import { QualityBadge } from '@/components/QualityBadge';
 
 /** Status tags that are not content tags — never show as clickable chips */
 const SYSTEM_TAGS = new Set(['Active', 'Forked', 'Built by Me', 'Inactive', 'Archived', 'Popular']);
@@ -114,6 +115,7 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
   const ps = repo.parentStats;
   const [commitsOpen, setCommitsOpen] = useState(false);
   const catStyle = getCategoryStyle(repo.primaryCategory);
+  const quality = repo.qualitySignals ?? repo.quality_signals;
 
   return (
     <div
@@ -136,6 +138,7 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
               {Math.round(repo.similarity * 100)}% match
             </span>
           )}
+          <QualityBadge quality={quality} />
           {repo.isFork && ps?.isArchived && (
             <span className="rounded-full bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">
               archived

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -132,6 +132,15 @@ export interface PortfolioInsights {
   summary: string[];
 }
 
+export interface QualitySignals {
+  has_tests: boolean;
+  has_ci: boolean;
+  commit_velocity_30d: number;
+  activity_score: number;
+  is_active: boolean;
+  overall_score: number;
+}
+
 export interface CrossDimensionCell {
   dim1_value: string;
   dim2_value: string;
@@ -287,6 +296,8 @@ export interface EnrichedRepo {
   programmingLanguages: string[];
   builders: Builder[];
   similarity?: number;
+  qualitySignals?: QualitySignals | null;
+  quality_signals?: QualitySignals | null;
   taxonomy?: TaxonomyEntry[];
 }
 


### PR DESCRIPTION
## Summary
- add a compact quality badge for repo cards when quality signals are present
- add a quality section on `/repo/[name]` with tests/CI/velocity/overall score
- keep the UI resilient when older payloads do not include quality signals

## Validation
- attempted `npx next build --webpack`
- current `dev` worktree still fails baseline frontend build setup in this environment (`@tailwindcss/postcss` missing in the transient npx install path and existing path-alias resolution drift), so I am not claiming a clean Next build here
- the patch itself is type-safe and scoped to optional quality-signal rendering