### PR TITLE
Add error.tsx boundaries to route segments

### DIFF
--- a/src/app/graph/error.tsx
+++ b/src/app/graph/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-zinc-200">Something went wrong</h2>
+      <p className="text-sm text-zinc-400">An unexpected error occurred. Please try again.</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-500 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/insights/error.tsx
+++ b/src/app/insights/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-zinc-200">Something went wrong</h2>
+      <p className="text-sm text-zinc-400">An unexpected error occurred. Please try again.</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-500 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/repo/[name]/error.tsx
+++ b/src/app/repo/[name]/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-zinc-200">Something went wrong</h2>
+      <p className="text-sm text-zinc-400">An unexpected error occurred. Please try again.</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-500 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/taxonomy/error.tsx
+++ b/src/app/taxonomy/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-zinc-200">Something went wrong</h2>
+      <p className="text-sm text-zinc-400">An unexpected error occurred. Please try again.</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-500 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/trends/error.tsx
+++ b/src/app/trends/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-zinc-200">Something went wrong</h2>
+      <p className="text-sm text-zinc-400">An unexpected error occurred. Please try again.</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-500 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds Next.js App Router `error.tsx` files to 5 route segments: `graph`, `insights`, `repo/[name]`, `taxonomy`, and `trends`
- Provides graceful runtime error handling with a retry button, matching the project's dark theme (zinc/violet palette)
- `src/app/asks/` was skipped as the directory does not exist

## Test plan
- [ ] Verify each route still loads normally
- [ ] Trigger a runtime error in each route segment and confirm the error boundary renders with "Try again" button
- [ ] Confirm "Try again" button resets the error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)