### PR TITLE
feat: group gap analysis by taxonomy dimension

### DIFF
--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import type { LibraryData } from '@/types/repo';
 import { AI_DEV_SKILLS } from '@/lib/buildTaxonomy';
+import { GapAnalysisPanel } from '@/components/GapAnalysisPanel';
 import { WikiNavBar } from '@/components/WikiNavBar';
 
 function getLibraryData(): LibraryData | null {
@@ -81,17 +82,7 @@ export default function WikiPage() {
       {data.gapAnalysis?.gaps && data.gapAnalysis.gaps.length > 0 && (
         <section>
           <h2 className="text-lg font-semibold text-zinc-200 mb-3">Library Gaps</h2>
-          <div className="space-y-2">
-            {data.gapAnalysis.gaps.map(gap => (
-              <div key={gap.category} className="rounded-lg border border-zinc-800 bg-zinc-900 p-3">
-                <div className="flex items-center gap-2">
-                  <span className="text-red-400 font-medium text-sm">{gap.category}</span>
-                  <span className="text-xs text-zinc-500">{gap.yourRepoCount} repos</span>
-                </div>
-                <p className="text-xs text-zinc-500 mt-1">{gap.description}</p>
-              </div>
-            ))}
-          </div>
+          <GapAnalysisPanel gaps={data.gapAnalysis.gaps} />
         </section>
       )}
     </div>

--- a/src/components/GapAnalysisPanel.tsx
+++ b/src/components/GapAnalysisPanel.tsx
@@ -1,0 +1,98 @@
+import type { Gap } from '@/types/repo';
+
+const DIMENSION_LABELS: Record<string, string> = {
+  skill_area: 'Skill Areas',
+  industry: 'Industries',
+  use_case: 'Use Cases',
+  modality: 'Modalities',
+  ai_trend: 'AI Trends',
+  deployment_context: 'Deployment Context',
+  dependency: 'Dependencies',
+  maturity_level: 'Maturity Levels',
+};
+
+function gapTitle(gap: Gap): string {
+  return gap.name ?? gap.skill ?? gap.category ?? 'Unclear';
+}
+
+function repoCount(gap: Gap): number {
+  return gap.repo_count ?? gap.repoCount ?? gap.yourRepoCount ?? 0;
+}
+
+function gapScore(gap: Gap): string | null {
+  const value = gap.gap_score;
+  if (typeof value !== 'number') return null;
+  return value.toFixed(value >= 10 ? 0 : 1);
+}
+
+export function GapAnalysisPanel({
+  gaps,
+  compact = false,
+}: {
+  gaps: Gap[];
+  compact?: boolean;
+}) {
+  if (!gaps.length) return null;
+
+  const overall = gaps.slice(0, compact ? 3 : 5);
+  const grouped = gaps.reduce<Map<string, Gap[]>>((map, gap) => {
+    if (!gap.dimension) return map;
+    const key = gap.dimension;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(gap);
+    return map;
+  }, new Map());
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-xs font-medium text-zinc-400 mb-1.5">Portfolio Gaps</p>
+        <div className="space-y-2">
+          {overall.map((gap, index) => (
+            <div
+              key={`${gap.dimension ?? 'overall'}:${gapTitle(gap)}:${index}`}
+              className="rounded-lg border border-zinc-800 p-2.5"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs font-medium text-zinc-300">{gapTitle(gap)}</p>
+                <span className="text-xs text-zinc-500">{repoCount(gap)} repos</span>
+              </div>
+              <p className="mt-1 text-xs text-zinc-500">{gap.description || gap.why || 'Gap surfaced by current portfolio coverage.'}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {grouped.size > 0 && (
+        <div className="space-y-3">
+          <p className="text-xs font-medium text-zinc-400 mb-1.5">By Taxonomy Dimension</p>
+          {[...grouped.entries()].map(([dimension, items]) => (
+            <div key={dimension} className="rounded-lg border border-zinc-800 bg-zinc-950/50 p-3">
+              <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+                {DIMENSION_LABELS[dimension] ?? dimension.replaceAll('_', ' ')}
+              </p>
+              <div className="mt-2 space-y-2">
+                {items.slice(0, compact ? 4 : 8).map((gap, index) => (
+                  <div
+                    key={`${dimension}:${gapTitle(gap)}:${index}`}
+                    className="flex items-start justify-between gap-3 text-sm"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-zinc-200">{gapTitle(gap)}</p>
+                      <p className="text-xs text-zinc-500">{repoCount(gap)} repos</p>
+                    </div>
+                    {gapScore(gap) ? (
+                      <span className="shrink-0 rounded-full border border-amber-700/30 bg-amber-900/20 px-2 py-0.5 text-[11px] text-amber-300">
+                        Gap {gapScore(gap)}
+                      </span>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MetricsSidebar.tsx
+++ b/src/components/MetricsSidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { LibraryData, TagMetrics, IntersectionMetrics, EnrichedRepo, CommitSummary, TrendData } from '@/types/repo';
 import { CATEGORIES } from '@/lib/buildCategories';
+import { GapAnalysisPanel } from '@/components/GapAnalysisPanel';
 
 interface MetricsSidebarProps {
   data: LibraryData;
@@ -653,22 +654,7 @@ function LibraryOverview({ data, tagMetrics, onRepoClick, onViewArchived, onView
 
           {/* Gap Analysis — always show if gaps exist */}
           {data.gapAnalysis && data.gapAnalysis.gaps.length > 0 && (
-            <div>
-              <p className="text-xs font-medium text-zinc-400 mb-1.5">🕳️ Library Gaps</p>
-              <div className="space-y-2">
-                {data.gapAnalysis.gaps.slice(0, 3).map(gap => (
-                  <div key={gap.category} className="rounded-lg border border-zinc-800 p-2.5">
-                    <p className="text-xs font-medium text-zinc-300">{gap.category}</p>
-                    <p className="text-xs text-zinc-500 mt-0.5">{gap.description}</p>
-                    {gap.popularMissingRepos.length > 0 && (
-                      <p className="text-xs text-zinc-600 mt-1">
-                        Missing: {gap.popularMissingRepos.slice(0, 2).map(r => r.name).join(', ')}
-                      </p>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
+            <GapAnalysisPanel gaps={data.gapAnalysis.gaps} compact />
           )}
 
           {/* Daily Digest link */}

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -154,6 +154,10 @@ export interface GapEssentialRepo {
 }
 
 export interface Gap {
+  dimension?: string;
+  name?: string;
+  repo_count?: number;
+  gap_score?: number;
   skill: string;
   severity: GapSeverity;
   repoCount: number;


### PR DESCRIPTION
## Summary
- add a reusable gap analysis panel that understands the new dimension-aware gap payload
- keep the overall portfolio gaps at the top
- group dimension-specific gaps under labeled taxonomy sections in the sidebar and wiki view

## Validation
- frontend worktree build remains blocked by existing `dev` environment drift, so this PR is validated by code inspection and compatibility with both legacy and new gap shapes