### PR TITLE
KAN-86: Repo card improvements — maturity badge + last push date

### DIFF
--- a/src/components/QualityBadge.tsx
+++ b/src/components/QualityBadge.tsx
@@ -6,15 +6,40 @@ function badgeClasses(score: number): string {
   return 'border-red-700/40 bg-red-900/40 text-red-300';
 }
 
+const MATURITY_CONFIG: Record<string, { label: string; cls: string }> = {
+  production: { label: 'production',  cls: 'border-emerald-700/40 bg-emerald-900/40 text-emerald-300' },
+  beta:       { label: 'beta',        cls: 'border-blue-700/40 bg-blue-900/40 text-blue-300' },
+  prototype:  { label: 'prototype',   cls: 'border-amber-700/40 bg-amber-900/40 text-amber-300' },
+  research:   { label: 'research',    cls: 'border-zinc-700/40 bg-zinc-800/40 text-zinc-400' },
+};
+
 export function QualityBadge({ quality }: { quality: QualitySignals | null | undefined }) {
-  if (!quality || typeof quality.overall_score !== 'number') return null;
+  if (!quality) return null;
+
+  const hasScore = typeof quality.overall_score === 'number';
+  const maturity = quality.maturity;
+  const maturityCfg = maturity ? MATURITY_CONFIG[maturity] : null;
+
+  if (!hasScore && !maturityCfg) return null;
 
   return (
-    <span
-      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${badgeClasses(quality.overall_score)}`}
-      title={`Overall quality score: ${quality.overall_score}`}
-    >
-      Quality {Math.round(quality.overall_score)}
-    </span>
+    <>
+      {hasScore && (
+        <span
+          className={`rounded-full border px-2 py-0.5 text-xs font-medium ${badgeClasses(quality.overall_score!)}`}
+          title={`Overall quality score: ${quality.overall_score}`}
+        >
+          Quality {Math.round(quality.overall_score!)}
+        </span>
+      )}
+      {maturityCfg && (
+        <span
+          className={`rounded-full border px-2 py-0.5 text-xs font-medium ${maturityCfg.cls}`}
+          title={`Maturity: ${maturity}`}
+        >
+          {maturityCfg.label}
+        </span>
+      )}
+    </>
   );
 }

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -412,11 +412,23 @@ export const RepoCard = memo(function RepoCard({ repo, similarCount, onTagClick,
         <p className="line-clamp-2 text-xs text-zinc-400">{repo.description}</p>
       )}
 
-      {repo.licenseSpdx && (
-        <div className="flex items-center gap-2">
-          <span className="rounded-full border border-zinc-700 bg-zinc-900/70 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
-            {repo.licenseSpdx}
-          </span>
+      {/* License + last meaningful update row */}
+      {(repo.licenseSpdx || repo.upstreamLastPushAt || repo.yourLastPushAt) && (
+        <div className="flex items-center gap-2 flex-wrap">
+          {repo.licenseSpdx && (
+            <span className="rounded-full border border-zinc-700 bg-zinc-900/70 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
+              {repo.licenseSpdx}
+            </span>
+          )}
+          {/* Last meaningful push date — upstream for forks, own push for built */}
+          {(repo.upstreamLastPushAt ?? repo.yourLastPushAt) && (
+            <span
+              className="text-[11px] text-zinc-500"
+              title={`Last push: ${repo.upstreamLastPushAt ?? repo.yourLastPushAt}`}
+            >
+              updated {relativeTime(repo.upstreamLastPushAt ?? repo.yourLastPushAt ?? '')}
+            </span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- `QualityBadge`: now renders both an `overall_score` pill (green/amber/red) and a `maturity` badge (production/beta/prototype/research) when both fields are present
- `RepoCard`: license row now shows a relative "updated N days/months ago" timestamp using `upstreamLastPushAt ?? yourLastPushAt`, giving users quick freshness signal

## Test plan
- [ ] Verify repo cards with quality signals show maturity badge (e.g. production, beta)
- [ ] Verify repos without quality signals still render cleanly (no badge)
- [ ] Verify license + updated timestamp row appears on repo cards that have push date
- [ ] Build passes: `npm run build` zero errors

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)