### PR TITLE
KAN-84: Mobile-responsive layout improvements

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -641,11 +641,11 @@ export function HomePageClient() {
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
         {/* Stage 2 loading banner — fades in/out while owned repos stay visible */}
         <LoadingBanner visible={isLoadingFull} progress={loadProgress} />
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
+        <div className="flex-1 overflow-y-auto p-3 sm:p-4 md:p-6 space-y-4 sm:space-y-5">
           {/* Header */}
-          <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
-              <h1 className="text-2xl font-bold text-zinc-100">Reporium</h1>
+              <h1 className="text-xl sm:text-2xl font-bold text-zinc-100">Reporium</h1>
               <p className="text-sm text-zinc-500">
                 {data ? `${data.username}'s GitHub Library` : 'Your GitHub Knowledge Library'}
               </p>
@@ -742,7 +742,7 @@ export function HomePageClient() {
           )}
 
           {/* Mini Ask — sticky as user scrolls */}
-          <div className="sticky top-0 z-20 -mx-4 md:-mx-6 px-4 md:px-6 py-2 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800/50">
+          <div className="sticky top-0 z-20 -mx-3 sm:-mx-4 md:-mx-6 px-3 sm:px-4 md:px-6 py-2 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800/50">
             <MiniAskBar />
           </div>
 

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -149,29 +149,29 @@ export function StatsBar({ data, tagMetrics, onTagClick }: StatsBarProps) {
           </p>
         </div>
 
-        {/* Core counts */}
-        <div className="flex gap-6">
-          <div>
+        {/* Core counts — scrollable on mobile */}
+        <div className="flex gap-4 sm:gap-6 overflow-x-auto pb-1 min-w-0">
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-zinc-100">{stats.total}</p>
             <p className="text-xs text-zinc-500">Repos</p>
           </div>
-          <div>
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-emerald-400">{stats.built}</p>
             <p className="text-xs text-zinc-500">Built</p>
           </div>
-          <div>
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-violet-400">{stats.forked}</p>
             <p className="text-xs text-zinc-500">Forked</p>
           </div>
-          <div>
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-blue-400">{activeCount}</p>
             <p className="text-xs text-zinc-500">Active 30d</p>
           </div>
-          <div>
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-zinc-100">{allTags.size}</p>
             <p className="text-xs text-zinc-500">Unique Tags</p>
           </div>
-          <div>
+          <div className="shrink-0">
             <p className="text-2xl font-bold text-zinc-100">{categoryCount}</p>
             <p className="text-xs text-zinc-500">Categories</p>
           </div>
@@ -259,7 +259,7 @@ export function StatsBar({ data, tagMetrics, onTagClick }: StatsBarProps) {
                 .slice(0, 30);
               const maxCount = visibleMetrics[0]?.repoCount ?? 1;
               return visibleMetrics.map((m) => {
-                const fontSize = Math.min(48, Math.max(12, 12 + (Math.log(m.repoCount + 1) / Math.log(maxCount + 1)) * 36));
+                const fontSize = Math.min(28, Math.max(11, 11 + (Math.log(m.repoCount + 1) / Math.log(maxCount + 1)) * 17));
                 const opacity = 0.4 + (m.activityScore / 100) * 0.6;
                 return (
                   <button


### PR DESCRIPTION
## Summary
- **StatsBar**: stats counts row now horizontally scrollable on mobile (`overflow-x-auto` + `shrink-0`)
- **StatsBar**: tag cloud max font size reduced 48px → 28px (was unreadable/overflowing on mobile)
- **HomePageClient**: heading shrinks from 2xl to xl on small screens
- **HomePageClient**: main content padding tightened on mobile (`p-3 sm:p-4 md:p-6`)
- **HomePageClient**: sticky MiniAskBar negative margins fixed for mobile viewport

Already responsive (no changes needed):
- RepoGrid: already `grid-cols-1` on mobile
- CategoryFilterBar: already `overflow-x-auto`
- Sidebar: already `hidden lg:flex` with mobile overlay

## Test plan
- [ ] StatsBar counts don't overflow at 375px
- [ ] Tag cloud is readable on mobile
- [ ] Mobile sidebar toggle works
- [ ] `npm run build` passes

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)