### PR TITLE
test: fix pre-existing CI test failures blocking prod deploy (KAN-43)

### DIFF
--- a/tests/AskPanel.test.tsx
+++ b/tests/AskPanel.test.tsx
@@ -26,7 +26,21 @@ describe('AskPanel', () => {
       status: 200,
       json: async () => ({
         answer: 'Use the RAG stack.',
-        sources: [{ name: 'repo-a', description: 'Repo A', similarity_score: 0.91 }],
+        question: 'best RAG tools',
+        model: 'claude-3',
+        answered_at: new Date().toISOString(),
+        embedding_candidates: 10,
+        tokens_used: { input: 100, output: 50, total: 150 },
+        sources: [{
+          name: 'repo-a',
+          owner: 'perditioinc',
+          forked_from: null,
+          description: 'Repo A',
+          stars: 42,
+          relevance_score: 0.91,
+          problem_solved: null,
+          integration_tags: [],
+        }],
       }),
     }) as unknown as typeof fetch;
 
@@ -38,10 +52,11 @@ describe('AskPanel', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     expect(await screen.findByText('Use the RAG stack.')).toBeTruthy();
-    expect(screen.getByText('repo-a')).toBeTruthy();
+    // Component renders "owner/name" as the upstream label
+    expect(screen.getByText('perditioinc/repo-a')).toBeTruthy();
     expect(screen.getByText('91%')).toBeTruthy();
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.example.com/intelligence/query',
+      'https://api.example.com/intelligence/ask',
       expect.objectContaining({ method: 'POST' }),
     );
   });

--- a/tests/RunsTable.test.tsx
+++ b/tests/RunsTable.test.tsx
@@ -9,7 +9,8 @@ const API_URL = 'https://api.example.com';
 
 describe('RunsTable', () => {
   test('exports runs page metadata', () => {
-    expect(metadata.title).toBe('Ingestion Run History | Reporium');
+    // Root layout applies "| Reporium" template at runtime — raw metadata.title is just the page title
+    expect(metadata.title).toBe('Ingestion Run History');
     expect(metadata.description).toBe('Recent ingestion pipeline runs for the Reporium AI dev tool library.');
   });
 


### PR DESCRIPTION
## What
Two pre-existing test failures were blocking every push to main and preventing the Vercel production deploy:

1. **AskPanel.test.tsx** — test mocked `/intelligence/query` schema but PR #74 changed the component to call `/intelligence/ask` with a different response shape (`relevance_score` not `similarity_score`, `owner`/`forked_from` fields required)
2. **RunsTable.test.tsx** — test expected `metadata.title` to be `'Ingestion Run History | Reporium'` but Next.js only applies the root layout title template at runtime; raw `metadata.title` is just `'Ingestion Run History'`

## Why
These failures were blocking the production Vercel deploy after the taxonomy recovery. Fixing them unblocks the live reporium.com deploy with real taxonomy data.

Refs: https://perditio.atlassian.net/browse/KAN-43

## Test plan
- [x] `AskPanel.test.tsx` — 4/4 pass locally
- [x] `RunsTable.test.tsx` — 4/4 pass locally

🤖 Generated with Claude