### PR TITLE
KAN-54: Frontend performance improvements

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -1,21 +1,24 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { LibraryData, EnrichedRepo, SortOption } from '@/types/repo';
 import type { TrendData } from '@/types/repo';
 import { StatsBar } from '@/components/StatsBar';
 import { SearchBar } from '@/components/SearchBar';
-import { FilterBar } from '@/components/FilterBar';
 import { RepoGrid } from '@/components/RepoGrid';
 import { LoadingState } from '@/components/LoadingState';
 import { LoadingBanner } from '@/components/LoadingBanner';
-import { MetricsSidebar } from '@/components/MetricsSidebar';
 import { MiniAskBar } from '@/components/MiniAskBar';
-import { LibraryInsightsWidget } from '@/components/LibraryInsightsWidget';
-import { CrossDimensionWidget } from '@/components/CrossDimensionWidget';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode, LoadProgress } from '@/lib/dataProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+
+// Lazy-load heavy components — they aren't needed for initial paint
+const FilterBar = dynamic(() => import('@/components/FilterBar').then(m => ({ default: m.FilterBar })), { ssr: false });
+const MetricsSidebar = dynamic(() => import('@/components/MetricsSidebar').then(m => ({ default: m.MetricsSidebar })), { ssr: false });
+const LibraryInsightsWidget = dynamic(() => import('@/components/LibraryInsightsWidget').then(m => ({ default: m.LibraryInsightsWidget })), { ssr: false });
+const CrossDimensionWidget = dynamic(() => import('@/components/CrossDimensionWidget').then(m => ({ default: m.CrossDimensionWidget })), { ssr: false });
 
 
 
@@ -310,6 +313,12 @@ export function HomePageClient() {
     return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([t]) => t);
   }, [data]);
 
+  // Stable sidebar data object — only recalculates when data or categories change
+  const sidebarData = useMemo(() => {
+    if (!data) return null;
+    return { ...data, categories: normalizedCategories };
+  }, [data, normalizedCategories]);
+
   // Intersection metrics — computed when 2+ tags selected, null otherwise
   const intersectionMetrics = useMemo(() => {
     if (!data || selectedTags.length < 2) return null;
@@ -518,7 +527,7 @@ export function HomePageClient() {
     });
   }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders, showClaudePluginsOnly, selectedSecurityRisk]);
 
-  function clearFilters() {
+  const clearFilters = useCallback(() => {
     setSearch('');
     setSearchMode('keyword');
     setSemanticResults(null);
@@ -541,54 +550,65 @@ export function HomePageClient() {
     setSelectedBuilders([]);
     setShowClaudePluginsOnly(false);
     setSelectedSecurityRisk('all');
-  }
+  }, []);
 
-  function toggleTag(tag: string) {
+  const toggleTag = useCallback((tag: string) => {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
     );
-  }
+  }, []);
 
-  function removeTag(tag: string) {
+  const removeTag = useCallback((tag: string) => {
     setSelectedTags((prev) => prev.filter((t) => t !== tag));
-  }
+  }, []);
 
-  function toggleAiDevSkill(skill: string) {
+  const toggleAiDevSkill = useCallback((skill: string) => {
     setSelectedAiDevSkills(prev => prev.includes(skill) ? prev.filter(s => s !== skill) : [...prev, skill]);
-  }
+  }, []);
 
-  function togglePmSkill(skill: string) {
+  const togglePmSkill = useCallback((skill: string) => {
     setSelectedPmSkills(prev => prev.includes(skill) ? prev.filter(s => s !== skill) : [...prev, skill]);
-  }
+  }, []);
 
-  function toggleIndustry(industry: string) {
+  const toggleIndustry = useCallback((industry: string) => {
     setSelectedIndustries(prev => prev.includes(industry) ? prev.filter(s => s !== industry) : [...prev, industry]);
-  }
+  }, []);
 
