### PR TITLE
feat(frontend): KAN-28 — dependencies section in repo detail page

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -606,6 +606,30 @@ export default async function RepoDetailPage({
               </div>
             </section>
 
+            {/* Dependencies — only rendered when taxonomy has `dependency` entries */}
+            {(() => {
+              const deps = (repo.taxonomy ?? []).filter((t) => t.dimension === 'dependency');
+              if (deps.length === 0) return null;
+              return (
+                <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+                  <div className="flex items-center justify-between gap-3 mb-4">
+                    <h2 className="text-lg font-semibold text-zinc-100">Dependencies</h2>
+                    <span className="text-xs text-zinc-500">{deps.length} detected</span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {deps.map((dep) => (
+                      <span
+                        key={dep.value}
+                        className="rounded-full border border-violet-700/40 bg-violet-900/20 px-3 py-1 text-xs font-medium text-violet-300"
+                      >
+                        {dep.value}
+                      </span>
+                    ))}
+                  </div>
+                </section>
+              );
+            })()}
+
             <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
               <h2 className="text-lg font-semibold text-zinc-100">Timeline</h2>
               <dl className="mt-4 space-y-3 text-sm">


### PR DESCRIPTION
## Summary
- Adds a **Dependencies** section to `src/app/repo/[name]/page.tsx`
- Positioned between the Languages section and the Timeline section in the sidebar column
- Checks `repo.taxonomy` for entries where `dimension === 'dependency'`
- If present: shows "X dependencies detected" count and renders each as a non-clickable badge chip (violet colour scheme)
- Section is conditionally hidden when no dependency taxonomy entries exist — zero visual impact for repos without dependencies

## Test plan
- [ ] Visit a repo that has dependency taxonomy entries — Dependencies section appears between Languages and Timeline
- [ ] Chip count matches the number of entries (`X dependencies detected`)
- [ ] Each chip is non-clickable (plain `<span>`, not a link)
- [ ] Repos without dependency entries show no Dependencies section

🤖 Generated with [Claude Code](https://claude.com/claude-code)