### PR TITLE
KAN-85: Sticky Ask Bar — persistent bottom bar with expand/minimize/fullscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/three": "^0.183.1",
         "d3-force": "^3.0.0",
+        "framer-motion": "^12.38.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -5936,6 +5937,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -8888,6 +8915,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/three": "^0.183.1",
     "d3-force": "^3.0.0",
+    "framer-motion": "^12.38.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { LayoutShell } from '@/components/LayoutShell';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -32,7 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark">
       <body className={`${inter.className} bg-zinc-950 text-zinc-100 antialiased`}>
-        {children}
+        <LayoutShell>{children}</LayoutShell>
       </body>
     </html>
   );

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -3,14 +3,17 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
 import { LibraryData, EnrichedRepo, SortOption } from '@/types/repo';
 import type { TrendData } from '@/types/repo';
 import { StatsBar } from '@/components/StatsBar';
 import { SearchBar } from '@/components/SearchBar';
 import { RepoGrid } from '@/components/RepoGrid';
+import { RepoCardMinimal } from '@/components/RepoCardMinimal';
+import { RepoDetailPanel } from '@/components/RepoDetailPanel';
 import { LoadingState } from '@/components/LoadingState';
 import { LoadingBanner } from '@/components/LoadingBanner';
-import { MiniAskBar } from '@/components/MiniAskBar';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode, LoadProgress } from '@/lib/dataProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -94,6 +97,10 @@ export function HomePageClient() {
   // Mobile sidebar toggle
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [dashboardMode, setDashboardMode] = useState<'normal' | 'minimized' | 'fullscreen'>('normal');
+
+  // KAN-84: Explore mode
+  const [exploreMode, setExploreMode] = useState(true);
+  const [selectedRepoName, setSelectedRepoName] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -670,6 +677,29 @@ export function HomePageClient() {
     setNlExcludeArchived(false);
   }, []);
 
+  // KAN-84: explore mode handlers
+  const router = useRouter();
+  const handleExploreSelect = useCallback((name: string) => {
+    setSelectedRepoName(prev => (prev === name ? null : name));
+  }, []);
+  const handleExploreClose = useCallback(() => setSelectedRepoName(null), []);
+  const handleOpenRepo = useCallback((name: string) => {
+    router.push(`/repo/${name}`);
+  }, [router]);
+
+  // Related repos: same dbCategory as selected repo
+  const selectedRepo = useMemo(
+    () => (selectedRepoName ? filteredAndSortedRepos.find(r => r.name === selectedRepoName) ?? null : null),
+    [selectedRepoName, filteredAndSortedRepos],
+  );
+  const relatedRepos = useMemo(() => {
+    if (!selectedRepo) return [];
+    const cat = selectedRepo.dbCategory;
+    if (!cat) return [];
+    return filteredAndSortedRepos.filter(r => r.name !== selectedRepo.name && r.dbCategory === cat).slice(0, 4);
+  }, [selectedRepo, filteredAndSortedRepos]);
+  const relatedNames = useMemo(() => new Set(relatedRepos.map(r => r.name)), [relatedRepos]);
+
   return (
     <div className="flex h-screen bg-zinc-950 overflow-hidden">
       {/* ── Main content ── */}
@@ -694,6 +724,20 @@ export function HomePageClient() {
                 <span>·</span>
                 <Link href="/wiki" className="hover:text-zinc-300 transition-colors">Wiki</Link>
               </nav>
+              {/* KAN-84: Explore mode toggle */}
+              <button
+                onClick={() => { setExploreMode(v => !v); setSelectedRepoName(null); }}
+                className="flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs transition-colors"
+                style={{
+                  borderColor: exploreMode ? 'rgba(139,92,246,0.5)' : '#3f3f46',
+                  backgroundColor: exploreMode ? 'rgba(139,92,246,0.1)' : 'transparent',
+                  color: exploreMode ? '#c4b5fd' : '#71717a',
+                }}
+                title={exploreMode ? 'Switch to classic mode' : 'Switch to explore mode'}
+              >
+                <span>{exploreMode ? '◈' : '◇'}</span>
+                <span className="hidden sm:inline">{exploreMode ? 'Explore' : 'Classic'}</span>
+              </button>
               {/* Dashboard view controls */}
               <div className="flex items-center border border-zinc-700 rounded-lg overflow-hidden">
                 <button
@@ -784,10 +828,6 @@ export function HomePageClient() {
             />
           )}
 
-          {/* Mini Ask — sticky as user scrolls */}
-          <div className="sticky top-0 z-20 -mx-3 sm:-mx-4 md:-mx-6 px-3 sm:px-4 md:px-6 py-2 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800/50">
-            <MiniAskBar />
-          </div>
 
           {dashboardMode !== 'minimized' && (
             <>
@@ -902,14 +942,38 @@ export function HomePageClient() {
             />
           )}
 
-          {/* Grid */}
+          {/* Grid — explore mode or classic mode */}
           <ErrorBoundary fallback={<div className="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-sm text-zinc-400">Repo grid unavailable.</div>}>
             {isLoading ? (
               <LoadingState />
+            ) : exploreMode ? (
+              <motion.div
+                layout
+                className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+              >
+                {filteredAndSortedRepos.map(repo => (
+                  <RepoCardMinimal
+                    key={repo.id}
+                    repo={repo}
+                    onSelect={handleExploreSelect}
+                    isSelected={repo.name === selectedRepoName}
+                    isRelated={relatedNames.has(repo.name)}
+                    anySelected={selectedRepoName !== null}
+                  />
+                ))}
+              </motion.div>
             ) : (
               <RepoGrid repos={filteredAndSortedRepos} allRepos={data?.repos} onTagClick={toggleTag} onCategoryClick={handleCategoryClick} />
             )}
           </ErrorBoundary>
+
+          {/* KAN-84: Detail panel overlay (explore mode) */}
+          <RepoDetailPanel
+            repo={selectedRepo}
+            relatedRepos={relatedRepos}
+            onClose={handleExploreClose}
+            onOpenRepo={handleOpenRepo}
+          />
         </div>
       </div>
 

--- a/src/components/LayoutShell.tsx
+++ b/src/components/LayoutShell.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { StickyAskBar } from './StickyAskBar';
+
+export function LayoutShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <div className="pb-14">{children}</div>
+      <StickyAskBar />
+    </>
+  );
+}

