### PR TITLE
fix: remove dead api.reporium.com DNS fallback — fail loudly on missing env var

### DIFF
--- a/src/app/ask/page.tsx
+++ b/src/app/ask/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import { WikiNavBar } from '@/components/WikiNavBar';
 import { AskPanel } from '@/components/AskPanel';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 export const metadata: Metadata = {
   title: 'Ask Reporium - Natural language search',

--- a/src/app/graph/page.tsx
+++ b/src/app/graph/page.tsx
@@ -19,9 +19,10 @@ export const metadata: Metadata = {
   },
 };
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 export default function GraphPage() {
   return (

--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -10,9 +10,10 @@ import type { EnrichedRepo, QualitySignals } from '@/types/repo';
 import { ViewTracker } from '@/components/ViewTracker'
 import { SimilarReposPanel } from '@/components/SimilarReposPanel';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 const SKILL_LIFECYCLE_GROUPS: Record<string, string> = {
   'Model Training & Fine-tuning': 'Foundation & Training',

--- a/src/app/runs/page.tsx
+++ b/src/app/runs/page.tsx
@@ -7,9 +7,10 @@ export const metadata: Metadata = {
   description: 'Recent ingestion pipeline runs for the Reporium AI dev tool library.',
 };
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 export interface IngestionRun {
   run_id: string;

--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { WikiNavBar } from '@/components/WikiNavBar';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 export const metadata: Metadata = {
   title: 'Taxonomy Explorer - 8 AI skill dimensions',

--- a/src/components/HomeGraphWidget.tsx
+++ b/src/components/HomeGraphWidget.tsx
@@ -17,9 +17,10 @@ const KnowledgeGraph3D = dynamic(
   { ssr: false },
 );
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 interface ApiRepoNode {
   name: string;

--- a/src/components/NLFilterBar.tsx
+++ b/src/components/NLFilterBar.tsx
@@ -16,9 +16,10 @@ import type { NLFilterResult } from '@/types/repo';
 
 const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 interface NLFilterBarProps {
   onApply: (result: NLFilterResult) => void;

--- a/src/components/RecommendationsWidget.tsx
+++ b/src/components/RecommendationsWidget.tsx
@@ -14,9 +14,10 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { SimilarRepo } from '@/types/repo';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 const VIEWED_KEY = 'reporium_viewed_repos';
 const MAX_VIEWED = 10;

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -102,9 +102,10 @@ type BarState = 'collapsed' | 'expanded' | 'fullscreen';
 
 const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
 
-const API_URL =
-  process.env.NEXT_PUBLIC_REPORIUM_API_URL ??
-  'https://api.reporium.com';
+if (!process.env.NEXT_PUBLIC_REPORIUM_API_URL) {
+  throw new Error('NEXT_PUBLIC_REPORIUM_API_URL environment variable is not set');
+}
+const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL;
 
 export function StickyAskBar() {
   const [barState, setBarState] = useState<BarState>('collapsed');


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_REPORIUM_API_URL` had a silent fallback to `https://api.reporium.com` across 9 source files
- `api.reporium.com` has no DNS record, so dropping the env var from Vercel caused silent failures routing to a dead host
- Replaced all `?? 'https://api.reporium.com'` fallbacks with an explicit `throw new Error(...)` so a missing env var fails loudly at build/startup time

## Files changed
- `src/app/ask/page.tsx`
- `src/app/graph/page.tsx`
- `src/app/runs/page.tsx`
- `src/app/taxonomy/page.tsx`
- `src/app/repo/[name]/page.tsx`
- `src/components/HomeGraphWidget.tsx`
- `src/components/NLFilterBar.tsx`
- `src/components/RecommendationsWidget.tsx`
- `src/components/StickyAskBar.tsx`

## Test plan
- [ ] Verify Vercel has \`NEXT_PUBLIC_REPORIUM_API_URL\` set before merging (preview build will fail loudly if not)
- [ ] Confirm preview deployment loads all affected pages correctly
- [ ] Confirm removing the env var from a test deployment throws a visible build/runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)