### PR TITLE
Fix dual scrollbar in preview

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,11 @@
   }
 }
 
+html, body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
## Summary
- Lock html/body to `overflow: hidden` so only the inner content container scrolls
- Prevents dual scrollbar visible in dev preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)