### PR TITLE
Expand knowledge graph: 5000 edges, full embedding coverage

### DIFF
--- a/src/components/HomeGraphWidget.tsx
+++ b/src/components/HomeGraphWidget.tsx
@@ -63,7 +63,7 @@ export function HomeGraphWidget() {
     let cancelled = false;
     const controller = new AbortController();
 
-    fetch(`${API_URL}/graph/edges?limit=2000&neighbours=3&min_similarity=0.55`, {
+    fetch(`${API_URL}/graph/edges?limit=5000&neighbours=5&min_similarity=0.40`, {
       signal: controller.signal,
       headers: { Accept: 'application/json' },
     })


### PR DESCRIPTION
## Summary
- Backfilled embeddings for all 1641 repos (was 1406)
- Increased graph from 2000→5000 edges, 3→5 neighbours, 0.55→0.40 min similarity
- Graph now shows 1489 repos (was 1097)

🤖 Generated with [Claude Code](https://claude.com/claude-code)