### PR TITLE
fix: remove merge conflict marker from RecommendationsWidget.tsx

### DIFF
--- a/src/components/RecommendationsWidget.tsx
+++ b/src/components/RecommendationsWidget.tsx
@@ -63,7 +63,6 @@ export function RecommendationsWidget({ currentRepos }: RecommendationsWidgetPro
     setLoading(true);
 
     fetch(`${API_URL}/intelligence/similar/${encodeURIComponent(seed)}?limit=${REC_LIMIT}`)
-<<<<<<< HEAD
       .then((r) => (r.ok ? r.json() : { similar: [] }))
       .then((data: { similar?: SimilarRepo[] } | SimilarRepo[]) => {
         // API returns { source_repo, similar: [...], total } — unwrap


### PR DESCRIPTION
## Summary
PR #139 left a `<<<<<<< HEAD` conflict marker in `RecommendationsWidget.tsx` that caused the Turbopack build to fail with "Merge conflict marker encountered." This removes the marker — the fix content itself is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)