### PR TITLE
Promote dev → main: test fix for KAN-90

### DIFF
--- a/tests/HomePageClient.test.tsx
+++ b/tests/HomePageClient.test.tsx
@@ -35,6 +35,12 @@ jest.mock('@/components/PortfolioInsightsWidget', () => ({ PortfolioInsightsWidg
 jest.mock('@/components/CrossDimensionWidget', () => ({ CrossDimensionWidget: () => <div>CrossDimensionWidget</div> }));
 jest.mock('@/components/TrendingThisWeekWidget', () => ({ TrendingThisWeekWidget: () => <div>TrendingThisWeekWidget</div> }));
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 mockProvider = {
   mode: 'production',
   getOwnedLibrary: jest.fn(),


### PR DESCRIPTION
## Summary
- Fix HomePageClient test: add `next/navigation` mock so `useRouter` works in jsdom

🤖 Generated with [Claude Code](https://claude.com/claude-code)