### PR TITLE
feat(frontend): KAN-25 — public intelligence query UI (/ask page)

### DIFF
--- a/src/app/ask/page.tsx
+++ b/src/app/ask/page.tsx
@@ -1,0 +1,32 @@
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { AskPanel } from '@/components/AskPanel';
+
+const API_URL =
+  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
+  'https://reporium-api-573778300586.us-central1.run.app';
+
+interface AskPageProps {
+  searchParams: Promise<{ q?: string }>;
+}
+
+export default async function AskPage({ searchParams }: AskPageProps) {
+  const { q } = await searchParams;
+  const initialQuery = typeof q === 'string' ? decodeURIComponent(q) : '';
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title="Ask Reporium" />
+
+      <main className="mx-auto max-w-4xl px-6 py-10 space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold text-zinc-100">Ask Reporium</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            Query the AI dev tool library with natural language. Answers are grounded in your indexed repos.
+          </p>
+        </div>
+
+        <AskPanel apiUrl={API_URL} initialQuery={initialQuery} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { LoadingState } from '@/components/LoadingState';
 import { LoadingBanner } from '@/components/LoadingBanner';
 import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { AskBar } from '@/components/AskBar';
+import { MiniAskBar } from '@/components/MiniAskBar';
 import { PortfolioInsightsWidget } from '@/components/PortfolioInsightsWidget';
 import { CrossDimensionWidget } from '@/components/CrossDimensionWidget';
 import { TrendingThisWeekWidget } from '@/components/TrendingThisWeekWidget';
@@ -549,6 +550,9 @@ export default function HomePage() {
             </div>
           )}
 
+
+          {/* Mini Ask — navigates to /ask for full query experience */}
+          <MiniAskBar />
 
           {/* Ask / Intelligence query */}
           <AskBar apiUrl={API_URL} />

