### PR TITLE
KAN-158: persist session_id in AskPanel for conversational memory

### DIFF
--- a/src/components/AskPanel.tsx
+++ b/src/components/AskPanel.tsx
@@ -31,6 +31,32 @@ interface QueryResponse {
 // Inner panel — reads ?q= from URL on the client side
 // ---------------------------------------------------------------------------
 const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
+const SESSION_STORAGE_KEY = 'reporium:ask:session_id';
+
+/**
+ * Return a stable session id persisted in localStorage.
+ * KAN-158: the backend uses session_id to thread conversational memory
+ * across requests, so we must reuse the same value for the lifetime of
+ * the browser session (and across reloads) rather than minting one per
+ * request.
+ */
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    const existing = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    if (existing) return existing;
+    const fresh =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `sess_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    window.localStorage.setItem(SESSION_STORAGE_KEY, fresh);
+    return fresh;
+  } catch {
+    // localStorage unavailable (private mode, quota) — fall back to an
+    // ephemeral per-page id so we still send a stable value within the tab.
+    return `sess_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
 
 interface AskPanelProps {
   apiUrl: string;
@@ -44,7 +70,13 @@ function AskPanelInner({ apiUrl }: AskPanelProps) {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string>('');
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Initialize (or load) the conversational session id on mount.
+  useEffect(() => {
+    setSessionId(getOrCreateSessionId());
+  }, []);
 
   // Auto-submit if ?q= param provided (navigated from mini bar)
   useEffect(() => {
@@ -76,7 +108,13 @@ function AskPanelInner({ apiUrl }: AskPanelProps) {
           'Content-Type': 'application/json',
           ...(APP_TOKEN && { 'X-App-Token': APP_TOKEN }),
         },
-        body: JSON.stringify({ question: queryText, top_k: 8 }),
+        body: JSON.stringify({
+          question: queryText,
+          top_k: 8,
+          // KAN-158: thread session id so the backend can link this turn
+          // to prior turns for conversational memory.
+          ...(sessionId ? { session_id: sessionId } : {}),
+        }),
       });
 
       if (res.status === 429) {


### PR DESCRIPTION
## Summary
- Generates a UUID on first mount, persists it in \`localStorage\` under \`reporium:ask:session_id\`, and reuses it across reloads/requests.
- Includes \`session_id\` in the POST body to \`/intelligence/ask\` so the backend can thread turns into conversational memory (KAN-158).
- Graceful fallback to an ephemeral per-tab id if \`localStorage\` is blocked (private mode, quota, SSR).

Closes the final frontend gap identified in the Phase 3 audit: the conversational-memory backend was fully shipped but every request was arriving without a session id, so each turn was treated as a fresh conversation.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Visit \`/intelligence/ask\`, open DevTools → Application → Local Storage: verify \`reporium:ask:session_id\` is set on first render
- [ ] Submit a query, inspect Network tab: request body contains \`session_id\`
- [ ] Reload page, submit another query: same \`session_id\` is reused
- [ ] Backend \`conversation_turns\` table shows both turns linked to the same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)