### PR TITLE
KAN-124: Add HSTS/CSP headers and fix GCP URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_REPORIUM_API_URL: https://reporium-api-573778300586.us-central1.run.app
+      NEXT_PUBLIC_REPORIUM_API_URL: https://api.reporium.com
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -104,7 +104,7 @@ const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
 
 const API_URL =
   process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://reporium-api-573778300586.us-central1.run.app';
+  'https://api.reporium.com';
 
 export function StickyAskBar() {
   const [barState, setBarState] = useState<BarState>('collapsed');

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,9 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "X-DNS-Prefetch-Control", "value": "on" }
+        { "key": "X-DNS-Prefetch-Control", "value": "on" },
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data:; connect-src 'self' https://api.reporium.com https://reporium-api-573778300586.us-central1.run.app https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.vercel.app; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add `Strict-Transport-Security` header (max-age=63072000, includeSubDomains, preload)
- Add comprehensive `Content-Security-Policy` header allowing self, api.reporium.com, Cloud Run API, Google Fonts, and Vercel analytics/insights
- Update remaining hardcoded Cloud Run URLs to use `api.reporium.com` (ci.yml, StickyAskBar.tsx)

Closes #180

## Test plan
- [ ] Verify Vercel preview deployment loads correctly with new headers
- [ ] Check browser console for CSP violations
- [ ] Confirm Google Fonts and Vercel Analytics still work
- [ ] Validate HSTS header present in response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)