### PR TITLE
fix: LibraryInsightsWidget enrichment-pending state (KAN-34)

### DIFF
--- a/src/components/LibraryInsightsWidget.tsx
+++ b/src/components/LibraryInsightsWidget.tsx
@@ -105,8 +105,6 @@ export function LibraryInsightsWidget({ repos, onTagClick }: LibraryInsightsWidg
     insights.taxonomyThemes.length > 0 ||
     insights.topTags.length > 0;
 
-  if (!hasAnyEnrichment) return null;
-
   const hasTaxonomy = insights.taxonomyThemes.length > 0;
 
   return (
@@ -123,6 +121,21 @@ export function LibraryInsightsWidget({ repos, onTagClick }: LibraryInsightsWidg
       </div>
 
       <div className="mt-4 grid gap-4 xl:grid-cols-3">
+
+        {/* ── Enrichment pending placeholder ── */}
+        {!hasAnyEnrichment && (
+          <div className="xl:col-span-2 rounded-xl border border-zinc-800 bg-zinc-900/60 p-3 flex flex-col justify-center gap-1.5">
+            <p className="text-xs font-medium uppercase tracking-wider text-zinc-500 mb-1">
+              AI Dev Skill Coverage &amp; Taxonomy Themes
+            </p>
+            <p className="text-sm text-zinc-500 leading-relaxed">
+              Enrichment is processing — skill coverage bars and taxonomy themes will appear after the next ingestion run completes.
+            </p>
+            <p className="text-xs text-zinc-600 mt-1">
+              {insights.total.toLocaleString()} repos indexed · {insights.reposWithSkills.toLocaleString()} AI-classified so far
+            </p>
+          </div>
+        )}
 
         {/* ── Skill Coverage ── */}
         {insights.sortedSkills.length > 0 && (


### PR DESCRIPTION
## Summary
- `LibraryInsightsWidget` was returning `null` when junction tables are empty (all `enrichedTags`/`aiDevSkills`/`taxonomy` arrays empty), leaving a blank section at the top of the page
- Now shows a 2-column "Enrichment is processing" panel explaining that skill coverage and taxonomy themes will appear after ingestion completes
- Includes repo count + AI-classified count so users can see the system has their repos but enrichment is pending
- Quality signals panel still renders with its own "pending" message
- No behaviour change once enrichment data is present — existing conditional rendering handles that

## Context
Production junction tables (`repo_tags`, `repo_ai_dev_skills`, `repo_taxonomy`) were empty, causing the widget to disappear entirely. Full ingestion is currently running to repopulate them.

## Test plan
- [ ] With enrichment data: widget shows skill coverage + taxonomy themes as before
- [ ] Without enrichment data: widget shows the pending panel + quality signals section instead of blank space
- [ ] `npx tsc --noEmit` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)