### PR TITLE
KAN-159: make Similar Repos panel client-side — fix empty SSG data

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -6,8 +6,9 @@ import type { Metadata } from 'next';
 import { QualityBadge } from '@/components/QualityBadge';
 import { WikiNavBar } from '@/components/WikiNavBar';
 import { CATEGORIES } from '@/lib/buildCategories';
-import type { EnrichedRepo, QualitySignals, SimilarRepo } from '@/types/repo';
-import { ViewTracker } from '@/components/ViewTracker';
+import type { EnrichedRepo, QualitySignals } from '@/types/repo';
+import { ViewTracker } from '@/components/ViewTracker'
+import { SimilarReposPanel } from '@/components/SimilarReposPanel';
 
 const API_URL =
   process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
@@ -246,21 +247,6 @@ async function getRepoDetail(name: string): Promise<RepoDetail | null> {
   }
 }
 
-async function getSimilarRepos(name: string): Promise<SimilarRepo[]> {
-  try {
-    // KAN-159: use /intelligence/similar/{name} (KAN-156 endpoint, pure pgvector)
-    const response = await fetch(`${API_URL}/intelligence/similar/${encodeURIComponent(name)}?limit=8`, {
-      next: { revalidate: 300 },
-      headers: { Accept: 'application/json' },
-    });
-    if (!response.ok) return [];
-    const json = await response.json();
-    // API returns { source_repo, similar: [...], total } — unwrap
-    return (Array.isArray(json) ? json : (json.similar ?? [])) as SimilarRepo[];
-  } catch {
-    return [];
-  }
-}
 
 interface RepoPageProps {
   params: Promise<{ name: string }>;
@@ -316,8 +302,6 @@ export default async function RepoDetailPage({
   const { name } = await params;
   const repo = await getRepoDetail(decodeURIComponent(name));
   if (!repo) notFound();
-  const similarRepos = await getSimilarRepos(repo.name);
-
   const skillGroups = groupSkills(repo.ai_dev_skills ?? []);
   const taxonomyGroups = groupTaxonomy(repo.taxonomy ?? []);
   const stars = repo.is_fork ? repo.parent_stars : repo.stargazers_count;
@@ -742,47 +726,7 @@ export default async function RepoDetailPage({
           </div>
         </section>
 
-        <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-zinc-100">Similar Repos</h2>
-            <p className="text-xs text-zinc-500">pgvector cosine similarity · $0</p>
-          </div>
-          {similarRepos.length > 0 ? (
-            <div className="mt-4 space-y-3">
-              {similarRepos.map((similar) => (
-                <Link
-                  key={similar.name}
-                  href={`/repo/${encodeURIComponent(similar.name)}`}
-                  className="flex items-start justify-between gap-4 rounded-2xl border border-zinc-800 bg-zinc-950/70 px-4 py-3 transition-colors hover:border-zinc-700"
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-zinc-100">{similar.name}</p>
-                    <p className="mt-1 line-clamp-2 text-xs text-zinc-500">
-                      {similar.readme_summary ?? similar.description ?? 'No description available.'}
-                    </p>
-                    {similar.stars != null && (
-                      <p className="mt-1 text-xs text-zinc-600">★ {similar.stars.toLocaleString()}</p>
-                    )}
-                  </div>
-                  <div className="flex shrink-0 flex-col items-end gap-1.5">
-                    {similar.primary_language ? (
-                      <span className="rounded-full border border-zinc-700 bg-zinc-800/70 px-2 py-0.5 text-xs text-zinc-300">
-                        {similar.primary_language}
-                      </span>
-                    ) : null}
-                    {typeof similar.similarity === 'number' ? (
-                      <span className="rounded-full border border-sky-700/30 bg-sky-900/30 px-2 py-0.5 text-xs font-medium text-sky-300">
-                        {Math.round(similar.similarity * 100)}% match
-                      </span>
-                    ) : null}
-                  </div>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <p className="mt-3 text-sm text-zinc-500">No similar repos surfaced yet — embeddings may still be generating.</p>
-          )}
-        </section>
+        <SimilarReposPanel repoName={repo.name} />
       </main>
     </div>
   );

--- a/src/components/RecommendationsWidget.tsx
+++ b/src/components/RecommendationsWidget.tsx
@@ -63,7 +63,6 @@ export function RecommendationsWidget({ currentRepos }: RecommendationsWidgetPro
     setLoading(true);
 
     fetch(`${API_URL}/intelligence/similar/${encodeURIComponent(seed)}?limit=${REC_LIMIT}`)
-<<<<<<< HEAD
       .then((r) => (r.ok ? r.json() : { similar: [] }))
       .then((data: { similar?: SimilarRepo[] } | SimilarRepo[]) => {
         // API returns { source_repo, similar: [...], total } — unwrap

--- a/src/components/SimilarReposPanel.tsx
+++ b/src/components/SimilarReposPanel.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { SimilarRepo } from '@/types/repo';
+
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? '';
+
+interface Props {
+  repoName: string;
+}
+
+export function SimilarReposPanel({ repoName }: Props) {
+  const [repos, setRepos] = useState<SimilarRepo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API_URL}/intelligence/similar/${encodeURIComponent(repoName)}?limit=8`, {
+      headers: { Accept: 'application/json' },
+    })
+      .then((r) => (r.ok ? r.json() : { similar: [] }))
+      .then((data: { similar?: SimilarRepo[] } | SimilarRepo[]) => {
+        const list: SimilarRepo[] = Array.isArray(data) ? data : (data.similar ?? []);
+        setRepos(list);
+      })
+      .catch(() => setRepos([]))
+      .finally(() => setLoading(false));
+  }, [repoName]);
+
+  return (
+    <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-zinc-100">Similar Repos</h2>
+        <p className="text-xs text-zinc-500">pgvector cosine similarity · $0</p>
+      </div>
+      {loading ? (
+        <p className="mt-3 text-sm text-zinc-600">Loading…</p>
+      ) : repos.length > 0 ? (
+        <div className="mt-4 space-y-3">
+          {repos.map((similar) => (
+            <Link
+              key={similar.name}
+              href={`/repo/${encodeURIComponent(similar.name)}`}
+              className="flex items-start justify-between gap-4 rounded-2xl border border-zinc-800 bg-zinc-950/70 px-4 py-3 transition-colors hover:border-zinc-700"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-zinc-100">{similar.name}</p>
+                <p className="mt-1 line-clamp-2 text-xs text-zinc-500">
+                  {similar.readme_summary ?? similar.description ?? 'No description available.'}
+                </p>
+                {similar.stars != null && (
+                  <p className="mt-1 text-xs text-zinc-600">★ {similar.stars.toLocaleString()}</p>
+                )}
+              </div>
+              <div className="flex shrink-0 flex-col items-end gap-1.5">
+                {similar.primary_language ? (
+                  <span className="rounded-full border border-zinc-700 bg-zinc-800/70 px-2 py-0.5 text-xs text-zinc-300">
+                    {similar.primary_language}
+                  </span>
+                ) : null}
+                {typeof similar.similarity === 'number' ? (
+                  <span className="rounded-full border border-sky-700/30 bg-sky-900/30 px-2 py-0.5 text-xs font-medium text-sky-300">
+                    {Math.round(similar.similarity * 100)}% match
+                  </span>
+                ) : null}
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-zinc-500">
+          No similar repos surfaced yet — embeddings may still be generating.
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- `getSimilarRepos` ran at SSG build time, making 1,576 concurrent calls to `/intelligence/similar/{name}` during CI
- Those calls silently returned `[]` (rate-limited or timed out in the CI environment), so all repo pages showed "No similar repos"
- Fix: move Similar Repos to a new `SimilarReposPanel` client component that fetches dynamically on page load — same pattern as `RecommendationsWidget`

## Changes
- `src/components/SimilarReposPanel.tsx` — new `'use client'` component, fetches from API on mount, correctly unwraps `{similar: [...]}` envelope
- `src/app/repo/[name]/page.tsx` — replaced SSG `getSimilarRepos` + inline JSX with `<SimilarReposPanel repoName={repo.name} />`; removed now-unused function and `SimilarRepo` type import

## Result
- Similar repos will always load dynamically on the client — no SSG fetch failures
- Data stays fresh as embeddings update (no need to rebuild to see changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)