### PR TITLE
feat(ui): Claude Plugin badges + security risk visualization on repo cards

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -55,6 +55,12 @@ interface FilterBarProps {
   onUseCaseToggle?: (value: string) => void;
   onModalityToggle?: (value: string) => void;
   onDeploymentContextToggle?: (value: string) => void;
+  // Claude Plugins filter
+  showClaudePluginsOnly?: boolean;
+  onPluginToggle?: () => void;
+  // Security risk filter
+  selectedSecurityRisk?: 'all' | 'incident' | 'critical' | 'high' | 'medium' | 'low';
+  onSecurityRiskChange?: (v: 'all' | 'incident' | 'critical' | 'high' | 'medium' | 'low') => void;
 }
 
 /** Activity indicator dot based on score */
@@ -86,7 +92,8 @@ type TabId =
   | 'pm-skills'
   | 'builders'
   | 'languages'
-  | 'licenses';
+  | 'licenses'
+  | 'security';
 
 /** Filter and sort controls for the repo library */
 export function FilterBar({
@@ -140,6 +147,10 @@ export function FilterBar({
   onUseCaseToggle,
   onModalityToggle,
   onDeploymentContextToggle,
+  showClaudePluginsOnly = false,
+  onPluginToggle,
+  selectedSecurityRisk = 'all',
+  onSecurityRiskChange,
 }: FilterBarProps) {
   const [showAllTags, setShowAllTags] = useState(false);
   const [activeTab, setActiveTab] = useState<TabId>('categories');
@@ -174,7 +185,9 @@ export function FilterBar({
     selectedUseCases.length > 0 ||
     selectedModalities.length > 0 ||
     selectedDeploymentContexts.length > 0 ||
-    selectedBuilders.length > 0;
+    selectedBuilders.length > 0 ||
+    showClaudePluginsOnly ||
+    selectedSecurityRisk !== 'all';
 
   const tabs: { id: TabId; label: string }[] = [
     { id: 'categories', label: 'Categories' },
@@ -188,6 +201,7 @@ export function FilterBar({
     { id: 'builders', label: 'Builders' },
     { id: 'languages', label: 'Languages' },
     { id: 'licenses', label: 'Licenses' },
+    { id: 'security', label: '🛡️ Security' },
   ];
 
   // Group builders by category
@@ -293,6 +307,20 @@ export function FilterBar({
               <button onClick={() => onBuilderToggle?.(builder)} className="ml-1 hover:opacity-70">×</button>
             </span>
           ))}
+          {/* Claude Plugins pill */}
+          {showClaudePluginsOnly && (
+            <span className="flex items-center gap-1 rounded-full bg-violet-900/40 border border-violet-700/60 px-2.5 py-1 text-xs font-medium text-violet-300">
+              🔌 MCP / Plugins
+              <button onClick={() => onPluginToggle?.()} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          )}
+          {/* Security risk pill */}
+          {selectedSecurityRisk !== 'all' && (
+            <span className="flex items-center gap-1 rounded-full bg-red-900/40 border border-red-700/60 px-2.5 py-1 text-xs font-medium text-red-300">
+              🛡️ {selectedSecurityRisk === 'incident' ? 'Has Incident' : selectedSecurityRisk.toUpperCase()}
+              <button onClick={() => onSecurityRiskChange?.('all')} className="ml-1 hover:opacity-70">×</button>
+            </span>
+          )}
           {/* Other active filters */}
           {selectedType !== 'all' && (
             <span className="flex items-center gap-1 rounded-full bg-zinc-700/50 border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300">
@@ -676,6 +704,47 @@ export function FilterBar({
           </div>
         )}
 
+        {/* Security tab */}
+        {activeTab === 'security' && (
+          <div className="space-y-3">
+            <p className="text-xs text-zinc-500">
+              Filter by security risk level. Incidents are manually curated — use the admin API to mark repos.
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {([
+                { value: 'all',      label: 'All',           cls: 'bg-zinc-800 text-zinc-400' },
+                { value: 'incident', label: '⚠️ Has Incident', cls: 'bg-red-950 border border-red-700 text-red-300' },
+                { value: 'critical', label: '🛡️ Critical',    cls: 'bg-red-950 border border-red-700 text-red-300' },
+                { value: 'high',     label: '🛡️ High',        cls: 'bg-orange-950 border border-orange-700 text-orange-300' },
+                { value: 'medium',   label: '🛡️ Medium',      cls: 'bg-amber-950 border border-amber-700 text-amber-300' },
+                { value: 'low',      label: '🛡️ Low',         cls: 'bg-zinc-800 border border-zinc-600 text-zinc-400' },
+              ] as const).map(opt => (
+                <button
+                  key={opt.value}
+                  onClick={() => onSecurityRiskChange?.(opt.value as typeof selectedSecurityRisk)}
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                    selectedSecurityRisk === opt.value
+                      ? opt.cls + ' ring-1 ring-white/20'
+                      : 'bg-zinc-800 text-zinc-400 hover:text-zinc-200'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <div className="border-t border-zinc-800 pt-3">
+              <p className="text-[11px] text-zinc-600 font-medium uppercase tracking-wide mb-2">To mark a repo</p>
+              <code className="text-[11px] text-zinc-500 font-mono leading-relaxed block">
+                PATCH /admin/repos/&#123;name&#125;/security<br />
+                {`{ "risk_level": "critical", "incident_reported": true,`}<br />
+                {`  "incident_date": "2025-01-15",`}<br />
+                {`  "incident_url": "https://...",`}<br />
+                {`  "incident_summary": "Supply chain attack..." }`}
+              </code>
+            </div>
+          </div>
+        )}
+
         {/* Controls row */}
         <div className="flex flex-wrap items-center gap-2 pt-1 border-t border-zinc-800">
           {/* Type filter */}
@@ -692,6 +761,18 @@ export function FilterBar({
               </button>
             ))}
           </div>
+
+          {/* Claude Plugin / MCP toggle */}
+          <button
+            onClick={() => onPluginToggle?.()}
+            className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+              showClaudePluginsOnly
+                ? 'border-violet-600 bg-violet-900/50 text-violet-300'
+                : 'border-zinc-700 text-zinc-400 hover:text-zinc-200'
+            }`}
+          >
+            🔌 MCP / Plugins
+          </button>
 
           <select
             value={selectedActivity}

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -56,6 +56,17 @@ export function HomePageClient() {
   const [selectedModalities, setSelectedModalities] = useState<string[]>([]);
   const [selectedDeploymentContexts, setSelectedDeploymentContexts] = useState<string[]>([]);
   const [selectedBuilders, setSelectedBuilders] = useState<string[]>([]);
+
+  // Security risk + Claude Plugin filter state
+  const [showClaudePluginsOnly, setShowClaudePluginsOnly] = useState(false);
+  const [selectedSecurityRisk, setSelectedSecurityRisk] = useState<'all' | 'incident' | 'critical' | 'high' | 'medium' | 'low'>('all');
+
+  /** Tags that identify MCP servers and Claude plugins (must stay in sync with RepoCard.tsx) */
+  const MCP_PLUGIN_TAGS = new Set([
+    'mcp', 'mcp-server', 'mcp-client', 'mcp-tool',
+    'model-context-protocol', 'modelcontextprotocol',
+    'claude-mcp', 'claude-plugin', 'claude-tools', 'claude-app',
+  ]);
   const [aiTrendValues, setAiTrendValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
   const [industryValues, setIndustryValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
   const [useCaseValues, setUseCaseValues] = useState<Awaited<ReturnType<typeof provider.getTaxonomyValues>>>([]);
@@ -404,6 +415,32 @@ export function HomePageClient() {
         if (!(repo.builders ?? []).some(b => selectedBuilders.includes(b.login))) return false;
       }
 
+      // Claude Plugins / MCP filter
+      if (showClaudePluginsOnly) {
+        const lowerName = repo.name.toLowerCase();
+        const lowerDesc = (repo.description ?? '').toLowerCase();
+        const lowerTags = (repo.enrichedTags ?? []).map(t => t.toLowerCase());
+        const isMCP =
+          lowerTags.some(t => MCP_PLUGIN_TAGS.has(t)) ||
+          lowerName.startsWith('mcp-') ||
+          lowerName.endsWith('-mcp') ||
+          lowerName.includes('-mcp-') ||
+          lowerDesc.includes('model context protocol') ||
+          lowerDesc.includes('mcp server') ||
+          lowerDesc.includes('claude plugin');
+        if (!isMCP) return false;
+      }
+
+      // Security risk filter
+      if (selectedSecurityRisk !== 'all') {
+        const sig = repo.securitySignals;
+        if (selectedSecurityRisk === 'incident' && !sig?.incident_reported) return false;
+        if (selectedSecurityRisk === 'critical' && sig?.risk_level !== 'critical') return false;
+        if (selectedSecurityRisk === 'high'     && sig?.risk_level !== 'high')     return false;
+        if (selectedSecurityRisk === 'medium'   && sig?.risk_level !== 'medium')   return false;
+        if (selectedSecurityRisk === 'low'      && sig?.risk_level !== 'low')      return false;
+      }
+
       return true;
     });
 
@@ -431,7 +468,7 @@ export function HomePageClient() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders, showClaudePluginsOnly, selectedSecurityRisk]);
 
   function clearFilters() {
     setSearch('');
@@ -454,6 +491,8 @@ export function HomePageClient() {
     setSelectedModalities([]);
     setSelectedDeploymentContexts([]);
     setSelectedBuilders([]);
+    setShowClaudePluginsOnly(false);
+    setSelectedSecurityRisk('all');
   }
 
   function toggleTag(tag: string) {
@@ -645,6 +684,10 @@ export function HomePageClient() {
                 industryStats={industryStats}
                 languageCounts={languageCounts}
                 licenseCounts={licenseCounts}
+                showClaudePluginsOnly={showClaudePluginsOnly}
+                onPluginToggle={() => setShowClaudePluginsOnly(v => !v)}
+                selectedSecurityRisk={selectedSecurityRisk}
+                onSecurityRiskChange={setSelectedSecurityRisk}
               />
             </>
           )}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -8,6 +8,39 @@ import { QualityBadge } from '@/components/QualityBadge';
 /** Status tags that are not content tags — never show as clickable chips */
 const SYSTEM_TAGS = new Set(['Active', 'Forked', 'Built by Me', 'Inactive', 'Archived', 'Popular']);
 
+/**
+ * Tags / keywords that identify a repo as an MCP server or Claude plugin.
+ * Detection is purely client-side from enrichedTags + repo name/description.
+ */
+const MCP_PLUGIN_TAGS = new Set([
+  'mcp', 'mcp-server', 'mcp-client', 'mcp-tool',
+  'model-context-protocol', 'modelcontextprotocol',
+  'claude-mcp', 'claude-plugin', 'claude-tools', 'claude-app',
+]);
+
+function detectPluginType(repo: EnrichedRepo): 'mcp-server' | null {
+  const lowerName = repo.name.toLowerCase();
+  const lowerDesc = (repo.description ?? '').toLowerCase();
+  const lowerTags = (repo.enrichedTags ?? []).map(t => t.toLowerCase());
+
+  const tagMatch = lowerTags.some(t => MCP_PLUGIN_TAGS.has(t));
+  const nameMatch = lowerName.startsWith('mcp-') || lowerName.endsWith('-mcp') || lowerName.includes('-mcp-');
+  const descMatch =
+    lowerDesc.includes('model context protocol') ||
+    lowerDesc.includes('mcp server') ||
+    lowerDesc.includes('claude plugin');
+
+  return tagMatch || nameMatch || descMatch ? 'mcp-server' : null;
+}
+
+/** Color + label config for each risk level */
+const RISK_CONFIG: Record<string, { bg: string; border: string; text: string; label: string }> = {
+  critical: { bg: 'bg-red-950/80',    border: 'border-red-700',   text: 'text-red-300',    label: 'CRITICAL' },
+  high:     { bg: 'bg-orange-950/70', border: 'border-orange-700', text: 'text-orange-300', label: 'HIGH RISK' },
+  medium:   { bg: 'bg-amber-950/60',  border: 'border-amber-700',  text: 'text-amber-300',  label: 'MEDIUM RISK' },
+  low:      { bg: 'bg-zinc-800/60',   border: 'border-zinc-600',   text: 'text-zinc-400',   label: 'LOW RISK' },
+};
+
 /** Own-account logins — don't render as "builder" since the Built/Forked badge already shows ownership */
 const OWN_LOGINS = new Set(['perditioinc']);
 
@@ -116,12 +149,45 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
   const [commitsOpen, setCommitsOpen] = useState(false);
   const catStyle = getCategoryStyle(repo.primaryCategory);
   const quality = repo.qualitySignals ?? repo.quality_signals;
+  const sec = repo.securitySignals ?? null;
+  const pluginType = detectPluginType(repo);
+  const riskCfg = sec?.risk_level ? (RISK_CONFIG[sec.risk_level] ?? null) : null;
 
   return (
     <div
       className="group relative flex flex-col gap-3 rounded-xl border-t border-r border-b border-zinc-800 p-5 transition-all hover:border-zinc-600 hover:shadow-lg hover:shadow-black/20"
       style={{ borderLeftColor: catStyle.borderColor, borderLeftWidth: '4px', backgroundColor: catStyle.backgroundColor }}
     >
+      {/* ── Security Incident Banner (critical-priority top-of-card alert) ── */}
+      {sec?.incident_reported && (
+        <div className="rounded-lg border border-red-700 bg-red-950/80 px-3 py-2 -mx-5 -mt-5 rounded-t-xl rounded-b-none mb-0">
+          <div className="flex items-start gap-2">
+            <span className="text-red-400 text-sm shrink-0 mt-0.5">⚠️</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold text-red-300 uppercase tracking-wide">Security Incident Reported</p>
+              {sec.incident_summary && (
+                <p className="text-xs text-red-400 mt-0.5 line-clamp-2">{sec.incident_summary}</p>
+              )}
+              <div className="flex items-center gap-2 mt-1 flex-wrap">
+                {sec.incident_date && (
+                  <span className="text-[11px] text-red-500">{sec.incident_date}</span>
+                )}
+                {sec.incident_url && (
+                  <a
+                    href={sec.incident_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-red-400 hover:text-red-200 underline underline-offset-2 transition-colors"
+                  >
+                    View advisory →
+                  </a>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-start justify-between gap-2">
         <a
@@ -132,10 +198,28 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
         >
           {repo.name}
         </a>
-        <div className="flex items-center gap-1.5 shrink-0">
+        <div className="flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
           {typeof repo.similarity === 'number' && (
             <span className="rounded-full bg-sky-900/40 border border-sky-700/40 px-2 py-0.5 text-xs font-medium text-sky-300">
               {Math.round(repo.similarity * 100)}% match
+            </span>
+          )}
+          {/* Claude Plugin / MCP badge */}
+          {pluginType && (
+            <span className="rounded-full bg-violet-900/50 border border-violet-700/60 px-2 py-0.5 text-xs font-semibold text-violet-300">
+              🔌 MCP
+            </span>
+          )}
+          {/* Security risk badge (non-incident — incident gets the full banner above) */}
+          {riskCfg && !sec?.incident_reported && (
+            <span className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${riskCfg.bg} ${riskCfg.border} ${riskCfg.text}`}>
+              🛡️ {riskCfg.label}
+            </span>
+          )}
+          {/* Compact risk badge shown alongside the incident banner */}
+          {sec?.incident_reported && riskCfg && (
+            <span className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${riskCfg.bg} ${riskCfg.border} ${riskCfg.text}`}>
+              🛡️ {riskCfg.label}
             </span>
           )}
           <QualityBadge quality={quality} />

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -145,6 +145,20 @@ export interface QualitySignals {
   maturity?: 'research' | 'prototype' | 'beta' | 'production' | null;
 }
 
+/** Security risk signals — manually curated via admin API */
+export interface SecuritySignals {
+  /** Overall risk level */
+  risk_level: 'critical' | 'high' | 'medium' | 'low' | null;
+  /** True when a publicly disclosed security incident has been recorded */
+  incident_reported: boolean;
+  /** ISO date of incident, e.g. "2024-05-20" */
+  incident_date: string | null;
+  /** URL to CVE / advisory / blog post */
+  incident_url: string | null;
+  /** One-sentence human-readable summary of the incident */
+  incident_summary: string | null;
+}
+
 export interface CrossDimensionCell {
   dim1_value: string;
   dim2_value: string;
@@ -314,6 +328,8 @@ export interface EnrichedRepo {
   qualitySignals?: QualitySignals | null;
   quality_signals?: QualitySignals | null;
   taxonomy?: TaxonomyEntry[];
+  /** Security risk metadata — present only when manually marked via admin API */
+  securitySignals?: SecuritySignals | null;
 }
 
 /** Summary statistics for a user's library */


### PR DESCRIPTION
## Summary

Three new features across the repo card, filter bar, and page state:

### 🔌 Claude Plugin / MCP Detection
- `detectPluginType()` in `RepoCard.tsx` detects MCP servers client-side from tags, repo name, and description
- Matching: tags like `mcp`, `mcp-server`, `model-context-protocol`, names starting/ending with `mcp-`, descriptions mentioning "Model Context Protocol"
- Shows a **🔌 MCP** violet badge in the card header
- **"🔌 MCP / Plugins" toggle** in the FilterBar controls row filters to only MCP repos
- Active filter pill with × to clear

### 🛡️ Security Risk Badge
- Reads `repo.securitySignals.risk_level` from the API
- Four levels: `critical` (red), `high` (orange), `medium` (amber), `low` (zinc)
- Compact **🛡️ CRITICAL** etc. badge shown in card header

### ⚠️ Security Incident Banner
- When `securitySignals.incident_reported === true` (e.g. LiteLLM supply-chain attack), a **full-width red banner** appears at the top of the card
- Shows: incident summary, date, and "View advisory →" link to the CVE/blog
- Perfect for tracking supply-chain compromises, malicious commits, etc.

### Filter Bar — Security Tab
- New **"🛡️ Security"** tab with buttons: All · Has Incident · Critical · High · Medium · Low
- Inline admin API hint showing how to mark a repo
- Active filter pill in the sticky filter bar

## Types
- `SecuritySignals` interface added to `repo.ts`
- `securitySignals?: SecuritySignals | null` added to `EnrichedRepo`

## Test plan
- [ ] Repos with `mcp` tag show 🔌 MCP badge; "MCP / Plugins" toggle filters to them
- [ ] Mark a repo via API: `PATCH /admin/repos/litellm/security` with `incident_reported: true`; card shows red incident banner
- [ ] Critical/high/medium/low risk levels show correct colored badge
- [ ] Security tab in FilterBar shows options and filters correctly
- [ ] "Clear all" resets plugin + security filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)