### PR TITLE
KAN-118: Upgrade CI to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '24'
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- `ci.yml` was using Node.js 20 while `deploy.yml` and `refresh-data.yml` already use Node 24
- Aligned all workflows to Node.js 24

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)