### PR TITLE
feat(cards): 0-5 fire trending score + life/health status emoji indicator

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -79,6 +79,8 @@ const SORT_LABELS: Record<SortOption, string> = {
   'upstream-updated': 'Upstream Updated',
   'fork-oldest': 'Forked: Oldest',
   'fork-newest': 'Forked: Newest',
+  trending: '🔥 Trending First',
+  health: '💚 Healthiest First',
 };
 
 type TabId =

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -444,9 +444,40 @@ export function HomePageClient() {
       return true;
     });
 
+    /** Trending score 0-5 for sort — mirrors RepoCard.tsx getTrendingScore */
+    const trendScore = (r: EnrichedRepo) => {
+      const c7 = r.commitStats?.last7Days ?? 0;
+      const c30 = r.commitStats?.last30Days ?? 0;
+      if (c7 >= 20) return 5;
+      if (c7 >= 10) return 4;
+      if (c7 >=  4) return 3;
+      if (c7 >=  2) return 2;
+      if (c7 >=  1 || c30 >= 8) return 1;
+      return 0;
+    };
+
+    /** Health score 0-4 for sort — mirrors RepoCard.tsx getLifeStatus */
+    const healthScore = (r: EnrichedRepo) => {
+      const c7  = r.commitStats?.last7Days  ?? 0;
+      const c30 = r.commitStats?.last30Days ?? 0;
+      const c90 = r.commitStats?.last90Days ?? 0;
+      const stars = r.parentStats?.stars ?? r.stars ?? 0;
+      const daysSince = (Date.now() - new Date(r.lastUpdated).getTime()) / 86400000;
+      if (r.parentStats?.isArchived) return 0;
+      if (c7 >= 10 || c30 >= 30)    return 4; // Hot
+      if (c30 > 0)                  return 3; // Active
+      if (c90 > 0)                  return 2; // Stable
+      if (stars > 500 || daysSince < 365) return 1; // Dormant but useful
+      return 0; // Inactive
+    };
+
     // Apply sort
     return [...filtered].sort((a, b) => {
       switch (sortBy) {
+        case 'trending':
+          return trendScore(b) - trendScore(a) || (b.commitStats?.last7Days ?? 0) - (a.commitStats?.last7Days ?? 0);
+        case 'health':
+          return healthScore(b) - healthScore(a) || (b.commitStats?.last30Days ?? 0) - (a.commitStats?.last30Days ?? 0);
         case 'stars':
           return (b.parentStats?.stars ?? b.stars) - (a.parentStats?.stars ?? a.stars);
         case 'tags':

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -33,6 +33,67 @@ function detectPluginType(repo: EnrichedRepo): 'mcp-server' | null {
   return tagMatch || nameMatch || descMatch ? 'mcp-server' : null;
 }
 
+// ── Trending score (0–5 🔥) ──────────────────────────────────────────────────
+// Derived from commit velocity. For forks this reflects upstream activity.
+function getTrendingScore(repo: EnrichedRepo): number {
+  const c7  = repo.commitStats?.last7Days  ?? 0;
+  const c30 = repo.commitStats?.last30Days ?? 0;
+  if (c7 >= 20) return 5;   // blazing — multiple commits per day
+  if (c7 >= 10) return 4;   // 1-2 commits/day
+  if (c7 >=  4) return 3;   // every couple of days
+  if (c7 >=  2) return 2;   // sporadic this week
+  if (c7 >=  1 || c30 >= 8) return 1;
+  return 0;
+}
+
+// ── Life / health status ──────────────────────────────────────────────────────
+interface LifeStatus {
+  emoji: string;
+  label: string;
+  tooltip: string;
+  textColor: string;
+}
+
+function getLifeStatus(repo: EnrichedRepo): LifeStatus {
+  const isArchived = repo.parentStats?.isArchived ?? false;
+  const stars      = repo.parentStats?.stars ?? repo.stars ?? 0;
+  const c7         = repo.commitStats?.last7Days  ?? 0;
+  const c30        = repo.commitStats?.last30Days ?? 0;
+  const c90        = repo.commitStats?.last90Days ?? 0;
+  const daysSince  = (Date.now() - new Date(repo.lastUpdated).getTime()) / 86400000;
+
+  if (isArchived) return {
+    emoji: '📦', label: 'Archived',
+    tooltip: 'Repository is archived — no new changes expected',
+    textColor: 'text-zinc-500',
+  };
+  if (c7 >= 10 || c30 >= 30) return {
+    emoji: '🚀', label: 'Hot',
+    tooltip: `${c7} commits this week — very active development`,
+    textColor: 'text-emerald-300',
+  };
+  if (c30 > 0) return {
+    emoji: '💚', label: 'Active',
+    tooltip: `${c30} commits in the last 30 days`,
+    textColor: 'text-emerald-400',
+  };
+  if (c90 > 0) return {
+    emoji: '💛', label: 'Stable',
+    tooltip: `${c90} commits in the last 90 days — slowing but maintained`,
+    textColor: 'text-amber-400',
+  };
+  if (stars > 500 || daysSince < 365) return {
+    emoji: '🌙', label: 'Dormant',
+    tooltip: `No recent commits — last activity ${Math.round(daysSince / 30)}mo ago`,
+    textColor: 'text-zinc-400',
+  };
+  return {
+    emoji: '💀', label: 'Inactive',
+    tooltip: `No activity for over ${Math.round(daysSince / 365 * 10) / 10} years`,
+    textColor: 'text-zinc-600',
+  };
+}
+
 /** Color + label config for each risk level */
 const RISK_CONFIG: Record<string, { bg: string; border: string; text: string; label: string }> = {
   critical: { bg: 'bg-red-950/80',    border: 'border-red-700',   text: 'text-red-300',    label: 'CRITICAL' },
@@ -152,6 +213,8 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
   const sec = repo.securitySignals ?? null;
   const pluginType = detectPluginType(repo);
   const riskCfg = sec?.risk_level ? (RISK_CONFIG[sec.risk_level] ?? null) : null;
+  const trendScore = getTrendingScore(repo);
+  const lifeStatus = getLifeStatus(repo);
 
   return (
     <div
@@ -347,6 +410,37 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
           </div>
         );
       })()}
+
+      {/* ── Trending score + Life status ── */}
+      <div className="flex items-center justify-between">
+        {/* Fire scale — 0-5 fires, inactive ones faded */}
+        <div
+          className="flex items-center gap-0.5 select-none"
+          title={trendScore > 0
+            ? `Trending ${trendScore}/5 · ${repo.commitStats?.last7Days ?? 0} commits this week`
+            : 'No recent commit activity'}
+        >
+          {[1, 2, 3, 4, 5].map(i => (
+            <span
+              key={i}
+              style={{ opacity: i <= trendScore ? 1 : 0.12, fontSize: '13px', lineHeight: 1 }}
+            >
+              🔥
+            </span>
+          ))}
+          {trendScore === 0 && (
+            <span className="text-[10px] text-zinc-700 ml-1">no recent activity</span>
+          )}
+        </div>
+
+        {/* Life / health status badge */}
+        <span
+          className={`text-xs font-medium ${lifeStatus.textColor}`}
+          title={lifeStatus.tooltip}
+        >
+          {lifeStatus.emoji} {lifeStatus.label}
+        </span>
+      </div>
 
       {/* PM Skills row */}
       {repo.pmSkills && repo.pmSkills.length > 0 && (

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -378,7 +378,7 @@ export interface IntersectionMetrics {
 }
 
 /** Sort options for the repo grid */
-export type SortOption = 'updated' | 'stars' | 'tags' | 'alpha' | 'oldest' | 'most-outdated' | 'upstream-updated' | 'fork-oldest' | 'fork-newest';
+export type SortOption = 'updated' | 'stars' | 'tags' | 'alpha' | 'oldest' | 'most-outdated' | 'upstream-updated' | 'fork-oldest' | 'fork-newest' | 'trending' | 'health';
 
 /** Full API response shape */
 export interface LibraryData {


### PR DESCRIPTION
## Summary

Two new purely client-side visual indicators on every repo card — no backend changes, no new DB columns. All computed from existing commit stats + stars + dates.

---

### 🔥 Trending Score (0–5 fires)

A 5-slot fire scale showing how hot a repo is right now. Inactive slots are rendered at 12% opacity so the full scale is always visible.

| Score | Threshold |
|-------|-----------|
| 🔥🔥🔥🔥🔥 | 20+ commits this week |
| 🔥🔥🔥🔥 | 10-19 commits/week |
| 🔥🔥🔥 | 4-9 commits/week |
| 🔥🔥 | 2-3 commits/week |
| 🔥 | 1 commit/week or 8+ last month |
| (no fires shown) | No recent activity |

For forks this reflects **upstream project heat** — shows how active the original project is.

---

### 💚 Life / Health Status

A single emoji + label showing the repo's lifecycle stage, factoring in commit velocity, recency, stars, and archived state:

| Stage | Condition |
|-------|-----------|
| 🚀 Hot | 10+ commits/week or 30+ last month |
| 💚 Active | Commits in the last 30 days |
| 💛 Stable | Commits in the last 90 days |
| 🌙 Dormant | No recent commits but >500 stars or updated within a year |
| 💀 Inactive | >1yr no activity, low stars |
| 📦 Archived | Parent repo is archived |

Color-coded: emerald for healthy, amber for slowing, zinc for dormant/dead.
Each badge has a hover tooltip showing exact commit counts and days since last activity.

---

### Sort by Trending / Health

Two new sort options added to the dropdown:
- **🔥 Trending First** — sorts by fire score descending (hottest repos first)
- **💚 Healthiest First** — sorts by health stage descending (most active first)

## Placement

The indicators appear as a compact row **between category badges and PM skills**, visible immediately without scrolling.

## Test plan
- [ ] A repo with 20+ commits/week (e.g. llama.cpp) shows 🔥🔥🔥🔥🔥
- [ ] An archived fork shows 📦 Archived in zinc
- [ ] A repo with no commits in 2+ years and <500 stars shows 💀 Inactive
- [ ] Sort by "🔥 Trending First" reorders grid to put active repos first
- [ ] Hover tooltip shows correct commit count

🤖 Generated with [Claude Code](https://claude.com/claude-code)