### PR TITLE
KAN-85: Ecosystem Stacks page — curated AI/ML tool combinations

### DIFF
--- a/src/app/stacks/page.tsx
+++ b/src/app/stacks/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { EcosystemStackCard } from '@/components/EcosystemStackCard';
+import { ECOSYSTEM_STACKS } from '@/data/ecosystemStacks';
+
+export const metadata: Metadata = {
+  title: 'Ecosystem Stacks — Reporium',
+  description:
+    'Curated AI/ML tool combinations for common use cases: RAG pipelines, agent systems, fine-tuning, observability, security, and MLOps.',
+  openGraph: {
+    title: 'Ecosystem Stacks — Reporium',
+    description:
+      'Curated AI/ML tool combinations for common use cases: RAG pipelines, agent systems, fine-tuning, observability, security, and MLOps.',
+    url: 'https://www.reporium.com/stacks',
+  },
+  twitter: {
+    title: 'Ecosystem Stacks — Reporium',
+    description:
+      'Curated AI/ML tool combinations for common use cases: RAG pipelines, agent systems, fine-tuning, observability, security, and MLOps.',
+  },
+};
+
+export default function StacksPage() {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title="Ecosystem Stacks" />
+
+      <main className="mx-auto max-w-4xl px-6 py-10 space-y-10">
+        {/* Header */}
+        <div>
+          <h1 className="text-3xl font-bold text-zinc-100">Ecosystem Stacks</h1>
+          <p className="mt-2 text-sm text-zinc-500 max-w-2xl">
+            Curated tool combinations for common AI/ML use cases. Each stack shows repos that work
+            well together — click to see what each tool does and why it belongs in the stack.
+          </p>
+        </div>
+
+        {/* Stack cards */}
+        <div className="space-y-4">
+          {ECOSYSTEM_STACKS.map((stack, index) => (
+            <EcosystemStackCard
+              key={stack.id}
+              stack={stack}
+              defaultExpanded={index === 0}
+            />
+          ))}
+        </div>
+
+        {/* Footer note */}
+        <p className="text-xs text-zinc-600 border-t border-zinc-800 pt-6">
+          Stacks are curated based on knowledge graph compatibility edges and community usage patterns.
+          Star counts are approximate.{' '}
+          <a href="/ask" className="text-zinc-500 hover:text-zinc-300 underline">
+            Ask Reporium
+          </a>{' '}
+          to explore alternatives or get personalized stack recommendations.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/EcosystemStackCard.tsx
+++ b/src/components/EcosystemStackCard.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import { ACCENT_CLASSES, type EcosystemStack } from '@/data/ecosystemStacks';
+
+interface EcosystemStackCardProps {
+  stack: EcosystemStack;
+  defaultExpanded?: boolean;
+}
+
+export function EcosystemStackCard({ stack, defaultExpanded = false }: EcosystemStackCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const accent = ACCENT_CLASSES[stack.accent] ?? ACCENT_CLASSES.blue;
+
+  return (
+    <div
+      className={`rounded-xl border ${accent.border} ${expanded ? accent.bg : 'bg-zinc-900/40'} transition-colors`}
+    >
+      {/* Header — always visible */}
+      <button
+        className="w-full text-left px-5 py-4 flex items-start gap-4"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        {/* Icon */}
+        <span className="text-2xl shrink-0 mt-0.5">{stack.icon}</span>
+
+        {/* Title + tagline */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className={`text-base font-semibold ${accent.text}`}>{stack.title}</h2>
+            <span className="shrink-0 text-zinc-600 text-sm">{expanded ? '▲' : '▼'}</span>
+          </div>
+          <p className="mt-0.5 text-xs text-zinc-400">{stack.tagline}</p>
+
+          {/* Tags */}
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {stack.tags.map((tag) => (
+              <span key={tag} className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${accent.badge}`}>
+                {tag}
+              </span>
+            ))}
+          </div>
+
+          {/* Repo pill preview when collapsed */}
+          {!expanded && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {stack.repos.map((repo) => (
+                <span key={repo.upstream} className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] bg-zinc-800 text-zinc-400">
+                  {repo.name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </button>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="px-5 pb-5 space-y-4">
+          {/* What you build */}
+          <p className="text-xs text-zinc-400 border-l-2 border-zinc-700 pl-3 leading-relaxed">
+            {stack.whatYouBuild}
+          </p>
+
+          {/* Repo cards */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            {stack.repos.map((repo) => {
+              const ghUrl = `https://github.com/${repo.upstream}`;
+              return (
+                <a
+                  key={repo.upstream}
+                  href={ghUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group block rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-3 hover:border-zinc-600 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <span className="text-sm font-medium text-zinc-200 group-hover:text-white">
+                        {repo.name}
+                      </span>
+                      <span className="ml-2 text-[10px] text-zinc-600 font-mono truncate">
+                        {repo.upstream}
+                      </span>
+                    </div>
+                    {repo.stars != null && (
+                      <span className="shrink-0 text-xs text-zinc-600">
+                        ★ {repo.stars >= 1000
+                          ? `${(repo.stars / 1000).toFixed(repo.stars >= 10000 ? 0 : 1)}k`
+                          : repo.stars}
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1.5 text-xs text-zinc-500 leading-relaxed">
+                    {repo.role}
+                  </p>
+                  <span className="mt-2 inline-block text-[10px] bg-zinc-800 text-zinc-500 px-1.5 py-0.5 rounded">
+                    {repo.category}
+                  </span>
+                </a>
+              );
+            })}
+          </div>
+
+          {/* Search library link */}
+          <a
+            href={`/ask`}
+            className={`inline-flex items-center gap-1.5 text-xs ${accent.text} hover:underline`}
+          >
+            ✦ Ask about this stack in the library
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WikiNavBar.tsx
+++ b/src/components/WikiNavBar.tsx
@@ -22,6 +22,7 @@ export function WikiNavBar({ title }: WikiNavBarProps) {
 
       <div className="flex items-center gap-4 text-xs text-zinc-500">
         <Link href="/ask" className="hover:text-zinc-300 transition-colors">Ask</Link>
+        <Link href="/stacks" className="hover:text-zinc-300 transition-colors">Stacks</Link>
         <Link href="/runs" className="hover:text-zinc-300 transition-colors">Run History</Link>
         <Link href="/taxonomy" className="hover:text-zinc-300 transition-colors">Taxonomy</Link>
         <span>☰ <Link href="/wiki" className="hover:text-zinc-300 transition-colors">Wiki</Link></span>

--- a/src/data/ecosystemStacks.ts
+++ b/src/data/ecosystemStacks.ts
@@ -1,0 +1,284 @@
+/**
+ * Curated Ecosystem Stacks — common AI/ML tool combinations.
+ * Each stack shows repos that work well together for a specific goal.
+ */
+
+export interface StackRepo {
+  /** Upstream owner/repo on GitHub */
+  upstream: string;
+  /** Human-readable name */
+  name: string;
+  /** What this repo does in the context of this stack */
+  role: string;
+  /** Stars (approximate, updated periodically) */
+  stars?: number;
+  /** Primary taxonomy category */
+  category: string;
+}
+
+export interface EcosystemStack {
+  id: string;
+  title: string;
+  tagline: string;
+  /** Emoji icon for the stack */
+  icon: string;
+  /** Tailwind color class for the accent */
+  accent: string;
+  /** High-level use case tags */
+  tags: string[];
+  /** What you can build with this stack */
+  whatYouBuild: string;
+  repos: StackRepo[];
+}
+
+export const ECOSYSTEM_STACKS: EcosystemStack[] = [
+  {
+    id: 'rag-starter',
+    title: 'RAG Starter Stack',
+    tagline: 'Production-ready Retrieval-Augmented Generation in a weekend',
+    icon: '🔍',
+    accent: 'blue',
+    tags: ['RAG', 'NLP', 'Vector Search'],
+    whatYouBuild:
+      'A document Q&A system that embeds your data, stores it in a vector database, retrieves semantically relevant chunks, and generates grounded answers with citations.',
+    repos: [
+      {
+        upstream: 'langchain-ai/langchain',
+        name: 'LangChain',
+        role: 'Orchestration framework — chains retrieval, prompts, and LLM calls together',
+        stars: 98000,
+        category: 'rag-retrieval',
+      },
+      {
+        upstream: 'chroma-core/chroma',
+        name: 'Chroma',
+        role: 'Embedded vector store — stores and queries document embeddings locally',
+        stars: 17000,
+        category: 'rag-retrieval',
+      },
+      {
+        upstream: 'UKPLab/sentence-transformers',
+        name: 'sentence-transformers',
+        role: 'Embedding model — converts text to dense vectors for semantic search',
+        stars: 16000,
+        category: 'nlp-text',
+      },
+      {
+        upstream: 'tiangolo/fastapi',
+        name: 'FastAPI',
+        role: 'API server — exposes your RAG pipeline as a REST endpoint',
+        stars: 80000,
+        category: 'dev-tools',
+      },
+    ],
+  },
+  {
+    id: 'agent-builder',
+    title: 'Agent Builder Stack',
+    tagline: 'Multi-agent systems with memory, tools, and browser control',
+    icon: '🤖',
+    accent: 'purple',
+    tags: ['Agents', 'Orchestration', 'Memory'],
+    whatYouBuild:
+      'An autonomous multi-agent system where specialized agents collaborate, share memory, browse the web, and complete complex multi-step tasks.',
+    repos: [
+      {
+        upstream: 'crewAIInc/crewAI',
+        name: 'CrewAI',
+        role: 'Multi-agent orchestration — defines agent roles, goals, and crew collaboration',
+        stars: 29000,
+        category: 'ai-agents',
+      },
+      {
+        upstream: 'langchain-ai/langgraph',
+        name: 'LangGraph',
+        role: 'Stateful agent graphs — models agentic workflows as directed graphs with cycles',
+        stars: 12000,
+        category: 'ai-agents',
+      },
+      {
+        upstream: 'mem0ai/mem0',
+        name: 'Mem0',
+        role: 'Agent memory — persistent, context-aware memory layer across conversations',
+        stars: 28000,
+        category: 'ai-agents',
+      },
+      {
+        upstream: 'gregpr07/browser-use',
+        name: 'browser-use',
+        role: 'Browser control — gives agents the ability to interact with real websites',
+        stars: 19000,
+        category: 'ai-agents',
+      },
+    ],
+  },
+  {
+    id: 'fine-tuning',
+    title: 'Fine-tuning Stack',
+    tagline: 'Train and serve custom LLMs efficiently on consumer hardware',
+    icon: '⚡',
+    accent: 'amber',
+    tags: ['Fine-tuning', 'Training', 'Inference'],
+    whatYouBuild:
+      'A custom LLM fine-tuned on your domain data — from dataset prep and QLoRA training through to quantized serving at production scale.',
+    repos: [
+      {
+        upstream: 'unslothai/unsloth',
+        name: 'Unsloth',
+        role: 'Fast fine-tuning — 2x faster LoRA/QLoRA training with 70% less VRAM',
+        stars: 27000,
+        category: 'model-training',
+      },
+      {
+        upstream: 'hiyouga/LLaMA-Factory',
+        name: 'LLaMA-Factory',
+        role: 'Training framework — unified interface for fine-tuning 100+ LLMs',
+        stars: 42000,
+        category: 'model-training',
+      },
+      {
+        upstream: 'wandb/wandb',
+        name: 'Weights & Biases',
+        role: 'Experiment tracking — logs training metrics, hyperparams, and model artifacts',
+        stars: 10000,
+        category: 'observability',
+      },
+      {
+        upstream: 'vllm-project/vllm',
+        name: 'vLLM',
+        role: 'High-throughput serving — PagedAttention-based LLM inference at scale',
+        stars: 44000,
+        category: 'inference-serving',
+      },
+    ],
+  },
+  {
+    id: 'observability',
+    title: 'LLM Observability Stack',
+    tagline: 'Full-stack tracing, evals, and prompt management for production LLMs',
+    icon: '📊',
+    accent: 'green',
+    tags: ['Observability', 'Evals', 'Tracing'],
+    whatYouBuild:
+      'A monitoring and evaluation system that traces every LLM call, measures quality over time, catches regressions before they reach users, and manages prompt versions.',
+    repos: [
+      {
+        upstream: 'langfuse/langfuse',
+        name: 'Langfuse',
+        role: 'LLM observability — distributed tracing, cost tracking, and user feedback collection',
+        stars: 9000,
+        category: 'observability',
+      },
+      {
+        upstream: 'Arize-ai/phoenix',
+        name: 'Phoenix',
+        role: 'ML observability — real-time monitoring, drift detection, and embedding visualization',
+        stars: 5000,
+        category: 'observability',
+      },
+      {
+        upstream: 'traceloop/openllmetry',
+        name: 'OpenLLMetry',
+        role: 'OpenTelemetry for LLMs — vendor-neutral instrumentation for any LLM framework',
+        stars: 2700,
+        category: 'observability',
+      },
+      {
+        upstream: 'promptfoo/promptfoo',
+        name: 'promptfoo',
+        role: 'Prompt testing — automated evals and regression tests for prompts and RAG pipelines',
+        stars: 5900,
+        category: 'evals-benchmarking',
+      },
+    ],
+  },
+  {
+    id: 'ai-security',
+    title: 'AI Security Stack',
+    tagline: 'Defend LLM applications from prompt injection, jailbreaks, and toxic outputs',
+    icon: '🛡️',
+    accent: 'red',
+    tags: ['Safety', 'Security', 'Guardrails'],
+    whatYouBuild:
+      'A defense-in-depth security layer that blocks prompt injection and jailbreaks at runtime, continuously red-teams your models for vulnerabilities, and enforces content policies.',
+    repos: [
+      {
+        upstream: 'NVIDIA/NeMo-Guardrails',
+        name: 'NeMo Guardrails',
+        role: 'Runtime guardrails — programmable rules that block policy violations at inference time',
+        stars: 4500,
+        category: 'safety-alignment',
+      },
+      {
+        upstream: 'leondz/garak',
+        name: 'Garak',
+        role: 'LLM red-teaming — automated vulnerability scanner for LLM security weaknesses',
+        stars: 3600,
+        category: 'safety-alignment',
+      },
+      {
+        upstream: 'promptfoo/promptfoo',
+        name: 'promptfoo',
+        role: 'Adversarial prompt testing — runs red-team evals and injection test suites',
+        stars: 5900,
+        category: 'evals-benchmarking',
+      },
+      {
+        upstream: 'Azure/PyRIT',
+        name: 'PyRIT',
+        role: 'Risk identification — Microsoft\'s framework for probing AI system risk surfaces',
+        stars: 2200,
+        category: 'safety-alignment',
+      },
+    ],
+  },
+  {
+    id: 'mlops-platform',
+    title: 'MLOps Platform Stack',
+    tagline: 'End-to-end ML lifecycle: experiments, pipelines, deployment, and monitoring',
+    icon: '🏗️',
+    accent: 'teal',
+    tags: ['MLOps', 'Infrastructure', 'Pipelines'],
+    whatYouBuild:
+      'A complete MLOps platform that tracks experiments, automates training pipelines, serves models with a feature store, and monitors production drift.',
+    repos: [
+      {
+        upstream: 'mlflow/mlflow',
+        name: 'MLflow',
+        role: 'Experiment tracking and model registry — the backbone of most ML platforms',
+        stars: 20000,
+        category: 'mlops-infrastructure',
+      },
+      {
+        upstream: 'zenml-io/zenml',
+        name: 'ZenML',
+        role: 'ML pipelines — portable, reproducible pipelines that run on any cloud',
+        stars: 4300,
+        category: 'mlops-infrastructure',
+      },
+      {
+        upstream: 'feast-dev/feast',
+        name: 'Feast',
+        role: 'Feature store — consistent feature serving for training and real-time inference',
+        stars: 5700,
+        category: 'mlops-infrastructure',
+      },
+      {
+        upstream: 'evidentlyai/evidently',
+        name: 'Evidently',
+        role: 'Model monitoring — detects data drift, target drift, and quality regressions',
+        stars: 5600,
+        category: 'observability',
+      },
+    ],
+  },
+];
+
+export const ACCENT_CLASSES: Record<string, { border: string; bg: string; text: string; badge: string }> = {
+  blue:   { border: 'border-blue-800/60',   bg: 'bg-blue-950/20',   text: 'text-blue-400',   badge: 'bg-blue-900/40 text-blue-300' },
+  purple: { border: 'border-purple-800/60', bg: 'bg-purple-950/20', text: 'text-purple-400', badge: 'bg-purple-900/40 text-purple-300' },
+  amber:  { border: 'border-amber-800/60',  bg: 'bg-amber-950/20',  text: 'text-amber-400',  badge: 'bg-amber-900/40 text-amber-300' },
+  green:  { border: 'border-green-800/60',  bg: 'bg-green-950/20',  text: 'text-green-400',  badge: 'bg-green-900/40 text-green-300' },
+  red:    { border: 'border-red-800/60',    bg: 'bg-red-950/20',    text: 'text-red-400',    badge: 'bg-red-900/40 text-red-300' },
+  teal:   { border: 'border-teal-800/60',   bg: 'bg-teal-950/20',   text: 'text-teal-400',   badge: 'bg-teal-900/40 text-teal-300' },
+};


### PR DESCRIPTION
## Summary
- New `/stacks` page with 6 curated AI/ML ecosystem stacks
- Each stack is an expandable card showing repos, their role in the stack, star count, and a link to explore further
- First card is expanded by default; all others are collapsed with a pill preview of the repos inside
- Adds "Stacks" link to WikiNavBar for discoverability

## Stacks included
| Stack | Tools |
|-------|-------|
| RAG Starter | LangChain + Chroma + sentence-transformers + FastAPI |
| Agent Builder | CrewAI + LangGraph + Mem0 + browser-use |
| Fine-tuning | Unsloth + LLaMA-Factory + W&B + vLLM |
| LLM Observability | Langfuse + Phoenix + OpenLLMetry + promptfoo |
| AI Security | NeMo-Guardrails + Garak + promptfoo + PyRIT |
| MLOps Platform | MLflow + ZenML + Feast + Evidently |

## Implementation
- Static data in `src/data/ecosystemStacks.ts` — no API call needed, loads instantly
- `EcosystemStackCard.tsx` is a client component with expand/collapse state
- Server component page (`src/app/stacks/page.tsx`) with full OpenGraph metadata

## Test plan
- [ ] `/stacks` loads without errors
- [ ] First stack card is expanded by default
- [ ] Clicking header toggles expand/collapse on other cards
- [ ] All GitHub links open correctly
- [ ] "Ask about this stack" links to `/ask`
- [ ] WikiNavBar shows "Stacks" link
- [ ] TypeScript passes (✓ already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)