### PR TITLE
feat: add pending state to GapAnalysisPanel (KAN-39)

### DIFF
--- a/src/components/GapAnalysisPanel.tsx
+++ b/src/components/GapAnalysisPanel.tsx
@@ -32,7 +32,16 @@ export function GapAnalysisPanel({
   gaps: Gap[];
   compact?: boolean;
 }) {
-  if (!gaps.length) return null;
+  if (!gaps.length) {
+    return (
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
+        <p className="text-xs font-medium text-zinc-400 mb-1">Portfolio Gaps</p>
+        <p className="text-xs text-zinc-500 leading-relaxed">
+          Data building up — gap analysis will appear after enrichment completes.
+        </p>
+      </div>
+    );
+  }
 
   const overall = gaps.slice(0, compact ? 3 : 5);
   const grouped = gaps.reduce<Map<string, Gap[]>>((map, gap) => {

--- a/src/components/MetricsSidebar.tsx
+++ b/src/components/MetricsSidebar.tsx
@@ -652,8 +652,8 @@ function LibraryOverview({ data, tagMetrics, onRepoClick, onViewArchived, onView
             </>
           )}
 
-          {/* Gap Analysis — always show if gaps exist */}
-          {data.gapAnalysis && data.gapAnalysis.gaps.length > 0 && (
+          {/* Gap Analysis — show pending state when empty, populated data when ready */}
+          {data.gapAnalysis && (
             <GapAnalysisPanel gaps={data.gapAnalysis.gaps} compact />
           )}
 


### PR DESCRIPTION
## What
Adds a pending/loading state to GapAnalysisPanel when gaps data is empty, instead of the component silently disappearing.

## Why
https://perditio.atlassian.net/browse/KAN-39
Same fix already applied to LibraryInsightsWidget (#72) and CrossDimensionWidget (#73).

## Test plan
- [ ] With empty gaps data: panel shows pending state message
- [ ] With populated gaps data: panel renders normally
- [ ] No visual regression on other MetricsSidebar components