### PR TITLE
fix: NL Smart Filter 0-result false negatives from strict tag matching

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -661,7 +661,7 @@ export function HomePageClient() {
     if (result.category) setSelectedDbCategory(result.category);
     if (result.sort === 'stars') setSortBy('stars' as SortOption);
     else if (result.sort === 'updated') setSortBy('updated' as SortOption);
-    if (result.tags?.length) setSelectedTags(result.tags);
+    // Don't apply NL tags to strict tag filter — too granular, causes 0-result false negatives
   }, []);
 
   const handleNLFilterClear = useCallback(() => {


### PR DESCRIPTION
## Summary
- Smart Filter was calling `setSelectedTags(result.tags)` with NL-derived tags like `["robotics"]`
- These granular tags don't exist in the library's `enrichedTags`, causing 0 results
- NL filter now applies category, language, sort, and min_stars only — the fields that reliably narrow the repo grid

## Test plan
- [ ] Type "robotics" → should show repos (no category match → no filter, grid unchanged)
- [ ] Type "Python RAG repos" → should filter to `category=rag-retrieval, language=python`
- [ ] Type "popular agents" → should filter to `category=agents, sort=stars`

🤖 Generated with [Claude Code](https://claude.com/claude-code)