### PR TITLE
feat: add similar repos section to repo detail

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { QualityBadge } from '@/components/QualityBadge';
 import { WikiNavBar } from '@/components/WikiNavBar';
 import { CATEGORIES } from '@/lib/buildCategories';
-import type { EnrichedRepo, QualitySignals } from '@/types/repo';
+import type { EnrichedRepo, QualitySignals, SimilarRepo } from '@/types/repo';
 
 const API_URL =
   process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
@@ -244,6 +244,19 @@ async function getRepoDetail(name: string): Promise<RepoDetail | null> {
   }
 }
 
+async function getSimilarRepos(name: string): Promise<SimilarRepo[]> {
+  try {
+    const response = await fetch(`${API_URL}/repos/${encodeURIComponent(name)}/similar?limit=5`, {
+      next: { revalidate: 300 },
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return [];
+    return (await response.json()) as SimilarRepo[];
+  } catch {
+    return [];
+  }
+}
+
 export async function generateStaticParams() {
   try {
     const data = JSON.parse(
@@ -273,6 +286,7 @@ export default async function RepoDetailPage({
   const { name } = await params;
   const repo = await getRepoDetail(decodeURIComponent(name));
   if (!repo) notFound();
+  const similarRepos = await getSimilarRepos(repo.name);
 
   const skillGroups = groupSkills(repo.ai_dev_skills ?? []);
   const taxonomyGroups = groupTaxonomy(repo.taxonomy ?? []);
@@ -618,6 +632,45 @@ export default async function RepoDetailPage({
               </dl>
             </section>
           </div>
+        </section>
+
+        <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-zinc-100">Similar Repos</h2>
+            <p className="text-xs text-zinc-500">Cosine similarity from repo embeddings</p>
+          </div>
+          {similarRepos.length > 0 ? (
+            <div className="mt-4 space-y-3">
+              {similarRepos.map((similar) => (
+                <Link
+                  key={similar.name}
+                  href={`/repo/${encodeURIComponent(similar.name)}`}
+                  className="flex items-start justify-between gap-4 rounded-2xl border border-zinc-800 bg-zinc-950/70 px-4 py-3 transition-colors hover:border-zinc-700"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-zinc-100">{similar.name}</p>
+                    <p className="mt-1 line-clamp-1 text-xs text-zinc-500">
+                      {similar.description ?? 'No description available.'}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {similar.primary_language ? (
+                      <span className="rounded-full border border-zinc-700 bg-zinc-800/70 px-2 py-0.5 text-xs text-zinc-300">
+                        {similar.primary_language}
+                      </span>
+                    ) : null}
+                    {typeof similar.similarity === 'number' ? (
+                      <span className="rounded-full border border-sky-700/30 bg-sky-900/30 px-2 py-0.5 text-xs font-medium text-sky-300">
+                        {Math.round(similar.similarity * 100)}% match
+                      </span>
+                    ) : null}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-zinc-500">No similar repos surfaced yet.</p>
+          )}
         </section>
       </main>
     </div>

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -5,7 +5,7 @@
  * Falls back to JSON if API is unreachable.
  */
 
-import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, PortfolioInsights, TaxonomyValueOption, CrossDimensionAnalytics } from '@/types/repo'
+import type { LibraryData, EnrichedRepo, TrendData, GapAnalysis, PortfolioInsights, TaxonomyValueOption, CrossDimensionAnalytics, SimilarRepo } from '@/types/repo'
 
 export type DataMode = 'lite' | 'production'
 export type SearchMode = 'keyword' | 'semantic'
@@ -21,6 +21,7 @@ export interface DataProvider {
   getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]>
   getPortfolioInsights(): Promise<PortfolioInsights | null>
   getCrossDimensionAnalytics(dim1: string, dim2: string, limit?: number): Promise<CrossDimensionAnalytics | null>
+  getSimilarRepos(name: string, limit?: number): Promise<SimilarRepo[]>
 }
 
 export function createDataProvider(): DataProvider {
@@ -202,6 +203,10 @@ class JsonDataProvider implements DataProvider {
         }),
     }
   }
+
+  async getSimilarRepos(_name: string, _limit = 5): Promise<SimilarRepo[]> {
+    return []
+  }
 }
 
 class ApiDataProvider implements DataProvider {
@@ -296,6 +301,14 @@ class ApiDataProvider implements DataProvider {
       )
     } catch {
       return this.fallback.getCrossDimensionAnalytics(dim1, dim2, limit)
+    }
+  }
+
+  async getSimilarRepos(name: string, limit = 5): Promise<SimilarRepo[]> {
+    try {
+      return await this.apiFetch<SimilarRepo[]>(`/repos/${encodeURIComponent(name)}/similar?limit=${limit}`)
+    } catch {
+      return this.fallback.getSimilarRepos(name, limit)
     }
   }
 }

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -154,6 +154,13 @@ export interface CrossDimensionAnalytics {
   pairs: CrossDimensionCell[];
 }
 
+export interface SimilarRepo {
+  name: string;
+  description: string | null;
+  primary_language?: string | null;
+  similarity?: number;
+}
+
 export type GapSeverity = 'missing' | 'weak' | 'moderate' | 'strong';
 
 export interface GapEssentialRepo {


### PR DESCRIPTION
## Summary
- add shared SimilarRepo typing and data-provider support for `/repos/{name}/similar`
- render a Similar Repos section on the repo detail page
- show repo name, one-line description, primary language, and similarity badge

## Validation
- validated by code inspection in the current frontend worktree
- full Next build remains blocked in this environment by the existing frontend dependency/setup drift on `dev`