--- a/src/components/RepoCardMinimal.tsx
+++ b/src/components/RepoCardMinimal.tsx
@@ -1,0 +1,150 @@
+'use client';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { EnrichedRepo } from '@/types/repo';
+
+interface RepoCardMinimalProps {
+  repo: EnrichedRepo;
+  onSelect: (name: string) => void;
+  isSelected: boolean;
+  isRelated: boolean;
+  anySelected: boolean; // true when ANY card is selected (to know whether to dim)
+}
+
+const SPRING = { type: 'spring' as const, stiffness: 300, damping: 30 };
+
+function getDisplayTag(repo: EnrichedRepo): string | null {
+  const SYSTEM_TAGS = new Set(['Active', 'Forked', 'Built by Me', 'Inactive', 'Archived', 'Popular']);
+  const contentTag = repo.enrichedTags.find(t => !SYSTEM_TAGS.has(t));
+  return contentTag ?? repo.dbCategory ?? null;
+}
+
+export function RepoCardMinimal({ repo, onSelect, isSelected, isRelated, anySelected }: RepoCardMinimalProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const stars = repo.parentStats?.stars ?? repo.stars ?? 0;
+  const displayTag = getDisplayTag(repo);
+
+  // Determine opacity for dimming
+  let opacity = 1;
+  if (anySelected && !isSelected && !isRelated) {
+    opacity = 0.4;
+  }
+
+  const borderColor = isSelected
+    ? '#8b5cf6'
+    : hovered
+    ? 'rgba(139,92,246,0.5)'
+    : '#27272a';
+
+  const boxShadow = isSelected
+    ? '0 0 0 1px #8b5cf6, 0 8px 24px rgba(139,92,246,0.25)'
+    : hovered
+    ? '0 0 0 1px rgba(139,92,246,0.3), 0 4px 12px rgba(0,0,0,0.4)'
+    : '0 1px 2px rgba(0,0,0,0.3)';
+
+  const bgColor = isSelected
+    ? 'rgba(139,92,246,0.08)'
+    : isRelated && anySelected
+    ? 'rgba(139,92,246,0.04)'
+    : '#18181b';
+
+  return (
+    <motion.div
+      layout
+      animate={{ opacity }}
+      transition={SPRING}
+      whileHover={{ y: -2, scale: 1.01 }}
+      onClick={() => onSelect(repo.name)}
+      onHoverStart={() => setHovered(true)}
+      onHoverEnd={() => setHovered(false)}
+      style={{
+        borderRadius: '0.5rem',
+        border: `1px solid ${borderColor}`,
+        boxShadow,
+        backgroundColor: bgColor,
+        cursor: 'pointer',
+        padding: '12px 14px',
+        transition: 'border-color 150ms ease-out, background-color 150ms ease-out, box-shadow 150ms ease-out',
+      }}
+    >
+      {/* Name row */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
+        <span
+          style={{
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            color: isSelected ? '#c4b5fd' : '#f4f4f5',
+            lineHeight: 1.3,
+            wordBreak: 'break-word',
+          }}
+        >
+          {repo.name}
+        </span>
+        {stars > 0 && (
+          <span
+            style={{
+              fontSize: '0.6875rem',
+              color: '#a1a1aa',
+              whiteSpace: 'nowrap',
+              paddingTop: 2,
+              flexShrink: 0,
+            }}
+          >
+            ★ {stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : stars}
+          </span>
+        )}
+      </div>
+
+      {/* Tag badge */}
+      {displayTag && (
+        <div style={{ marginTop: 6 }}>
+          <span
+            style={{
+              display: 'inline-block',
+              fontSize: '0.625rem',
+              fontWeight: 500,
+              color: '#a1a1aa',
+              backgroundColor: 'rgba(63,63,70,0.6)',
+              border: '1px solid #3f3f46',
+              borderRadius: '9999px',
+              padding: '1px 7px',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {displayTag}
+          </span>
+        </div>
+      )}
+
+      {/* Description — reveals on hover */}
+      <motion.div
+        animate={{ height: hovered ? 'auto' : 0, opacity: hovered ? 1 : 0 }}
+        transition={{ duration: 0.18, ease: 'easeOut' }}
+        style={{ overflow: 'hidden' }}
+      >
+        {repo.description && (
+          <p
+            style={{
+              marginTop: 8,
+              fontSize: '0.75rem',
+              color: '#71717a',
+              lineHeight: 1.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical' as const,
+              overflow: 'hidden',
+            }}
+          >
+            {repo.description}
+          </p>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/RepoDetailPanel.tsx
+++ b/src/components/RepoDetailPanel.tsx
@@ -1,0 +1,305 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+import { EnrichedRepo } from '@/types/repo';
+
+interface RepoDetailPanelProps {
+  repo: EnrichedRepo | null;
+  relatedRepos: EnrichedRepo[];
+  onClose: () => void;
+  onOpenRepo: (name: string) => void;
+}
+
+const SPRING = { type: 'spring' as const, stiffness: 300, damping: 30 };
+
+function formatStars(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+const LIFE_STATUS_MAP: Record<string, { emoji: string; label: string; color: string }> = {
+  active:   { emoji: '💚', label: 'Active',   color: '#4ade80' },
+  hot:      { emoji: '🚀', label: 'Hot',      color: '#86efac' },
+  stable:   { emoji: '💛', label: 'Stable',   color: '#fbbf24' },
+  dormant:  { emoji: '🌙', label: 'Dormant',  color: '#a1a1aa' },
+  inactive: { emoji: '💀', label: 'Inactive', color: '#52525b' },
+  archived: { emoji: '📦', label: 'Archived', color: '#52525b' },
+};
+
+function getLifeLabel(repo: EnrichedRepo): { emoji: string; label: string; color: string } {
+  const isArchived = repo.parentStats?.isArchived ?? repo.isArchived ?? false;
+  if (isArchived) return LIFE_STATUS_MAP.archived;
+
+  const c7  = Math.max(repo.commitStats?.last7Days ?? 0, repo.commitsLast7Days?.length ?? 0);
+  const c30 = Math.max(repo.commitStats?.last30Days ?? 0, repo.commitsLast30Days?.length ?? 0);
+  const c90 = Math.max(repo.commitStats?.last90Days ?? 0, repo.commitsLast90Days?.length ?? 0);
+  const stars = repo.parentStats?.stars ?? repo.stars ?? 0;
+  const daysSince = (Date.now() - new Date(repo.lastUpdated).getTime()) / 86400000;
+
+  if (c7 >= 10 || c30 >= 30) return LIFE_STATUS_MAP.hot;
+  if (c30 > 0) return LIFE_STATUS_MAP.active;
+  if (c90 > 0 || daysSince < 90) return LIFE_STATUS_MAP.stable;
+  if (stars > 500 || daysSince < 365) return LIFE_STATUS_MAP.dormant;
+  return LIFE_STATUS_MAP.inactive;
+}
+
+export function RepoDetailPanel({ repo, relatedRepos, onClose, onOpenRepo }: RepoDetailPanelProps) {
+  return (
+    <AnimatePresence>
+      {repo && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={onClose}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              backgroundColor: 'rgba(0,0,0,0.5)',
+              zIndex: 30,
+            }}
+          />
+
+          {/* Panel */}
+          <motion.aside
+            key="panel"
+            initial={{ x: '100%', opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: '100%', opacity: 0 }}
+            transition={SPRING}
+            style={{
+              position: 'fixed',
+              top: 0,
+              right: 0,
+              bottom: 0,
+              width: 'min(420px, 92vw)',
+              backgroundColor: '#18181b',
+              borderLeft: '1px solid #27272a',
+              zIndex: 40,
+              display: 'flex',
+              flexDirection: 'column',
+              overflowY: 'auto',
+            }}
+          >
+            {/* Header */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                justifyContent: 'space-between',
+                padding: '20px 20px 0',
+                gap: 12,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <h2
+                  style={{
+                    fontSize: '1.125rem',
+                    fontWeight: 700,
+                    color: '#f4f4f5',
+                    wordBreak: 'break-word',
+                    marginBottom: 6,
+                  }}
+                >
+                  {repo.name}
+                </h2>
+                {repo.dbCategory && (
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      fontSize: '0.6875rem',
+                      fontWeight: 500,
+                      color: '#c4b5fd',
+                      backgroundColor: 'rgba(139,92,246,0.15)',
+                      border: '1px solid rgba(139,92,246,0.3)',
+                      borderRadius: '9999px',
+                      padding: '2px 8px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    {repo.dbCategory}
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={onClose}
+                style={{
+                  flexShrink: 0,
+                  width: 28,
+                  height: 28,
+                  borderRadius: '0.375rem',
+                  border: '1px solid #3f3f46',
+                  backgroundColor: 'transparent',
+                  color: '#71717a',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '0.875rem',
+                }}
+                aria-label="Close panel"
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* Body */}
+            <div style={{ padding: '16px 20px', flex: 1 }}>
+              {/* Description */}
+              {repo.description && (
+                <p
+                  style={{
+                    fontSize: '0.875rem',
+                    color: '#a1a1aa',
+                    lineHeight: 1.6,
+                    marginBottom: 16,
+                  }}
+                >
+                  {repo.description}
+                </p>
+              )}
+
+              {/* Stats row */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 16,
+                  marginBottom: 16,
+                  flexWrap: 'wrap',
+                }}
+              >
+                {(repo.parentStats?.stars ?? repo.stars ?? 0) > 0 && (
+                  <span style={{ fontSize: '0.8125rem', color: '#a1a1aa' }}>
+                    ★ {formatStars(repo.parentStats?.stars ?? repo.stars ?? 0)} stars
+                  </span>
+                )}
+                {(repo.parentStats?.forks ?? repo.forks ?? 0) > 0 && (
+                  <span style={{ fontSize: '0.8125rem', color: '#a1a1aa' }}>
+                    ⑂ {repo.parentStats?.forks ?? repo.forks ?? 0} forks
+                  </span>
+                )}
+                {repo.language && (
+                  <span style={{ fontSize: '0.8125rem', color: '#a1a1aa' }}>
+                    {repo.language}
+                  </span>
+                )}
+                {(() => {
+                  const life = getLifeLabel(repo);
+                  return (
+                    <span style={{ fontSize: '0.8125rem', color: life.color }}>
+                      {life.emoji} {life.label}
+                    </span>
+                  );
+                })()}
+              </div>
+
+              {/* Tags */}
+              {repo.enrichedTags.length > 0 && (
+                <div style={{ marginBottom: 20 }}>
+                  <p
+                    style={{
+                      fontSize: '0.6875rem',
+                      fontWeight: 600,
+                      color: '#52525b',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      marginBottom: 8,
+                    }}
+                  >
+                    Tags
+                  </p>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {repo.enrichedTags.slice(0, 6).map(tag => (
+                      <span
+                        key={tag}
+                        style={{
+                          fontSize: '0.6875rem',
+                          color: '#a1a1aa',
+                          backgroundColor: 'rgba(63,63,70,0.5)',
+                          border: '1px solid #3f3f46',
+                          borderRadius: '9999px',
+                          padding: '2px 8px',
+                        }}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Related repos */}
+              {relatedRepos.length > 0 && (
+                <div style={{ marginBottom: 20 }}>
+                  <p
+                    style={{
+                      fontSize: '0.6875rem',
+                      fontWeight: 600,
+                      color: '#52525b',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      marginBottom: 8,
+                    }}
+                  >
+                    Related repos
+                  </p>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {relatedRepos.slice(0, 4).map(r => (
+                      <button
+                        key={r.name}
+                        onClick={() => onOpenRepo(r.name)}
+                        style={{
+                          fontSize: '0.75rem',
+                          color: '#c4b5fd',
+                          backgroundColor: 'rgba(139,92,246,0.1)',
+                          border: '1px solid rgba(139,92,246,0.25)',
+                          borderRadius: '0.375rem',
+                          padding: '4px 10px',
+                          cursor: 'pointer',
+                          transition: 'background-color 150ms',
+                        }}
+                      >
+                        {r.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div
+              style={{
+                padding: '12px 20px 20px',
+                borderTop: '1px solid #27272a',
+              }}
+            >
+              <button
+                onClick={() => onOpenRepo(repo.name)}
+                style={{
+                  width: '100%',
+                  padding: '10px 16px',
+                  backgroundColor: '#8b5cf6',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '0.5rem',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'background-color 150ms',
+                }}
+              >
+                Open full page →
+              </button>
+            </div>
+          </motion.aside>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -1,0 +1,461 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { SPRING } from '@/styles/tokens';
+
+// ---------------------------------------------------------------------------
+// Session ID management (KAN-158/KAN-159)
+// ---------------------------------------------------------------------------
+const SESSION_KEY = 'reporium_ask_session_id';
+
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return crypto.randomUUID();
+  const existing = sessionStorage.getItem(SESSION_KEY);
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  sessionStorage.setItem(SESSION_KEY, id);
+  return id;
+}
+
+function clearSessionId(): void {
+  if (typeof window !== 'undefined') sessionStorage.removeItem(SESSION_KEY);
+}
+
+// ---------------------------------------------------------------------------
+// Types matching /intelligence/ask/stream SSE events
+// ---------------------------------------------------------------------------
+interface SourceRepo {
+  name: string;
+  owner: string;
+  forked_from: string | null;
+  description: string | null;
+  stars: number | null;
+  relevance_score: number;
+  problem_solved: string | null;
+  integration_tags: string[];
+}
+
+interface TokensUsed {
+  input: number;
+  output: number;
+  total: number;
+}
+
+interface SourcesEvent { type: 'sources'; sources: SourceRepo[]; cache_hit: boolean }
+interface TokenEvent { type: 'token'; text: string }
+interface DoneEvent { type: 'done'; tokens: TokensUsed; cache_hit?: boolean }
+interface ErrorEvent { type: 'error'; message: string }
+type StreamEvent = SourcesEvent | TokenEvent | DoneEvent | ErrorEvent;
+
+// ---------------------------------------------------------------------------
+// Client-side rate limit guard
+// ---------------------------------------------------------------------------
+const RATE_KEY = 'reporium_ask_timestamps';
+const RATE_PER_MIN = 10;
+const RATE_PER_DAY = 100;
+
+function getRateLimitState(): { minuteCount: number; dayCount: number } {
+  if (typeof window === 'undefined') return { minuteCount: 0, dayCount: 0 };
+  try {
+    const raw = localStorage.getItem(RATE_KEY);
+    const timestamps: number[] = raw ? JSON.parse(raw) : [];
+    const now = Date.now();
+    const minuteCount = timestamps.filter((t) => t > now - 60_000).length;
+    const dayCount = timestamps.filter((t) => t > now - 86_400_000).length;
+    return { minuteCount, dayCount };
+  } catch {
+    return { minuteCount: 0, dayCount: 0 };
+  }
+}
+
+function recordRequest() {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(RATE_KEY);
+    const timestamps: number[] = raw ? JSON.parse(raw) : [];
+    const now = Date.now();
+    const pruned = timestamps.filter((t) => t > now - 86_400_000);
+    pruned.push(now);
+    localStorage.setItem(RATE_KEY, JSON.stringify(pruned));
+  } catch { /* degrade gracefully */ }
+}
+
+// ---------------------------------------------------------------------------
+// Injection pre-check (mirrors server-side patterns)
+// ---------------------------------------------------------------------------
+const INJECTION_RE = /ignore (previous|above|all|prior)|disregard (instructions?|rules?|system)|you are now|act as|new (role|persona|instructions?)|system:\s|reveal (your|the) (prompt|instructions?)|print (your|the) (prompt|instructions?)|repeat (after|back)|DAN mode|jailbreak|END OF CONTEXT|IGNORE ABOVE/i;
+
+function parseSseLine(line: string): StreamEvent | null {
+  if (!line.startsWith('data: ')) return null;
+  try {
+    return JSON.parse(line.slice(6)) as StreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State machine
+// ---------------------------------------------------------------------------
+type BarState = 'collapsed' | 'expanded' | 'fullscreen';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.reporium.com';
+
+export function StickyAskBar() {
+  const [barState, setBarState] = useState<BarState>('collapsed');
+  const [question, setQuestion] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Streaming state
+  const [streamingAnswer, setStreamingAnswer] = useState('');
+  const [sources, setSources] = useState<SourceRepo[]>([]);
+  const [tokensUsed, setTokensUsed] = useState<TokensUsed | null>(null);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Session state
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [turnCount, setTurnCount] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const answerRef = useRef<HTMLDivElement>(null);
+
+  // Esc key exits fullscreen
+  useEffect(() => {
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Escape' && barState === 'fullscreen') {
+        setBarState('expanded');
+      }
+    }
+    window.addEventListener('keyup', onKeyUp);
+    return () => window.removeEventListener('keyup', onKeyUp);
+  }, [barState]);
+
+  // Auto-scroll answer area as tokens arrive
+  useEffect(() => {
+    if (answerRef.current) {
+      answerRef.current.scrollTop = answerRef.current.scrollHeight;
+    }
+  }, [streamingAnswer]);
+
+  const handleNewConversation = useCallback(() => {
+    clearSessionId();
+    setSessionId(null);
+    setTurnCount(0);
+    setStreamingAnswer('');
+    setSources([]);
+    setTokensUsed(null);
+    setDone(false);
+    setError(null);
+    setQuestion('');
+    setBarState('collapsed');
+    inputRef.current?.focus();
+  }, []);
+
+  const { minuteCount, dayCount } = getRateLimitState();
+  const atMinuteLimit = minuteCount >= RATE_PER_MIN;
+  const atDayLimit = dayCount >= RATE_PER_DAY;
+  const nearMinuteLimit = minuteCount >= RATE_PER_MIN - 2;
+  const nearDayLimit = dayCount >= RATE_PER_DAY - 5;
+  const remainingMin = Math.max(0, RATE_PER_MIN - minuteCount);
+  const remainingDay = Math.max(0, RATE_PER_DAY - dayCount);
+
+  async function handleAsk() {
+    const q = question.trim();
+    if (!q || q.length < 3) { setError('Please enter at least 3 characters.'); return; }
+    if (q.length > 500) { setError('Question must be 500 characters or fewer.'); return; }
+    if (INJECTION_RE.test(q)) { setError('That question contains disallowed content. Please rephrase.'); return; }
+    if (atMinuteLimit) { setError('Rate limit: 10 questions per minute. Please wait a moment.'); return; }
+    if (atDayLimit) { setError('Daily limit of 100 questions reached. Try again tomorrow.'); return; }
+
+    setLoading(true);
+    setError(null);
+    setStreamingAnswer('');
+    setSources([]);
+    setTokensUsed(null);
+    setDone(false);
+    setBarState('expanded');
+    recordRequest();
+
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const sid = sessionId ?? getOrCreateSessionId();
+      if (!sessionId) setSessionId(sid);
+
+      const res = await fetch(`${API_URL}/intelligence/ask/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: q, top_k: 8, session_id: sid }),
+        signal: controller.signal,
+      });
+
+      if (res.status === 429) { setError('Rate limit exceeded. Please wait before asking again.'); return; }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.detail ?? `Server error (${res.status}). Please try again.`);
+        return;
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) { setError('Streaming not supported by this browser. Please try again.'); return; }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done: streamDone, value } = await reader.read();
+        if (streamDone) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          const event = parseSseLine(trimmed);
+          if (!event) continue;
+
+          if (event.type === 'sources') {
+            setSources(event.sources);
+          } else if (event.type === 'token') {
+            setStreamingAnswer((prev) => prev + event.text);
+          } else if (event.type === 'done') {
+            setTokensUsed(event.tokens);
+            setDone(true);
+            setTurnCount((n) => n + 1);
+          } else if (event.type === 'error') {
+            setError(event.message);
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError('Network error. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleAsk();
+    }
+  }
+
+  const hasAnswer = streamingAnswer.length > 0;
+
+  const heightValue =
+    barState === 'collapsed' ? 56 :
+    barState === 'fullscreen' ? '100vh' :
+    '50vh';
+
+  return (
+    <motion.div
+      className="fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-zinc-950/95 backdrop-blur-md border-t border-zinc-800 overflow-hidden"
+      initial={{ height: 56 }}
+      animate={{ height: heightValue }}
+      transition={SPRING.snappy}
+    >
+      {/* Input bar — always visible */}
+      <div className="flex items-center gap-2 px-3 py-2 shrink-0 h-14">
+        {/* Spark icon */}
+        <span className="text-zinc-500 text-sm select-none shrink-0">✦</span>
+
+        <input
+          ref={inputRef}
+          type="text"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask anything about the repo library..."
+          maxLength={500}
+          disabled={atMinuteLimit || atDayLimit}
+          className="flex-1 min-w-0 rounded-lg border border-zinc-700/60 bg-zinc-800/60 py-1.5 px-3 text-sm text-zinc-200 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500/50 disabled:opacity-50 transition-colors"
+        />
+
+        {/* Ask / Stop button */}
+        <button
+          type="button"
+          onClick={loading ? () => abortRef.current?.abort() : handleAsk}
+          disabled={(!loading && (atMinuteLimit || atDayLimit))}
+          className="shrink-0 rounded-lg bg-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          {loading ? (
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-zinc-400 border-t-transparent" />
+              Stop
+            </span>
+          ) : 'Ask'}
+        </button>
+
+        {/* Divider */}
+        <div className="h-5 w-px bg-zinc-700 shrink-0" />
+
+        {/* Minimize (collapse) button — only when expanded/fullscreen */}
+        {barState !== 'collapsed' && (
+          <button
+            type="button"
+            onClick={() => setBarState(barState === 'fullscreen' ? 'expanded' : 'collapsed')}
+            aria-label={barState === 'fullscreen' ? 'Exit fullscreen' : 'Minimize'}
+            className="shrink-0 rounded-md p-1.5 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            {/* Chevron down */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="4 6 8 10 12 6" />
+            </svg>
+          </button>
+        )}
+
+        {/* Fullscreen button — only when expanded */}
+        {barState === 'expanded' && (
+          <button
+            type="button"
+            onClick={() => setBarState('fullscreen')}
+            aria-label="Fullscreen"
+            className="shrink-0 rounded-md p-1.5 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            {/* Expand icon */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="5 3 3 3 3 5" /><polyline points="11 3 13 3 13 5" />
+              <polyline points="5 13 3 13 3 11" /><polyline points="11 13 13 13 13 11" />
+            </svg>
+          </button>
+        )}
+
+        {/* Clear / close button — when there is content */}
+        {(hasAnswer || error || question) && (
+          <button
+            type="button"
+            onClick={handleNewConversation}
+            aria-label="Clear"
+            className="shrink-0 rounded-md p-1.5 text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            {/* X icon */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="4" y1="4" x2="12" y2="12" /><line x1="12" y1="4" x2="4" y2="12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Answer / content area — visible when expanded or fullscreen */}
+      <AnimatePresence>
+        {barState !== 'collapsed' && (
+          <motion.div
+            key="content"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3"
+            ref={answerRef}
+          >
+            {/* Session continuity indicator */}
+            {sessionId && turnCount > 0 && (
+              <div className="flex items-center justify-between gap-3 pt-1">
+                <span className="flex items-center gap-1.5 text-xs text-sky-400/80">
+                  <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
+                  Continuing conversation ({turnCount} {turnCount === 1 ? 'turn' : 'turns'})
+                </span>
+                <button
+                  onClick={handleNewConversation}
+                  className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors underline-offset-2 hover:underline"
+                >
+                  New conversation
+                </button>
+              </div>
+            )}
+
+            {/* Loading status */}
+            {loading && sources.length === 0 && (
+              <p className="text-xs text-zinc-500 pt-1">Searching repos and finding the best matches…</p>
+            )}
+            {loading && sources.length > 0 && !hasAnswer && (
+              <p className="text-xs text-zinc-500 pt-1">Generating answer from {sources.length} repos…</p>
+            )}
+
+            {/* Rate limit warning */}
+            {(nearMinuteLimit || nearDayLimit) && !atMinuteLimit && !atDayLimit && (
+              <p className="text-xs text-amber-500/80">
+                {nearDayLimit
+                  ? `${remainingDay} questions remaining today`
+                  : `${remainingMin} questions remaining this minute`}
+              </p>
+            )}
+
+            {/* Error */}
+            {error && (
+              <div className="rounded-lg border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-400">
+                {error}
+              </div>
+            )}
+
+            {/* Source repos */}
+            {sources.length > 0 && (
+              <div className="space-y-1.5">
+                <p className="text-xs text-zinc-500 font-medium uppercase tracking-wider">
+                  Sources · {sources.length} repos
+                </p>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {sources.map((repo) => {
+                    const upstream = repo.forked_from ?? `${repo.owner}/${repo.name}`;
+                    const ghUrl = `https://github.com/${upstream}`;
+                    const score = Math.round(repo.relevance_score * 100);
+                    return (
+                      <a
+                        key={`${repo.owner}/${repo.name}`}
+                        href={ghUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group block rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2.5 hover:border-zinc-600 transition-colors"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <span className="text-xs font-mono text-zinc-300 group-hover:text-zinc-100 truncate">
+                            {upstream}
+                          </span>
+                          <span className="shrink-0 text-xs text-zinc-600">{score}% match</span>
+                        </div>
+                        {repo.description && (
+                          <p className="mt-1 text-xs text-zinc-500 line-clamp-2">{repo.description}</p>
+                        )}
+                        {repo.stars != null && (
+                          <p className="mt-1 text-xs text-zinc-600">★ {repo.stars.toLocaleString()}</p>
+                        )}
+                      </a>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Streaming answer */}
+            {hasAnswer && (
+              <div className="space-y-2">
+                <div className="rounded-lg bg-zinc-800/60 px-4 py-3 text-sm text-zinc-200 leading-relaxed whitespace-pre-wrap">
+                  {streamingAnswer}
+                  {loading && (
+                    <span className="inline-block w-0.5 h-4 ml-0.5 bg-zinc-400 align-middle animate-pulse" />
+                  )}
+                </div>
+                {done && tokensUsed && (
+                  <p className="text-xs text-zinc-600">
+                    {sources.length > 0 ? `${sources.length} repos searched` : ''}
+                    {sources.length > 0 && tokensUsed ? ' · ' : ''}
+                    {tokensUsed ? `${tokensUsed.total} tokens` : ''}
+                  </p>
+                )}
+              </div>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- StickyAskBar: fixed-bottom component with SSE streaming. Collapses to 56px input bar, expands upward to 50vh with answer, or goes fullscreen.
- LayoutShell: client wrapper that adds pb-14 offset so page content isn't hidden behind the bar.
- Removed MiniAskBar from home page (replaced by global bar).
- Framer Motion spring animation for height transitions.

## Test plan
- [ ] Bar visible at bottom of every page (home, /graph, /repo/*, /wiki/*)
- [ ] Ask question → answer streams in expanded area
- [ ] Minimize collapses to input only
- [ ] Fullscreen expands to full viewport
- [ ] Esc key exits fullscreen
- [ ] Page content not hidden behind bar (pb-14 offset)
- [ ] Mobile layout works
- [ ] Build passes TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)