### PR TITLE
test: add coverage for ask, runs, mini ask, and taxonomy pages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ const config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  testMatch: ['**/tests/**/*.test.ts'],
+  testMatch: ['**/tests/**/*.test.ts', '**/tests/**/*.test.tsx'],
   testPathIgnorePatterns: ['/node_modules/', '/.claude/worktrees/'],
 };
 

--- a/tests/AskPanel.test.tsx
+++ b/tests/AskPanel.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AskPanel } from '@/components/AskPanel';
+
+describe('AskPanel', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders input and submits to the API', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        answer: 'Use the RAG stack.',
+        sources: [{ name: 'repo-a', description: 'Repo A', similarity_score: 0.91 }],
+      }),
+    }) as unknown as typeof fetch;
+
+    render(<AskPanel apiUrl="https://api.example.com" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'best RAG tools' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(await screen.findByText('Use the RAG stack.')).toBeTruthy();
+    expect(screen.getByText('repo-a')).toBeTruthy();
+    expect(screen.getByText('91%')).toBeTruthy();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.example.com/intelligence/query',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('shows loading state while waiting for the API', async () => {
+    let resolveFetch: ((value: unknown) => void) | undefined;
+    global.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    ) as unknown as typeof fetch;
+
+    render(<AskPanel apiUrl="https://api.example.com" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'agent frameworks' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(screen.getByText('Querying...')).toBeTruthy();
+
+    resolveFetch?.({
+      ok: true,
+      status: 200,
+      json: async () => ({ answer: 'Done', sources: [] }),
+    });
+
+    expect(await screen.findByText('Done')).toBeTruthy();
+  });
+
+  test('shows server error state', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'Boom' }),
+    }) as unknown as typeof fetch;
+
+    render(<AskPanel apiUrl="https://api.example.com" initialQuery="bad query" />);
+
+    expect(await screen.findByText('Boom')).toBeTruthy();
+  });
+
+  test('shows network error state', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+    render(<AskPanel apiUrl="https://api.example.com" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'edge inference' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error. Please check your connection and try again.')).toBeTruthy();
+    });
+  });
+});

--- a/tests/MiniAskBar.test.tsx
+++ b/tests/MiniAskBar.test.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MiniAskBar } from '@/components/MiniAskBar';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe('MiniAskBar', () => {
+  beforeEach(() => {
+    push.mockReset();
+  });
+
+  test('renders input and navigates to ask page on submit', () => {
+    render(<MiniAskBar />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'best eval frameworks' },
+    });
+    fireEvent.click(screen.getByText('Ask'));
+
+    expect(push).toHaveBeenCalledWith('/ask?q=best%20eval%20frameworks');
+  });
+});

--- a/tests/RunsTable.test.tsx
+++ b/tests/RunsTable.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { RunsTable } from '@/components/RunsTable';
+
+const API_URL = 'https://api.example.com';
+
+describe('RunsTable', () => {
+  test('renders empty state', () => {
+    render(<RunsTable runs={[]} apiUrl={API_URL} showRefresh />);
+
+    expect(screen.getByText('No run history available yet.')).toBeTruthy();
+    expect(screen.getByText('Refresh')).toBeTruthy();
+  });
+
+  test('renders run rows with formatted duration and status badge', () => {
+    render(
+      <RunsTable
+        apiUrl={API_URL}
+        runs={[
+          {
+            run_id: 'run-1',
+            mode: 'quick',
+            status: 'success',
+            repos_upserted: 42,
+            started_at: '2026-03-24T05:00:00Z',
+            finished_at: '2026-03-24T05:02:30Z',
+            errors: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('quick')).toBeTruthy();
+    expect(screen.getByText('success')).toBeTruthy();
+    expect(screen.getByText('2m 30s')).toBeTruthy();
+    expect(screen.getByText('42')).toBeTruthy();
+  });
+
+  test('expands error rows on click', () => {
+    render(
+      <RunsTable
+        apiUrl={API_URL}
+        runs={[
+          {
+            run_id: 'run-2',
+            mode: 'full',
+            status: 'failed',
+            repos_upserted: 3,
+            started_at: '2026-03-24T05:00:00Z',
+            finished_at: '2026-03-24T05:00:20Z',
+            errors: ['boom'],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('run-2'));
+
+    expect(screen.getByText('Errors (1)')).toBeTruthy();
+    expect(screen.getByText('boom')).toBeTruthy();
+  });
+});

--- a/tests/TaxonomyPage.test.tsx
+++ b/tests/TaxonomyPage.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import TaxonomyPage from '@/app/taxonomy/page';
+
+jest.mock('next/link', () => {
+  return function Link(props: { href: string; children: React.ReactNode; className?: string }) {
+    return React.createElement('a', { href: props.href, className: props.className }, props.children);
+  };
+});
+
+describe('TaxonomyPage', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders 8 dimension cards', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { dimension: 'skill_area', value: 'Agents', repo_count: 10 },
+          { dimension: 'industry', value: 'Healthcare', repo_count: 7 },
+          { dimension: 'use_case', value: 'Code generation', repo_count: 6 },
+          { dimension: 'modality', value: 'Text', repo_count: 9 },
+          { dimension: 'ai_trend', value: 'Agentic AI', repo_count: 8 },
+          { dimension: 'deployment_context', value: 'Cloud', repo_count: 5 },
+          { dimension: 'tags', value: 'production-ready', repo_count: 4 },
+          { dimension: 'maturity_level', value: 'production', repo_count: 3 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          gaps: [
+            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+            { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
+          ],
+        }),
+      }) as unknown as typeof fetch;
+
+    const element = await TaxonomyPage();
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('Skill Areas');
+    expect(html).toContain('Industries');
+    expect(html).toContain('Use Cases');
+    expect(html).toContain('Modalities');
+    expect(html).toContain('AI Trends');
+    expect(html).toContain('Deployment Context');
+    expect(html).toContain('Tags');
+    expect(html).toContain('Maturity Level');
+  });
+
+  test('renders gap chips with the expected labels', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          gaps: [
+            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+          ],
+        }),
+      }) as unknown as typeof fetch;
+
+    const element = await TaxonomyPage();
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('Gap Analysis Summary');
+    expect(html).toContain('Long Context');
+    expect(html).toContain('amber');
+  });
+});


### PR DESCRIPTION
## Changes
- add Jest coverage for AskPanel, RunsTable, MiniAskBar, and TaxonomyPage
- update the Jest matcher so .tsx tests are collected
- verify the new tests pass alongside the existing suite

## Validation
- 
px tsc --noEmit
- 
px jest --passWithNoTests
