### PR TITLE
fix: increase 429 retry backoff in fetch-library to survive rate-limit window

### DIFF
--- a/scripts/fetch-library.ts
+++ b/scripts/fetch-library.ts
@@ -40,7 +40,9 @@ if (!API_URL) {
 }
 
 const MAX_RETRIES = 3
-const RETRY_DELAYS_MS = [2000, 5000, 10000] as const
+// Delays must exceed the API's 60-second rate-limit window so that a 429 retry
+// doesn't immediately hit the same "5 per 1 minute" ceiling again.
+const RETRY_DELAYS_MS = [15000, 35000, 65000] as const
 
 function isRetryableStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599)
@@ -63,7 +65,12 @@ async function fetchWithRetry(url: string): Promise<Response> {
         )
       }
 
-      const retryDelayMs = RETRY_DELAYS_MS[attempt - 1]
+      // Honour the Retry-After header if present; fall back to our own schedule.
+      const retryAfterSec = Number(res.headers.get('Retry-After') ?? NaN)
+      const retryDelayMs = isFinite(retryAfterSec)
+        ? retryAfterSec * 1000 + 2000  // add 2s buffer
+        : RETRY_DELAYS_MS[attempt - 1]
+
       console.warn(
         `[fetch-library] attempt ${attempt}/${MAX_RETRIES} failed with ${res.status}; retrying in ${retryDelayMs / 1000}s`
       )


### PR DESCRIPTION
## Summary

- The GitHub Pages deploy was failing consistently on page 5 of the `/library/full` paginated fetch with `HTTP 429 Too Many Requests — Rate limit exceeded: 5 per 1 minute`
- The root cause: the old retry delays (`[2s, 5s, 10s]`) are all shorter than the API's 60-second sliding window, so each retry attempt hit the same rate-limit ceiling without the window ever resetting
- With 3 retries all exhausted within ~17 seconds, the script threw a fatal error and the deploy job exited with code 1

## Changes

- Raised `RETRY_DELAYS_MS` from `[2000, 5000, 10000]` to `[15000, 35000, 65000]` — the final 65s delay ensures the 60-second rate-limit window fully resets before the last attempt
- Added `Retry-After` response header support: if the API sends one, use it directly (plus a 2s buffer) rather than the fixed schedule

## Test plan

- [ ] Trigger the "Deploy to GitHub Pages" workflow manually after merging and confirm it completes all 9 pages without 429 errors
- [ ] Verify the deployed site at the GitHub Pages URL loads correctly with up-to-date library data

🤖 Generated with [Claude Code](https://claude.com/claude-code)