### PR TITLE
fix: JSON-LD codeRepository → upstream URL for forks

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -328,7 +328,9 @@ export default async function RepoDetailPage({
     name: upstream,
     description: repo.readme_summary ?? repo.description ?? undefined,
     url: `https://www.reporium.com/repo/${encodeURIComponent(repo.name)}`,
-    codeRepository: repo.github_url,
+    codeRepository: repo.is_fork && repo.forked_from
+      ? `https://github.com/${repo.forked_from}`
+      : repo.github_url,
     programmingLanguage: repo.primary_language ?? undefined,
     ...(stars != null && { aggregateRating: {
       '@type': 'AggregateRating',


### PR DESCRIPTION
## Summary

- For forked repos (99%+ of the library), `codeRepository` in the JSON-LD `SoftwareSourceCode` block now points to the **canonical upstream repo** (`https://github.com/{forked_from}`) instead of our fork URL
- Non-fork repos are unchanged (still use `repo.github_url`)

## Why

Google's structured data parser follows `codeRepository` to understand the software. Pointing it to the upstream canonical repo improves schema.org signal quality and may improve SEO association with well-known libraries like vLLM, LangChain, etc.

## Test plan
- [ ] Check a fork's repo page (e.g. `/repo/vllm`) — `codeRepository` should be `https://github.com/vllm-project/vllm`
- [ ] Check a non-fork page — `codeRepository` should still be the owned URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)