### PR TITLE
test: sync AskPanel tests with /intelligence/ask schema (KAN-43)

### DIFF
--- a/tests/AskPanel.test.tsx
+++ b/tests/AskPanel.test.tsx
@@ -26,7 +26,21 @@ describe('AskPanel', () => {
       status: 200,
       json: async () => ({
         answer: 'Use the RAG stack.',
-        sources: [{ name: 'repo-a', description: 'Repo A', similarity_score: 0.91 }],
+        question: 'best RAG tools',
+        model: 'claude-3',
+        answered_at: new Date().toISOString(),
+        embedding_candidates: 10,
+        tokens_used: { input: 100, output: 50, total: 150 },
+        sources: [{
+          name: 'repo-a',
+          owner: 'perditioinc',
+          forked_from: null,
+          description: 'Repo A',
+          stars: 42,
+          relevance_score: 0.91,
+          problem_solved: null,
+          integration_tags: [],
+        }],
       }),
     }) as unknown as typeof fetch;
 
@@ -38,10 +52,11 @@ describe('AskPanel', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     expect(await screen.findByText('Use the RAG stack.')).toBeTruthy();
-    expect(screen.getByText('repo-a')).toBeTruthy();
+    // Component renders "owner/name" as the upstream label
+    expect(screen.getByText('perditioinc/repo-a')).toBeTruthy();
     expect(screen.getByText('91%')).toBeTruthy();
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.example.com/intelligence/query',
+      'https://api.example.com/intelligence/ask',
       expect.objectContaining({ method: 'POST' }),
     );
   });


### PR DESCRIPTION
## What
Updates AskPanel tests to match the schema changes from PR #74.

## Why
PR #74 changed AskPanel to call \`/intelligence/ask\` (was \`/intelligence/query\`) and updated response types (\`relevance_score\` + \`owner\`/\`forked_from\` fields). Tests still mocked the old schema — CI was failing on every push to main, blocking the Vercel redeploy.

Fixes: https://perditio.atlassian.net/browse/KAN-43

## Changes
- Mock response now matches \`QueryResponse\` type (relevance_score, owner, forked_from, stars, etc.)
- API path assertion updated to \`/intelligence/ask\`
- Source display assertion updated to \`owner/name\` format (how component renders it)

## Test plan
- [x] All 4 AskPanel tests pass locally
- [ ] CI green

🤖 Generated with Claude