### PR TITLE
KAN-124: Bidirectional graph-card sync

### DIFF
--- a/src/components/HomeGraphWidget.tsx
+++ b/src/components/HomeGraphWidget.tsx
@@ -51,7 +51,14 @@ interface ApiResponse {
   edges: ApiEdge[];
 }
 
-export function HomeGraphWidget() {
+interface HomeGraphWidgetProps {
+  /** When a repo card is selected externally, highlight it on the graph */
+  selectedRepoName?: string | null;
+  /** Callback when a node is clicked on the graph (repo name, not full id) */
+  onGraphNodeSelect?: (repoName: string) => void;
+}
+
+export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGraphWidgetProps = {}) {
   const router = useRouter();
   const [edges, setEdges] = useState<GraphEdge[]>([]);
   const [nodeMetadata, setNodeMetadata] = useState<Map<string, NodeMeta>>(new Map());
@@ -135,9 +142,15 @@ export function HomeGraphWidget() {
   const handleNodeClick = useCallback(
     (id: string) => {
       const name = id.includes('/') ? id.split('/').pop()! : id;
-      router.push(`/repo/${name}`);
+      if (onGraphNodeSelect) {
+        // Bidirectional sync: notify parent so repo card gets highlighted
+        onGraphNodeSelect(name);
+      } else {
+        // Fallback: navigate to repo page
+        router.push(`/repo/${name}`);
+      }
     },
-    [router],
+    [router, onGraphNodeSelect],
   );
 
   // Don't render anything if graph fails to load
@@ -170,6 +183,7 @@ export function HomeGraphWidget() {
           height={420}
           onNodeClick={handleNodeClick}
           compact
+          selectedNodeId={selectedRepoName}
         />
       )}
     </div>

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -844,7 +844,10 @@ export function HomePageClient() {
           {/* Knowledge Graph */}
           <div className="px-3 sm:px-4 md:px-6">
             <ErrorBoundary fallback={null}>
-              <HomeGraphWidget />
+              <HomeGraphWidget
+                selectedRepoName={selectedRepoName}
+                onGraphNodeSelect={handleExploreSelect}
+              />
             </ErrorBoundary>
           </div>
 

--- a/src/components/KnowledgeGraph3D.tsx
+++ b/src/components/KnowledgeGraph3D.tsx
@@ -206,6 +206,8 @@ interface KnowledgeGraph3DProps {
   height?: number;
   onNodeClick?: (nodeId: string) => void;
   compact?: boolean;
+  /** External selection — when set, auto-selects and focuses the matching node */
+  selectedNodeId?: string | null;
 }
 
 export function KnowledgeGraph3D({
@@ -214,6 +216,7 @@ export function KnowledgeGraph3D({
   height = 560,
   onNodeClick,
   compact = false,
+  selectedNodeId,
 }: KnowledgeGraph3DProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -271,6 +274,36 @@ export function KnowledgeGraph3D({
   useEffect(() => { hoveredNodeRef.current = hoveredNode; }, [hoveredNode]);
   useEffect(() => { selectedNodeRef.current = selectedNode; }, [selectedNode]);
   useEffect(() => { hiddenCategoriesRef.current = hiddenCategories; }, [hiddenCategories]);
+
+  // Sync external selection → internal state
+  useEffect(() => {
+    if (selectedNodeId === undefined) return; // prop not provided
+    if (selectedNodeId === null) {
+      // External deselection
+      if (selectedNode) {
+        setSelectedNode(null);
+        setIsAutoRotating(true);
+      }
+      return;
+    }
+    // Find matching node — try exact match first, then match by label (short name)
+    const match =
+      nodes.find((n) => n.id === selectedNodeId) ??
+      nodes.find((n) => n.label === selectedNodeId) ??
+      nodes.find((n) => n.id.endsWith(`/${selectedNodeId}`));
+    if (match && match.id !== selectedNode?.id) {
+      setSelectedNode(match);
+      setIsAutoRotating(false);
+      // Pan camera toward the selected node
+      const camera = cameraRef.current;
+      const controls = controlsRef.current;
+      if (camera && controls && match.x !== undefined && match.y !== undefined) {
+        const targetPos = new THREE.Vector3(match.x, match.y, match.z ?? 0);
+        controls.target.lerp(targetPos, 0.5);
+        controls.update();
+      }
+    }
+  }, [selectedNodeId, nodes]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Initialize Three.js scene
   useEffect(() => {


### PR DESCRIPTION
## Summary
- When a repo card is selected, the corresponding node on the 3D knowledge graph highlights and camera pans to it
- When a node is clicked on the graph, the corresponding repo card gets selected (instead of navigating away)
- Threaded `selectedRepoName` through HomePageClient → HomeGraphWidget → KnowledgeGraph3D
- Node matching supports exact ID, label name, and owner/name suffix patterns

## Test plan
- [ ] Select a repo card → verify the graph highlights the matching node and camera pans
- [ ] Click a node on the graph → verify the repo card below gets selected/expanded
- [ ] Click the same node again → verify it deselects
- [ ] Click outside the expanded card → verify both card and graph node deselect
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)