### PR TITLE
feat: infinite scroll + API date fix

### DIFF
--- a/src/components/RepoGrid.tsx
+++ b/src/components/RepoGrid.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { EnrichedRepo } from '@/types/repo';
 import { RepoCard } from './RepoCard';
 
@@ -11,6 +12,7 @@ interface RepoGridProps {
 }
 
 const SYSTEM_TAGS = new Set(['Forked', 'Built by Me', 'Active', 'Inactive', 'Archived', 'Popular']);
+const PAGE_SIZE = 24;
 
 /**
  * Count of repos in the full library that share 2+ non-system enrichedTags with the given repo.
@@ -26,8 +28,38 @@ function computeSimilarCount(repo: EnrichedRepo, allRepos: EnrichedRepo[]): numb
   }).length;
 }
 
-/** Grid of repo cards */
+/** Grid of repo cards with infinite scroll */
 export function RepoGrid({ repos, allRepos, onTagClick, onCategoryClick }: RepoGridProps) {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Reset visible count when repos change (new filter/sort)
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [repos]);
+
+  // Intersection Observer for infinite scroll
+  const loadMore = useCallback(() => {
+    setVisibleCount(prev => Math.min(prev + PAGE_SIZE, repos.length));
+  }, [repos.length]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: '400px' }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
   if (repos.length === 0) {
     return (
       <div className="flex h-40 items-center justify-center text-zinc-500">
@@ -36,17 +68,35 @@ export function RepoGrid({ repos, allRepos, onTagClick, onCategoryClick }: RepoG
     );
   }
 
+  const visible = repos.slice(0, visibleCount);
+  const hasMore = visibleCount < repos.length;
+
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
-      {repos.map((repo) => (
-        <RepoCard
-          key={repo.id}
-          repo={repo}
-          similarCount={allRepos ? computeSimilarCount(repo, allRepos) : undefined}
-          onTagClick={onTagClick}
-          onCategoryClick={onCategoryClick}
-        />
-      ))}
+    <div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+        {visible.map((repo) => (
+          <RepoCard
+            key={repo.id}
+            repo={repo}
+            similarCount={allRepos ? computeSimilarCount(repo, allRepos) : undefined}
+            onTagClick={onTagClick}
+            onCategoryClick={onCategoryClick}
+          />
+        ))}
+      </div>
+
+      {/* Scroll sentinel + status */}
+      <div ref={sentinelRef} className="flex items-center justify-center py-6">
+        {hasMore ? (
+          <span className="text-xs text-zinc-600">
+            Showing {visible.length} of {repos.length} repos
+          </span>
+        ) : repos.length > PAGE_SIZE ? (
+          <span className="text-xs text-zinc-600">
+            All {repos.length} repos loaded
+          </span>
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Infinite scroll**: loads 24 cards at a time as you scroll (Tumblr-style)
- Resets on filter/sort change
- Shows "X of Y repos" counter

Paired with API fix: `lastUpdated` now uses `github_updated_at` instead of DB `updated_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)