### PR TITLE
KAN-57: 16-category filter bar (agents, rag-retrieval, llm-serving…)

### DIFF
--- a/src/components/CategoryFilterBar.tsx
+++ b/src/components/CategoryFilterBar.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * KAN-57 — 16-category filter bar using DB primary_category field.
+ * Shows a horizontal scrollable row of chips, one per category.
+ * Clicking a chip sets ?category=<id> and filters the repo grid.
+ */
+
+import { useMemo } from 'react';
+import { EnrichedRepo } from '@/types/repo';
+
+interface CategoryChip {
+  id: string;
+  label: string;
+  icon: string;
+  count: number;
+}
+
+const DB_CATEGORIES: Omit<CategoryChip, 'count'>[] = [
+  { id: 'agents',           label: 'Agents',          icon: '🤖' },
+  { id: 'rag-retrieval',    label: 'RAG & Retrieval',  icon: '🔍' },
+  { id: 'llm-serving',      label: 'LLM Serving',      icon: '⚡' },
+  { id: 'fine-tuning',      label: 'Fine-tuning',      icon: '🎯' },
+  { id: 'evaluation',       label: 'Evaluation',       icon: '📊' },
+  { id: 'orchestration',    label: 'Orchestration',    icon: '🔀' },
+  { id: 'vector-databases', label: 'Vector DBs',       icon: '🗄️' },
+  { id: 'observability',    label: 'Observability',    icon: '👁️' },
+  { id: 'security-safety',  label: 'Security & Safety',icon: '🔒' },
+  { id: 'code-generation',  label: 'Code Gen',         icon: '💻' },
+  { id: 'data-processing',  label: 'Data Processing',  icon: '⚙️' },
+  { id: 'computer-vision',  label: 'Computer Vision',  icon: '👁' },
+  { id: 'nlp-text',         label: 'NLP & Text',       icon: '📝' },
+  { id: 'speech-audio',     label: 'Speech & Audio',   icon: '🎙️' },
+  { id: 'generative-media', label: 'Generative Media', icon: '🎨' },
+  { id: 'infrastructure',   label: 'Infrastructure',   icon: '🏗️' },
+];
+
+interface Props {
+  repos: EnrichedRepo[];
+  selected: string;
+  onSelect: (category: string) => void;
+}
+
+export function CategoryFilterBar({ repos, selected, onSelect }: Props) {
+  const chips = useMemo<CategoryChip[]>(() => {
+    const counts = new Map<string, number>();
+    for (const repo of repos) {
+      if (repo.dbCategory) {
+        counts.set(repo.dbCategory, (counts.get(repo.dbCategory) ?? 0) + 1);
+      }
+    }
+    return DB_CATEGORIES
+      .map(cat => ({ ...cat, count: counts.get(cat.id) ?? 0 }))
+      .filter(cat => cat.count > 0)
+      .sort((a, b) => b.count - a.count);
+  }, [repos]);
+
+  if (chips.length === 0) return null;
+
+  const totalRepos = repos.filter(r => r.dbCategory).length;
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2 overflow-x-auto pb-2 scrollbar-hide">
+        {/* All chip */}
+        <button
+          onClick={() => onSelect('')}
+          className={[
+            'flex-shrink-0 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all',
+            !selected
+              ? 'bg-zinc-100 text-zinc-900 ring-1 ring-zinc-300'
+              : 'text-zinc-500 hover:text-zinc-700 hover:bg-zinc-50',
+          ].join(' ')}
+        >
+          All
+          <span className="text-xs text-zinc-400">{totalRepos.toLocaleString()}</span>
+        </button>
+
+        {/* Divider */}
+        <div className="flex-shrink-0 w-px h-5 bg-zinc-200" />
+
+        {/* Category chips */}
+        {chips.map(cat => {
+          const isActive = selected === cat.id;
+          return (
+            <button
+              key={cat.id}
+              onClick={() => onSelect(isActive ? '' : cat.id)}
+              className={[
+                'flex-shrink-0 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all whitespace-nowrap',
+                isActive
+                  ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-300'
+                  : 'text-zinc-500 hover:text-zinc-700 hover:bg-zinc-50',
+              ].join(' ')}
+            >
+              <span>{cat.icon}</span>
+              <span>{cat.label}</span>
+              <span className={`text-xs ${isActive ? 'text-indigo-400' : 'text-zinc-400'}`}>
+                {cat.count.toLocaleString()}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -13,6 +13,7 @@ import { MiniAskBar } from '@/components/MiniAskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode, LoadProgress } from '@/lib/dataProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { CategoryFilterBar } from '@/components/CategoryFilterBar';
 
 // Lazy-load heavy components — they aren't needed for initial paint
 const FilterBar = dynamic(() => import('@/components/FilterBar').then(m => ({ default: m.FilterBar })), { ssr: false });
@@ -50,6 +51,7 @@ export function HomePageClient() {
   const [attentionFilter, setAttentionFilter] = useState<'all' | 'archived-parent' | 'stale'>('all');
   const [showOutdatedOnly, setShowOutdatedOnly] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('');
+  const [selectedDbCategory, setSelectedDbCategory] = useState(''); // KAN-57: 16-category DB filter
 
   // New taxonomy filter state
   const [selectedAiDevSkills, setSelectedAiDevSkills] = useState<string[]>([]);
@@ -95,6 +97,10 @@ export function HomePageClient() {
       if (tagParam) {
         setSelectedTags([tagParam]);
       }
+      const categoryParam = params.get('category');
+      if (categoryParam) {
+        setSelectedDbCategory(categoryParam);
+      }
       const taxonomyDimension = params.get('taxonomyDimension');
       const taxonomyValue = params.get('taxonomyValue');
       if (taxonomyDimension && taxonomyValue) {
@@ -114,6 +120,20 @@ export function HomePageClient() {
       }
     }
   }, []); // run once on mount
+
+  // KAN-57: sync ?category= URL param when selectedDbCategory changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (selectedDbCategory) {
+      params.set('category', selectedDbCategory);
+    } else {
+      params.delete('category');
+    }
+    const newSearch = params.toString();
+    const newUrl = newSearch ? `?${newSearch}` : window.location.pathname;
+    window.history.replaceState({}, '', newUrl);
+  }, [selectedDbCategory]);
 
   useEffect(() => {
     let cancelled = false;
@@ -394,6 +414,11 @@ export function HomePageClient() {
         }
       }
 
+      // KAN-57: DB 16-category filter (agents, rag-retrieval, llm-serving, etc.)
+      if (selectedDbCategory) {
+        if (repo.dbCategory !== selectedDbCategory) return false;
+      }
+
       // AI Dev Skills filter
       if (selectedAiDevSkills.length > 0) {
         if (!selectedAiDevSkills.every(s => (repo.aiDevSkills ?? []).some(a => a.skill === s))) return false;
@@ -525,7 +550,7 @@ export function HomePageClient() {
           return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
       }
     });
-  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders, showClaudePluginsOnly, selectedSecurityRisk]);
+  }, [data, search, searchMode, semanticResults, selectedType, selectedLanguage, selectedLicense, selectedTags, selectedActivity, sortBy, attentionFilter, selectedSyncStatus, showOutdatedOnly, selectedCategory, selectedDbCategory, selectedAiDevSkills, selectedPmSkills, selectedAiTrends, selectedIndustries, selectedUseCases, selectedModalities, selectedDeploymentContexts, selectedBuilders, showClaudePluginsOnly, selectedSecurityRisk]);
 
   const clearFilters = useCallback(() => {
     setSearch('');
@@ -811,6 +836,15 @@ export function HomePageClient() {
                 onSecurityRiskChange={setSelectedSecurityRisk}
               />
             </>
+          )}
+
+          {/* KAN-57: 16-category filter chips */}
+          {data && !isLoading && (
+            <CategoryFilterBar
+              repos={data.repos}
+              selected={selectedDbCategory}
+              onSelect={setSelectedDbCategory}
+            />
           )}
 
           {/* Grid */}

--- a/src/lib/enrichRepo.ts
+++ b/src/lib/enrichRepo.ts
@@ -650,6 +650,8 @@ export function enrichRepo(
     totalCommitsFetched: 0,
     primaryCategory: '',
     allCategories: [],
+    dbCategory: null,
+    dbSecondaryCategories: [],
     commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] },
     latestRelease: null,
     aiDevSkills: [],

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -307,6 +307,8 @@ export interface EnrichedRepo {
   // Category assignment
   primaryCategory: string;              // top-level category (from buildCategories)
   allCategories: string[];              // all categories this repo belongs to
+  dbCategory?: string | null;           // KAN-41 16-category taxonomy from DB (agents, rag-retrieval, etc.)
+  dbSecondaryCategories?: string[];     // secondary DB categories
 
   // Accurate commit stats with true counts (paginated if needed)
   commitStats: {


### PR DESCRIPTION
## Summary
- Adds `CategoryFilterBar` component — horizontal scrollable chips for all 16 DB categories (KAN-41 taxonomy), sorted by repo count, with live counts shown on each chip
- Clicking a chip filters the repo grid to repos with that `dbCategory`; clicking again clears
- `?category=agents` URL param: parsed on mount, synced on change — filter state survives refresh and is shareable
- Zero impact on existing filters — fully additive

## What this unlocks
KAN-41 classified all 1,544 repos at 100% coverage. Without this PR, that work was invisible to users. Now they can browse by:
**agents (299) · computer-vision (181) · infrastructure (165) · data-processing (163) · code-generation (138) · orchestration (116)** … and 10 more

## Files changed
| File | Change |
|------|--------|
| `src/components/CategoryFilterBar.tsx` | New component — chip row with counts |
| `src/components/HomePageClient.tsx` | State + URL param + filter logic + renders bar |
| `src/types/repo.ts` | Adds optional `dbCategory` / `dbSecondaryCategories` fields |
| `src/lib/enrichRepo.ts` | Adds defaults for new fields |

## Depends on
API PR: `claude/feature/KAN-57-category-filter-api` in reporium-api (exposes `dbCategory` field)

## Test plan
- [x] TypeScript compiles clean (zero errors in prod code)
- [ ] Filter chips render with correct counts
- [ ] Clicking agents shows ~299 repos, clicking again clears
- [ ] `?category=rag-retrieval` loads page with RAG filter pre-applied
- [ ] Works on mobile (chips scroll horizontally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)