### PR TITLE
fix: cross-dimension widget 422 error (limit exceeded API max)

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -147,7 +147,7 @@ export function HomePageClient() {
           .catch(() => {});
         // portfolio insights retained for future API-driven intelligence
         if (!cancelled) setLoadProgress({ stage: 'taxonomy', percent: 75, detail: 'Loading taxonomy…' });
-        provider.getCrossDimensionAnalytics('industry', 'ai_trend', 250)
+        provider.getCrossDimensionAnalytics('industry', 'ai_trend', 50)
           .then(analytics => { if (!cancelled) setCrossDimensionAnalytics(analytics); })
           .catch(() => {});
         if (!cancelled) setLoadProgress({ stage: 'ready', percent: 100, detail: 'Ready' });


### PR DESCRIPTION
API caps at 50, we sent 250 — widget disappeared. Fixed to 50.