-  function toggleAiTrend(value: string) {
+  const toggleAiTrend = useCallback((value: string) => {
     setSelectedAiTrends(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
-  }
+  }, []);
 
-  function toggleUseCase(value: string) {
+  const toggleUseCase = useCallback((value: string) => {
     setSelectedUseCases(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
-  }
+  }, []);
 
-  function toggleModality(value: string) {
+  const toggleModality = useCallback((value: string) => {
     setSelectedModalities(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
-  }
+  }, []);
 
-  function toggleDeploymentContext(value: string) {
+  const toggleDeploymentContext = useCallback((value: string) => {
     setSelectedDeploymentContexts(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
-  }
+  }, []);
 
-  function toggleBuilder(builder: string) {
+  const toggleBuilder = useCallback((builder: string) => {
     setSelectedBuilders(prev => prev.includes(builder) ? prev.filter(s => s !== builder) : [...prev, builder]);
-  }
+  }, []);
 
-  function handleRepoClick(name: string) {
+  const handleRepoClick = useCallback((name: string) => {
     setSearch(name);
     setSidebarOpen(false);
-  }
+  }, []);
+
+  // Stable callbacks for MetricsSidebar
+  const handleSidebarTagClick = useCallback((tag: string) => {
+    setSelectedTags(prev => prev.includes(tag) ? prev : [...prev, tag]);
+  }, []);
+  const handleViewArchived = useCallback(() => setAttentionFilter('archived-parent'), []);
+  const handleViewStale = useCallback(() => setAttentionFilter('stale'), []);
+  const handleViewOutdated = useCallback(() => setShowOutdatedOnly(true), []);
+  const handleSyncFilter = useCallback((status: string) => setSelectedSyncStatus(status as typeof selectedSyncStatus), []);
+  const handlePluginToggle = useCallback(() => setShowClaudePluginsOnly(v => !v), []);
+  const handleCategoryClick = useCallback((id: string) => setSelectedCategory(prev => prev === id ? '' : id), []);
 
   return (
     <div className="flex h-screen bg-zinc-950 overflow-hidden">
@@ -692,7 +712,7 @@ export function HomePageClient() {
             <StatsBar
               data={data}
               tagMetrics={data.tagMetrics}
-              onTagClick={(tag) => toggleTag(tag)}
+              onTagClick={toggleTag}
             />
           )}
 
@@ -707,7 +727,7 @@ export function HomePageClient() {
                 {data && (
                   <LibraryInsightsWidget
                     repos={data.repos}
-                    onTagClick={(tag) => toggleTag(tag)}
+                    onTagClick={toggleTag}
                   />
                 )}
               </ErrorBoundary>
@@ -786,7 +806,7 @@ export function HomePageClient() {
                 languageCounts={languageCounts}
                 licenseCounts={licenseCounts}
                 showClaudePluginsOnly={showClaudePluginsOnly}
-                onPluginToggle={() => setShowClaudePluginsOnly(v => !v)}
+                onPluginToggle={handlePluginToggle}
                 selectedSecurityRisk={selectedSecurityRisk}
                 onSecurityRiskChange={setSelectedSecurityRisk}
               />
@@ -798,7 +818,7 @@ export function HomePageClient() {
             {isLoading ? (
               <LoadingState />
             ) : (
-              <RepoGrid repos={filteredAndSortedRepos} allRepos={data?.repos} onTagClick={toggleTag} onCategoryClick={(id) => setSelectedCategory(prev => prev === id ? '' : id)} />
+              <RepoGrid repos={filteredAndSortedRepos} allRepos={data?.repos} onTagClick={toggleTag} onCategoryClick={handleCategoryClick} />
             )}
           </ErrorBoundary>
         </div>
@@ -811,17 +831,17 @@ export function HomePageClient() {
           <aside className="hidden lg:flex flex-col w-[380px] shrink-0 border-l border-zinc-800 bg-zinc-950">
             <ErrorBoundary fallback={<div className="rounded-lg border border-zinc-700 bg-zinc-800 m-4 px-4 py-3 text-sm text-zinc-400">Metrics sidebar unavailable.</div>}>
               <MetricsSidebar
-                data={{ ...data, categories: normalizedCategories }}
+                data={sidebarData!}
                 selectedTags={selectedTags}
                 tagMetrics={data.tagMetrics ?? []}
                 intersectionMetrics={intersectionMetrics}
-                onTagClick={(tag) => { if (!selectedTags.includes(tag)) toggleTag(tag); }}
+                onTagClick={handleSidebarTagClick}
                 onTagRemove={removeTag}
                 onRepoClick={handleRepoClick}
-                onViewArchived={() => setAttentionFilter('archived-parent')}
-                onViewStale={() => setAttentionFilter('stale')}
-                onViewOutdated={() => setShowOutdatedOnly(true)}
-                onSyncFilter={(status) => setSelectedSyncStatus(status as typeof selectedSyncStatus)}
+                onViewArchived={handleViewArchived}
+                onViewStale={handleViewStale}
+                onViewOutdated={handleViewOutdated}
+                onSyncFilter={handleSyncFilter}
                 onCategoryFilter={setSelectedCategory}
                 selectedCategory={selectedCategory}
                 trends={trends}
@@ -839,17 +859,17 @@ export function HomePageClient() {
               <div className="w-[340px] border-l border-zinc-800 bg-zinc-950 overflow-y-auto">
                 <ErrorBoundary fallback={<div className="rounded-lg border border-zinc-700 bg-zinc-800 m-4 px-4 py-3 text-sm text-zinc-400">Metrics sidebar unavailable.</div>}>
                   <MetricsSidebar
-                    data={{ ...data, categories: normalizedCategories }}
+                    data={sidebarData!}
                     selectedTags={selectedTags}
                     tagMetrics={data.tagMetrics ?? []}
                     intersectionMetrics={intersectionMetrics}
-                    onTagClick={(tag) => { if (!selectedTags.includes(tag)) toggleTag(tag); }}
+                    onTagClick={handleSidebarTagClick}
                     onTagRemove={removeTag}
                     onRepoClick={handleRepoClick}
-                    onViewArchived={() => setAttentionFilter('archived-parent')}
-                    onViewStale={() => setAttentionFilter('stale')}
-                    onViewOutdated={() => setShowOutdatedOnly(true)}
-                    onSyncFilter={(status) => setSelectedSyncStatus(status as typeof selectedSyncStatus)}
+                    onViewArchived={handleViewArchived}
+                    onViewStale={handleViewStale}
+                    onViewOutdated={handleViewOutdated}
+                    onSyncFilter={handleSyncFilter}
                     onCategoryFilter={setSelectedCategory}
                     selectedCategory={selectedCategory}
                     trends={trends}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { EnrichedRepo } from '@/types/repo';
 import { CATEGORIES } from '@/lib/buildCategories';
 import { QualityBadge } from '@/components/QualityBadge';
@@ -266,7 +266,7 @@ function getCategoryStyle(primaryCategory: string): { borderColor: string; backg
 }
 
 /** A single repo card in the library grid */
-export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: RepoCardProps) {
+export const RepoCard = memo(function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: RepoCardProps) {
   const langColor = repo.language ? (LANGUAGE_COLORS[repo.language] ?? '#8b949e') : '#8b949e';
   const ps = repo.parentStats;
   const [commitsOpen, setCommitsOpen] = useState(false);
@@ -848,4 +848,4 @@ export function RepoCard({ repo, similarCount, onTagClick, onCategoryClick }: Re
       })()}
     </div>
   );
-}
+});

--- a/src/components/RepoGrid.tsx
+++ b/src/components/RepoGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { EnrichedRepo } from '@/types/repo';
 import { RepoCard } from './RepoCard';
 
@@ -15,23 +15,60 @@ const SYSTEM_TAGS = new Set(['Forked', 'Built by Me', 'Active', 'Inactive', 'Arc
 const PAGE_SIZE = 24;
 
 /**
- * Count of repos in the full library that share 2+ non-system enrichedTags with the given repo.
- * Excludes the repo itself.
+ * Pre-build a Map<repoId, similarCount> using an inverted tag index.
+ * O(repos * avgTags) instead of O(repos^2).
  */
-function computeSimilarCount(repo: EnrichedRepo, allRepos: EnrichedRepo[]): number {
-  const myTags = new Set(repo.enrichedTags.filter((t) => !SYSTEM_TAGS.has(t)));
-  if (myTags.size === 0) return 0;
-  return allRepos.filter((other) => {
-    if (other.id === repo.id) return false;
-    const shared = other.enrichedTags.filter((t) => !SYSTEM_TAGS.has(t) && myTags.has(t)).length;
-    return shared >= 2;
-  }).length;
+function buildSimilarCountMap(allRepos: EnrichedRepo[]): Map<string | number, number> {
+  // Inverted index: tag → set of repo ids
+  const tagToRepos = new Map<string, Set<string | number>>();
+  const repoTags = new Map<string | number, string[]>();
+
+  for (const repo of allRepos) {
+    const tags = repo.enrichedTags.filter(t => !SYSTEM_TAGS.has(t));
+    repoTags.set(repo.id, tags);
+    for (const tag of tags) {
+      let set = tagToRepos.get(tag);
+      if (!set) { set = new Set(); tagToRepos.set(tag, set); }
+      set.add(repo.id);
+    }
+  }
+
+  const result = new Map<string | number, number>();
+  for (const repo of allRepos) {
+    const myTags = repoTags.get(repo.id);
+    if (!myTags || myTags.length === 0) { result.set(repo.id, 0); continue; }
+
+    // Count how many times each other repo shares a tag with this one
+    const sharedCounts = new Map<string | number, number>();
+    for (const tag of myTags) {
+      const peers = tagToRepos.get(tag);
+      if (!peers) continue;
+      for (const peerId of peers) {
+        if (peerId === repo.id) continue;
+        sharedCounts.set(peerId, (sharedCounts.get(peerId) ?? 0) + 1);
+      }
+    }
+
+    let count = 0;
+    for (const shared of sharedCounts.values()) {
+      if (shared >= 2) count++;
+    }
+    result.set(repo.id, count);
+  }
+
+  return result;
 }
 
 /** Grid of repo cards with infinite scroll */
 export function RepoGrid({ repos, allRepos, onTagClick, onCategoryClick }: RepoGridProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Pre-compute similar counts once when allRepos changes (not per-card)
+  const similarCountMap = useMemo(
+    () => allRepos ? buildSimilarCountMap(allRepos) : null,
+    [allRepos]
+  );
 
   // Reset visible count when repos change (new filter/sort)
   useEffect(() => {
@@ -78,7 +115,7 @@ export function RepoGrid({ repos, allRepos, onTagClick, onCategoryClick }: RepoG
           <RepoCard
             key={repo.id}
             repo={repo}
-            similarCount={allRepos ? computeSimilarCount(repo, allRepos) : undefined}
+            similarCount={similarCountMap?.get(repo.id)}
             onTagClick={onTagClick}
             onCategoryClick={onCategoryClick}
           />

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -41,6 +41,7 @@ export function createDataProvider(): DataProvider {
 
 class JsonDataProvider implements DataProvider {
   mode: DataMode = 'lite'
+  private libraryCache: LibraryData | null = null
 
   getDegradedState(): boolean {
     return false
@@ -64,10 +65,13 @@ class JsonDataProvider implements DataProvider {
   }
 
   async getLibrary(_onProgress?: (p: LoadProgress) => void): Promise<LibraryData> {
+    if (this.libraryCache) return this.libraryCache
     const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
     const res = await fetch(`${basePath}/data/library.json`)
     if (!res.ok) throw new Error('Library data not found. Run npm run generate to generate it.')
-    return res.json()
+    const data: LibraryData = await res.json()
+    this.libraryCache = data
+    return data
   }
 
   async getTrends(): Promise<TrendData | null> {
@@ -231,6 +235,9 @@ class ApiDataProvider implements DataProvider {
   private apiUrl: string
   private fallback: JsonDataProvider
   private degraded = false
+  /** In-memory cache so subsequent getLibrary() calls don't re-fetch */
+  private libraryCache: LibraryData | null = null
+  private libraryPromise: Promise<LibraryData> | null = null
 
   constructor(apiUrl: string) {
     this.apiUrl = apiUrl.replace(/\/$/, '')
@@ -254,6 +261,21 @@ class ApiDataProvider implements DataProvider {
   }
 
   async getLibrary(onProgress?: (p: LoadProgress) => void): Promise<LibraryData> {
+    // Return cached data immediately if available
+    if (this.libraryCache) return this.libraryCache
+    // Deduplicate concurrent calls
+    if (this.libraryPromise) return this.libraryPromise
+    this.libraryPromise = this._fetchLibrary(onProgress)
+    try {
+      const result = await this.libraryPromise
+      this.libraryCache = result
+      return result
+    } finally {
+      this.libraryPromise = null
+    }
+  }
+
+  private async _fetchLibrary(onProgress?: (p: LoadProgress) => void): Promise<LibraryData> {
     const report = onProgress ?? (() => {})
     try {
       this.degraded = false


### PR DESCRIPTION
## JIRA
[KAN-54] Frontend performance improvements

## Summary
- **Lazy-load** 4 heavy components (FilterBar, MetricsSidebar, LibraryInsightsWidget, CrossDimensionWidget) via `next/dynamic` — reduces initial JS bundle for first paint
- **`useCallback`** on all event handlers in HomePageClient to prevent unnecessary child re-renders
- **`React.memo`** on RepoCard — cards no longer re-render when unrelated state changes
- **O(n²) → O(n×tags)** fix in RepoGrid: replaced `computeSimilarCount` (ran per-card per-render) with a single `buildSimilarCountMap` using an inverted tag index, memoized via `useMemo`
- **Library fetch cache** in both `JsonDataProvider` and `ApiDataProvider` — deduplicates concurrent calls and caches result in-memory

## Test plan
- [ ] Home page loads and displays repo grid
- [ ] Filters, search, tag clicks all work correctly
- [ ] Infinite scroll loads next 24 cards
- [ ] MetricsSidebar and FilterBar render after initial paint (lazy)
- [ ] No console errors

## Notes
`test-results/` and `tmp-reporium-audit.spec.cjs` are untracked and intentionally excluded from this commit — suggest adding them to `.gitignore` (KAN-55 cleanup ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)