### PR TITLE
fix: remove all api.reporium.com references (ci.yml, vercel.json, scripts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_REPORIUM_API_URL: https://api.reporium.com
+      NEXT_PUBLIC_REPORIUM_API_URL: https://reporium-api-573778300586.us-central1.run.app
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/fetch-library.ts
+++ b/scripts/fetch-library.ts
@@ -8,7 +8,7 @@
  *   npx tsx scripts/fetch-library.ts
  *
  * Environment:
- *   NEXT_PUBLIC_REPORIUM_API_URL — required (e.g. https://api.reporium.com)
+ *   NEXT_PUBLIC_REPORIUM_API_URL — required (e.g. https://reporium-api-573778300586.us-central1.run.app)
  */
 
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs'
@@ -35,7 +35,7 @@ const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL
 if (!API_URL) {
   console.error('ERROR: NEXT_PUBLIC_REPORIUM_API_URL is not set.')
   console.error('Set it in .env.local or pass it as an environment variable.')
-  console.error('Example: NEXT_PUBLIC_REPORIUM_API_URL=https://api.reporium.com')
+  console.error('Example: NEXT_PUBLIC_REPORIUM_API_URL=https://reporium-api-573778300586.us-central1.run.app')
   process.exit(1)
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "X-DNS-Prefetch-Control", "value": "on" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data:; connect-src 'self' https://api.reporium.com https://reporium-api-573778300586.us-central1.run.app https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.vercel.app; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data:; connect-src 'self' https://reporium-api-573778300586.us-central1.run.app https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.vercel.app; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- **ci.yml**: Replace dead `api.reporium.com` with the live GCP URL for `NEXT_PUBLIC_REPORIUM_API_URL` — CI builds now embed the correct endpoint
- **vercel.json**: Remove `api.reporium.com` from CSP `connect-src` allowlist — no browser traffic should target a non-existent host
- **scripts/fetch-library.ts**: Update example/error message strings to reference the real GCP endpoint

This branch is based on `hotfix/dead-dns-fallback` (PR #195) which removed the dead fallback from 9 src/ files. This PR completes the sweep by cleaning up the remaining config/script occurrences. Supersedes #195.

## Test plan
- [ ] CI build passes with updated `NEXT_PUBLIC_REPORIUM_API_URL`
- [ ] No `api.reporium.com` in grep scan of main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)