### PR TITLE
feat(frontend): KAN-26 — ingestion run history page (/runs)

### DIFF
--- a/src/app/runs/page.tsx
+++ b/src/app/runs/page.tsx
@@ -1,0 +1,57 @@
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { RunsTable } from '@/components/RunsTable';
+
+const API_URL =
+  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
+  'https://reporium-api-573778300586.us-central1.run.app';
+
+export interface IngestionRun {
+  run_id: string;
+  mode: string;
+  status: string;
+  repos_upserted: number;
+  started_at: string;
+  finished_at: string | null;
+  errors?: string[];
+}
+
+async function getRuns(): Promise<IngestionRun[]> {
+  try {
+    const res = await fetch(`${API_URL}/admin/runs`, {
+      next: { revalidate: 60 },
+      headers: { Accept: 'application/json' },
+    });
+    if (res.status === 404) return [];
+    if (!res.ok) return [];
+    const data = await res.json();
+    // API may return array directly or wrapped under `runs`
+    if (Array.isArray(data)) return data as IngestionRun[];
+    if (data && Array.isArray((data as { runs?: unknown }).runs)) {
+      return (data as { runs: IngestionRun[] }).runs;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+export default async function RunsPage() {
+  const runs = await getRuns();
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title="Run History" />
+
+      <main className="mx-auto max-w-6xl px-6 py-10 space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-zinc-100">Ingestion Run History</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            Recent ingestion runs that populate the repo library.
+          </p>
+        </div>
+
+        <RunsTable runs={runs} apiUrl={API_URL} showRefresh />
+      </main>
+    </div>
+  );
+}

--- a/src/components/RunsTable.tsx
+++ b/src/components/RunsTable.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import type { IngestionRun } from '@/app/runs/page';
+
+interface RunsTableProps {
+  runs: IngestionRun[];
+  apiUrl: string;
+  showRefresh?: boolean;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function formatDuration(started: string, finished: string | null): string {
+  if (!finished) return 'In progress';
+  const ms = new Date(finished).getTime() - new Date(started).getTime();
+  if (ms < 0) return '—';
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}m ${rem}s`;
+}
+
+function statusColor(status: string): string {
+  switch (status.toLowerCase()) {
+    case 'success':
+    case 'completed':
+      return 'text-emerald-400 border-emerald-700/40 bg-emerald-900/30';
+    case 'failed':
+    case 'error':
+      return 'text-red-400 border-red-700/40 bg-red-900/30';
+    case 'running':
+    case 'in_progress':
+      return 'text-sky-400 border-sky-700/40 bg-sky-900/30';
+    default:
+      return 'text-zinc-400 border-zinc-700 bg-zinc-800/50';
+  }
+}
+
+export function RunsTable({ runs: initialRuns, apiUrl, showRefresh }: RunsTableProps) {
+  const [runs, setRuns] = useState<IngestionRun[]>(initialRuns);
+  const [refreshing, setRefreshing] = useState(false);
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const res = await fetch(`${apiUrl}/admin/runs`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) setRuns(data as IngestionRun[]);
+        else if (Array.isArray(data?.runs)) setRuns(data.runs as IngestionRun[]);
+      }
+    } catch {
+      // silently ignore — keep stale data
+    } finally {
+      setRefreshing(false);
+    }
+  }, [apiUrl]);
+
+  function toggleRow(runId: string) {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) next.delete(runId);
+      else next.add(runId);
+      return next;
+    });
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="space-y-4 w-full">
+        {showRefresh && (
+          <div className="flex justify-end">
+            <button
+              onClick={refresh}
+              disabled={refreshing}
+              className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 disabled:opacity-50 transition-colors"
+            >
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+          </div>
+        )}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
+          <p className="text-sm text-zinc-500">No run history available yet.</p>
+          <p className="mt-1 text-xs text-zinc-600">Ingestion runs will appear here once completed.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 w-full">
+      {showRefresh && (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-zinc-500">{runs.length} run{runs.length !== 1 ? 's' : ''} found</p>
+          <button
+            onClick={refresh}
+            disabled={refreshing}
+            className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 disabled:opacity-50 transition-colors"
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-xl border border-zinc-800">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 bg-zinc-900/70">
+              <th className="px-4 py-3 text-left text-[11px] uppercase tracking-[0.15em] text-zinc-500">Run ID</th>
+              <th className="px-4 py-3 text-left text-[11px] uppercase tracking-[0.15em] text-zinc-500">Mode</th>
+              <th className="px-4 py-3 text-left text-[11px] uppercase tracking-[0.15em] text-zinc-500">Status</th>
+              <th className="px-4 py-3 text-right text-[11px] uppercase tracking-[0.15em] text-zinc-500">Repos</th>
+              <th className="px-4 py-3 text-left text-[11px] uppercase tracking-[0.15em] text-zinc-500">Started</th>
+              <th className="px-4 py-3 text-left text-[11px] uppercase tracking-[0.15em] text-zinc-500">Finished</th>
+              <th className="px-4 py-3 text-right text-[11px] uppercase tracking-[0.15em] text-zinc-500">Duration</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800/60">
+            {runs.map((run) => {
+              const hasErrors = run.errors && run.errors.length > 0;
+              const isExpanded = expandedRows.has(run.run_id);
+              return (
+                <>
+                  <tr
+                    key={run.run_id}
+                    className={`bg-zinc-900/30 hover:bg-zinc-900/60 transition-colors ${hasErrors ? 'cursor-pointer' : ''}`}
+                    onClick={() => hasErrors && toggleRow(run.run_id)}
+                  >
+                    <td className="px-4 py-3 font-mono text-xs text-zinc-400">
+                      <span className="flex items-center gap-1.5">
+                        {hasErrors && (
+                          <span className="text-zinc-600">{isExpanded ? '▼' : '▶'}</span>
+                        )}
+                        {run.run_id.length > 16 ? `${run.run_id.slice(0, 16)}…` : run.run_id}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-zinc-300">{run.mode}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-medium ${statusColor(run.status)}`}>
+                        {run.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-300">{run.repos_upserted.toLocaleString()}</td>
+                    <td className="px-4 py-3 text-zinc-400">{formatDate(run.started_at)}</td>
+                    <td className="px-4 py-3 text-zinc-400">{formatDate(run.finished_at)}</td>
+                    <td className="px-4 py-3 text-right text-zinc-400">{formatDuration(run.started_at, run.finished_at)}</td>
+                  </tr>
+                  {hasErrors && isExpanded && (
+                    <tr key={`${run.run_id}-errors`} className="bg-red-950/10">
+                      <td colSpan={7} className="px-6 py-3">
+                        <p className="text-[11px] uppercase tracking-[0.15em] text-red-400 mb-2">
+                          Errors ({run.errors!.length})
+                        </p>
+                        <ul className="space-y-1">
+                          {run.errors!.map((err, i) => (
+                            <li key={i} className="text-xs text-red-300 font-mono bg-red-950/20 rounded px-3 py-1">
+                              {err}
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
+                    </tr>
+                  )}
+                </>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/runs` server-side page that fetches `GET /admin/runs`
- Shows a table: run_id, mode, status, repos_upserted, started_at, finished_at, duration
- Each row is expandable (click) to show errors if any exist
- Gracefully handles 404/empty with "No run history available yet." message
- Client-side Refresh button re-fetches without a full page reload
- Status badges color-coded (emerald = success, red = failed, sky = running)

## Test plan
- [ ] Visit `/runs` — if API returns empty/404, see empty state message
- [ ] If runs exist, table renders with correct columns
- [ ] Click a row that has errors to expand/collapse error list
- [ ] Click Refresh button — spinner shows, table updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)