### PR TITLE
fix: trends/insights loading hang, badge taxonomy, AI-classified counter

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -18,6 +18,33 @@ import { EnrichedRepo, LibraryData } from '@/types/repo';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? '';
 
+/** Reverse-lookup from human-readable primaryCategory (library.json fallback) → DB category ID */
+const LABEL_TO_CATEGORY_ID: Record<string, string> = {
+  'Agents & Orchestration': 'agents', 'AI Agents': 'agents',
+  'RAG & Retrieval': 'rag-retrieval', 'RAG & Knowledge': 'rag-retrieval', 'Search & Knowledge': 'rag-retrieval',
+  'LLM Serving': 'llm-serving', 'Inference & Serving': 'llm-serving',
+  'Fine-tuning': 'fine-tuning', 'Model Training': 'fine-tuning',
+  'Evaluation': 'evaluation', 'Evals & Benchmarking': 'evaluation',
+  'Orchestration': 'orchestration',
+  'Vector Databases': 'vector-databases',
+  'Observability': 'observability',
+  'Security & Safety': 'security-safety',
+  'Code Generation': 'code-generation',
+  'Data Processing': 'data-processing', 'Data Science': 'data-processing',
+  'Computer Vision': 'computer-vision',
+  'NLP & Text': 'nlp-text',
+  'Speech & Audio': 'speech-audio',
+  'Generative Media': 'generative-media',
+  'Infrastructure': 'infrastructure', 'ML Platform & Infrastructure': 'infrastructure',
+};
+
+function resolveCategory(repo: EnrichedRepo): string | null {
+  if (repo.dbCategory) return repo.dbCategory;
+  const label = (repo as unknown as Record<string, string>).primaryCategory;
+  if (!label) return null;
+  return LABEL_TO_CATEGORY_ID[label] ?? null;
+}
+
 const CATEGORY_ICONS: Record<string, string> = {
   'agents': '🤖', 'rag-retrieval': '🔍', 'llm-serving': '⚡',
   'fine-tuning': '🎯', 'evaluation': '📊', 'orchestration': '🔀',
@@ -90,11 +117,20 @@ export default function InsightsPage() {
 
   useEffect(() => {
     async function load() {
+      // page_size max is 500 per API constraint; use timeout to avoid cold-start hangs
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const res = await fetch(`${API_URL}/library/full?page=1&page_size=2000`);
+        const res = await fetch(
+          `${API_URL}/library/full?page=1&page_size=500`,
+          { signal: controller.signal },
+        );
+        clearTimeout(timeoutId);
         if (!res.ok) throw new Error(`API error ${res.status}`);
         setData(await res.json());
       } catch (e) {
+        clearTimeout(timeoutId);
+        // Fallback to cached library.json (served from Vercel CDN)
         try {
           const res = await fetch('/data/library.json');
           if (!res.ok) throw new Error('Cache miss');
@@ -145,7 +181,7 @@ export default function InsightsPage() {
     if (!data) return [] as EnrichedRepo[];
     const leaders = new Map<string, EnrichedRepo>();
     for (const repo of data.repos) {
-      const cat = repo.dbCategory;
+      const cat = resolveCategory(repo);
       if (!cat) continue;
       const current = leaders.get(cat);
       const score = (repo.parentStats?.stars ?? repo.stars) + (repo.commitStats?.last30Days ?? 0) * 10;

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -36,6 +36,33 @@ const CATEGORY_LABELS: Record<string, { label: string; icon: string; color: stri
   'infrastructure':   { label: 'Infrastructure',     icon: '🏗️', color: '#78716c' },
 };
 
+/** Reverse-lookup from human-readable primaryCategory (library.json fallback) → DB category ID */
+const LABEL_TO_CATEGORY_ID: Record<string, string> = {
+  'Agents & Orchestration': 'agents', 'AI Agents': 'agents',
+  'RAG & Retrieval': 'rag-retrieval', 'RAG & Knowledge': 'rag-retrieval', 'Search & Knowledge': 'rag-retrieval',
+  'LLM Serving': 'llm-serving', 'Inference & Serving': 'llm-serving',
+  'Fine-tuning': 'fine-tuning', 'Model Training': 'fine-tuning',
+  'Evaluation': 'evaluation', 'Evals & Benchmarking': 'evaluation',
+  'Orchestration': 'orchestration',
+  'Vector Databases': 'vector-databases', 'Vector DBs': 'vector-databases',
+  'Observability': 'observability',
+  'Security & Safety': 'security-safety', 'AI Safety': 'security-safety',
+  'Code Generation': 'code-generation', 'Code Gen': 'code-generation',
+  'Data Processing': 'data-processing', 'Data Science': 'data-processing',
+  'Computer Vision': 'computer-vision',
+  'NLP & Text': 'nlp-text', 'NLP': 'nlp-text',
+  'Speech & Audio': 'speech-audio',
+  'Generative Media': 'generative-media',
+  'Infrastructure': 'infrastructure', 'ML Platform & Infrastructure': 'infrastructure',
+};
+
+function resolveCategory(repo: EnrichedRepo): string | null {
+  if (repo.dbCategory) return repo.dbCategory;
+  const label = (repo as unknown as Record<string, string>).primaryCategory;
+  if (!label) return null;
+  return LABEL_TO_CATEGORY_ID[label] ?? null;
+}
+
 interface CategoryMomentum {
   id: string;
   label: string;
@@ -50,7 +77,7 @@ interface CategoryMomentum {
 function computeCategoryMomentum(repos: EnrichedRepo[]): CategoryMomentum[] {
   const counts = new Map<string, { repos: number; c7: number; c30: number }>();
   for (const repo of repos) {
-    const cat = repo.dbCategory;
+    const cat = resolveCategory(repo);
     if (!cat) continue;
     const cur = counts.get(cat) ?? { repos: 0, c7: 0, c30: 0 };
     cur.repos += 1;
@@ -134,12 +161,20 @@ export default function TrendsPage() {
 
   useEffect(() => {
     async function load() {
+      // page_size max is 500 per API constraint; use timeout to avoid cold-start hangs
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const res = await fetch(`${API_URL}/library/full?page=1&page_size=2000`);
+        const res = await fetch(
+          `${API_URL}/library/full?page=1&page_size=500`,
+          { signal: controller.signal },
+        );
+        clearTimeout(timeoutId);
         if (!res.ok) throw new Error(`API error ${res.status}`);
         setData(await res.json());
       } catch (e) {
-        // Fallback to cached library.json
+        clearTimeout(timeoutId);
+        // Fallback to cached library.json (served from Vercel CDN)
         try {
           const res = await fetch('/data/library.json');
           if (!res.ok) throw new Error('Cache miss');

--- a/src/components/LibraryInsightsWidget.tsx
+++ b/src/components/LibraryInsightsWidget.tsx
@@ -84,7 +84,11 @@ export function LibraryInsightsWidget({ repos, onTagClick }: LibraryInsightsWidg
     }
 
     // ── 5. Enrichment coverage stats ────────────────────────────────────────
-    const reposWithSkills   = repos.filter(r => (r.aiDevSkills?.length   ?? 0) > 0).length;
+    // Use dbCategory (primary_category in DB) as the canonical "AI-classified" signal —
+    // it has 92%+ coverage vs aiDevSkills which was never fully populated.
+    const reposWithSkills   = repos.filter(r =>
+      r.dbCategory || (r.aiDevSkills?.length ?? 0) > 0
+    ).length;
     const reposWithTaxonomy = repos.filter(r => (r.taxonomy?.length      ?? 0) > 0).length;
     const reposWithRichTags = repos.filter(r => (r.enrichedTags?.length  ?? 0) >= 8).length;
     const hasQualityData    = withTests + withCI + active > 0;

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -107,14 +107,12 @@ export function StatsBar({ data, tagMetrics, onTagClick }: StatsBarProps) {
     .filter(b => b.category !== 'individual')
     .slice(0, 25);
 
-  // AI Dev Coverage — compute from dbCategory when aiDevSkillStats is empty (always the case
-  // with the FastAPI backend which doesn't populate that field). Falls back to the pre-computed
-  // stats if they exist.
+  // AI Dev Coverage — always computed from the 16-category dbCategory taxonomy.
+  // The legacy aiDevSkillStats (28-skill pre-taxonomy) is ignored; it contained
+  // stale counts and led to ❌ badges for skills like "Structured Output" even when
+  // repos were present under a different category name in the new taxonomy.
   const aiDevStats = useMemo<SkillStats[]>(() => {
-    if (data.aiDevSkillStats && data.aiDevSkillStats.length > 0) {
-      return data.aiDevSkillStats;
-    }
-    // Build from dbCategory counts
+    // Build from dbCategory counts using the current 16-category taxonomy
     const counts = new Map<string, { count: number; repos: string[] }>();
     for (const repo of repos) {
       const cat = repo.dbCategory;
@@ -134,7 +132,7 @@ export function StatsBar({ data, tagMetrics, onTagClick }: StatsBarProps) {
         coverage: count >= 10 ? 'strong' : count >= 3 ? 'moderate' : count >= 1 ? 'weak' : 'none',
         topRepos,
       } as SkillStats));
-  }, [repos, data.aiDevSkillStats]);
+  }, [repos]);
 
   return (
     <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5 space-y-4">


### PR DESCRIPTION
## Root Causes Fixed

### 1. Trends/Insights stuck on "Loading..." (critical)
- **Cause:** `page_size=2000` exceeded the API max of 500 → HTTP 422 error. Cloud Run cold start made the 422 response take **89 seconds** — page appeared stuck indefinitely
- **Fix:** Changed to `page_size=500` + added 10s `AbortController` timeout; on timeout/error falls back to `/data/library.json` CDN cache (instant)

### 2. "Structured Output ❌ / Edge AI ⚠️" badges (regression from KAN-78)
- **Cause:** `StatsBar` preferred stale `aiDevSkillStats` (28-skill legacy taxonomy, baked into `/library/full` response) over the `dbCategory` computation. "Structured Output: 1 repo", "Edge AI: 7 repos" in old stats → ❌/⚠️ badges despite having many repos under the new 16-category taxonomy
- **Fix:** Always compute from `dbCategory` (16-category canonical taxonomy); drops legacy stats entirely

### 3. "16 repos AI-classified" in Library Insights
- **Cause:** Counter used `aiDevSkills.length > 0` — only 2 rows exist in `repo_ai_dev_skills` table
- **Fix:** Count repos with `dbCategory` set (92%+ of 1,505 repos are classified)

### 4. Trends/Insights: library.json fallback data compatibility
- **Fix:** Added `resolveCategory()` helper that maps `primaryCategory` (human-readable, in library.json) → DB category ID, so category momentum/leaders sections work even on CDN fallback

## Test plan
- [ ] `/trends` page loads within 3s (no more 90s hang)
- [ ] `/insights` page loads within 3s
- [ ] AI Dev Coverage badges show 16 categories, all ✅ (agents, rag-retrieval, etc.)
- [ ] "N repos AI-classified" shows ~1,390 (92% of 1,505) instead of 16
- [ ] If API cold, pages fall back to library.json without showing error

🤖 Generated with [Claude Code](https://claude.com/claude-code)