--- a/src/components/AskPanel.tsx
+++ b/src/components/AskPanel.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types matching /intelligence/query response schema
+// ---------------------------------------------------------------------------
+interface SourceRepo {
+  name: string;
+  description: string | null;
+  similarity_score: number;
+}
+
+interface QueryResponse {
+  answer: string;
+  sources: SourceRepo[];
+  query?: string;
+  model?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AskPanel — full-page query UI used on /ask
+// ---------------------------------------------------------------------------
+interface AskPanelProps {
+  apiUrl: string;
+  /** Pre-fill the query input (e.g. from ?q= param) */
+  initialQuery?: string;
+}
+
+export function AskPanel({ apiUrl, initialQuery = '' }: AskPanelProps) {
+  const [query, setQuery] = useState(initialQuery);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<QueryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-submit if initialQuery provided (navigated from mini panel)
+  useEffect(() => {
+    if (initialQuery && initialQuery.length >= 3) {
+      handleSubmit(initialQuery);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleSubmit(q?: string) {
+    const queryText = (q ?? query).trim();
+    if (!queryText || queryText.length < 3) {
+      setError('Please enter at least 3 characters.');
+      return;
+    }
+    if (queryText.length > 500) {
+      setError('Query must be 500 characters or fewer.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await fetch(`${apiUrl}/intelligence/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: queryText, include_sources: true }),
+      });
+
+      if (res.status === 429) {
+        setError('Rate limit exceeded. Please wait before querying again.');
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError((body as { detail?: string })?.detail ?? `Server error (${res.status}). Please try again.`);
+        return;
+      }
+
+      const data: QueryResponse = await res.json();
+      setResult(data);
+    } catch {
+      setError('Network error. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Input row */}
+      <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5 space-y-4">
+        <div className="flex gap-3">
+          <div className="relative flex-1">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm select-none">
+              ✦
+            </span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask a question about AI dev tools..."
+              maxLength={500}
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-900 py-3 pl-8 pr-4 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            />
+          </div>
+          <button
+            onClick={() => handleSubmit()}
+            disabled={loading}
+            className="shrink-0 rounded-lg bg-zinc-700 px-5 py-3 text-sm text-zinc-200 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-400 border-t-transparent" />
+                Querying...
+              </span>
+            ) : (
+              'Submit'
+            )}
+          </button>
+        </div>
+
+        {loading && (
+          <p className="text-xs text-zinc-500">Searching repos and generating answer — this may take a moment…</p>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+
+      {/* Results */}
+      {result && (
+        <div className="space-y-5">
+          {/* Answer */}
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <p className="text-[11px] uppercase tracking-[0.2em] text-zinc-500 mb-3">Answer</p>
+            <div className="text-sm text-zinc-200 leading-relaxed whitespace-pre-wrap">
+              {result.answer}
+            </div>
+          </div>
+
+          {/* Source repos */}
+          {result.sources && result.sources.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-[11px] uppercase tracking-[0.2em] text-zinc-500 font-medium">
+                Sources · {result.sources.length} repo{result.sources.length !== 1 ? 's' : ''}
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {result.sources.map((repo) => {
+                  const score = Math.round(repo.similarity_score * 100);
+                  return (
+                    <div
+                      key={repo.name}
+                      className="rounded-xl border border-zinc-800 bg-zinc-900/60 px-4 py-3 space-y-1.5"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="text-xs font-mono font-medium text-zinc-200 truncate">
+                          {repo.name}
+                        </span>
+                        <span className="shrink-0 rounded-full border border-sky-700/30 bg-sky-900/30 px-2 py-0.5 text-[10px] font-medium text-sky-300">
+                          {score}%
+                        </span>
+                      </div>
+                      {repo.description && (
+                        <p className="text-xs text-zinc-500 line-clamp-2">{repo.description}</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MiniAskBar.tsx
+++ b/src/components/MiniAskBar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+/** Mini ask input on the library home — navigates to /ask?q=... */
+export function MiniAskBar() {
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+
+  function navigate() {
+    const q = query.trim();
+    if (!q) return;
+    router.push(`/ask?q=${encodeURIComponent(q)}`);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      navigate();
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-3">
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm select-none">
+            ✦
+          </span>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask a question about AI dev tools..."
+            maxLength={500}
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-900 py-2.5 pl-8 pr-4 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          />
+        </div>
+        <button
+          onClick={navigate}
+          className="shrink-0 rounded-lg bg-zinc-700 px-4 py-2.5 text-sm text-zinc-200 hover:bg-zinc-600 transition-colors"
+        >
+          Ask
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WikiNavBar.tsx
+++ b/src/components/WikiNavBar.tsx
@@ -20,9 +20,12 @@ export function WikiNavBar({ title }: WikiNavBarProps) {
         {title ?? 'Reporium Wiki'}
       </span>
 
-      <span className="text-xs text-zinc-500">
-        ☰ <Link href="/wiki" className="hover:text-zinc-300 transition-colors">Wiki</Link>
-      </span>
+      <div className="flex items-center gap-4 text-xs text-zinc-500">
+        <Link href="/ask" className="hover:text-zinc-300 transition-colors">Ask</Link>
+        <Link href="/runs" className="hover:text-zinc-300 transition-colors">Run History</Link>
+        <Link href="/taxonomy" className="hover:text-zinc-300 transition-colors">Taxonomy</Link>
+        <span>☰ <Link href="/wiki" className="hover:text-zinc-300 transition-colors">Wiki</Link></span>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `/ask` page with full `AskPanel` component that POSTs to `/intelligence/query` with `{query, include_sources: true}`
- Displays answer text and source repo cards (name, description, similarity score)
- Shows loading state while fetching; gracefully handles errors
- Extracts `AskPanel` as a reusable component at `src/components/AskPanel.tsx`
- Adds `MiniAskBar` to the main library page (`src/app/page.tsx`) — input + button that navigates to `/ask?q=...` with the query pre-filled
- Updates `WikiNavBar` with nav links to Ask, Run History, and Taxonomy pages
- Matches existing dark zinc-950 design system

## Test plan
- [ ] Visit `/ask`, enter a question, verify answer + source cards appear
- [ ] On main library page, enter text in MiniAskBar, click Ask — should navigate to `/ask?q=...` and auto-submit
- [ ] Pre-filled query from `?q=` param auto-submits on page load
- [ ] Loading spinner shows while request is in flight
- [ ] Error messages surface on network/server failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)