### PR TITLE
feat: KG3D animated physics — d3-force-3d, quadrant seeding, traveling edges, cluster tooltips

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,21 @@
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+
+  // Dev-only: proxy /api/* to the Reporium API to avoid CORS issues.
+  // In production the static export makes direct client-side calls instead.
+  // Note: `rewrites` are ignored during `next export` but active in `next dev`.
+  async rewrites() {
+    const apiUrl =
+      process.env.NEXT_PUBLIC_REPORIUM_API_URL ||
+      'https://reporium-api-573778300586.us-central1.run.app';
+    return [
+      {
+        source: '/api/proxy/:path*',
+        destination: `${apiUrl}/:path*`,
+      },
+    ];
+  },
 }
 
 module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/three": "^0.183.1",
         "d3-force": "^3.0.0",
+        "d3-force-3d": "^3.0.6",
         "framer-motion": "^12.38.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -4569,6 +4570,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="
+    },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
@@ -4589,6 +4595,26 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/three": "^0.183.1",
     "d3-force": "^3.0.0",
+    "d3-force-3d": "^3.0.6",
     "framer-motion": "^12.38.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/src/app/graph/GraphPageClient.tsx
+++ b/src/app/graph/GraphPageClient.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import type { GraphEdge, NodeMeta } from '@/components/KnowledgeGraph3D';
+import { API_URL as CLIENT_API_URL } from '@/lib/apiUrl';
 
 const KnowledgeGraph3D = dynamic(
   () => import('@/components/KnowledgeGraph3D').then((m) => ({ default: m.KnowledgeGraph3D })),
@@ -42,6 +43,7 @@ interface ApiResponse {
   total?: number;
   total_repos?: number;
   total_edges?: number;
+  total_knowledge_graph_edges?: number;
   edges: ApiEdge[];
 }
 
@@ -56,6 +58,7 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [totalRepos, setTotalRepos] = useState(0);
+  const [totalGraphEdges, setTotalGraphEdges] = useState(0);
   const [limit, setLimit] = useState(2000);
 
   useEffect(() => {
@@ -70,7 +73,7 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
       min_similarity: '0.5',
     });
 
-    fetch(`${apiUrl}/graph/edges?${params}`, {
+    fetch(`${CLIENT_API_URL}/graph/edges?${params}`, {
       signal: controller.signal,
       headers: { Accept: 'application/json' },
     })
@@ -80,6 +83,7 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
         if (cancelled) return;
 
         setTotalRepos(data.total_repos ?? 0);
+        setTotalGraphEdges(data.total_knowledge_graph_edges ?? data.total ?? 0);
 
         const nodeId = (
           node: ApiRepoNode | undefined,
@@ -132,7 +136,7 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
       cancelled = true;
       controller.abort();
     };
-  }, [apiUrl, limit]);
+  }, [limit]);
 
   const nodeCount = useMemo(
     () => new Set(allEdges.flatMap((e) => [e.source, e.target])).size,
@@ -148,7 +152,7 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
 
   // Keyboard: [ / ] to cycle edge limit for graph navigation
   useEffect(() => {
-    const LIMITS = [500, 1000, 2000, 5000];
+    const LIMITS = [500, 1000, 2000, 5000, 10000];
     const handler = (e: KeyboardEvent) => {
       if (e.key === ']') {
         setLimit((prev) => {
@@ -180,16 +184,18 @@ export function GraphPageClient({ apiUrl }: GraphPageClientProps) {
           className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 focus:outline-none"
         >
           <option value={500}>500 edges</option>
-          <option value={1000}>1000 edges</option>
-          <option value={2000}>2000 edges</option>
-          <option value={5000}>5000 edges</option>
+          <option value={1000}>1,000 edges</option>
+          <option value={2000}>2,000 edges</option>
+          <option value={5000}>5,000 edges</option>
+          <option value={10000}>10,000 edges</option>
         </select>
       </div>
 
       {/* Stats */}
       {!loading && !error && (
         <p className="text-xs text-zinc-600">
-          {nodeCount} repos &middot; {allEdges.length.toLocaleString()} similarity edges
+          {nodeCount} repos &middot; {allEdges.length.toLocaleString()} edges shown
+          {totalGraphEdges > allEdges.length ? ` of ${totalGraphEdges.toLocaleString()} total` : ''}
           {totalRepos > nodeCount ? ` \u00b7 ${totalRepos.toLocaleString()} in library` : ''}
         </p>
       )}

--- a/src/components/HomeGraphWidget.tsx
+++ b/src/components/HomeGraphWidget.tsx
@@ -49,6 +49,7 @@ interface ApiResponse {
   total?: number;
   total_edges?: number;
   total_repos?: number;
+  total_knowledge_graph_edges?: number;
   edges: ApiEdge[];
 }
 
@@ -71,7 +72,7 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
     let cancelled = false;
     const controller = new AbortController();
 
-    fetch(`${API_URL}/graph/edges?limit=6000&neighbours=5&min_similarity=0.40`, {
+    fetch(`${API_URL}/graph/edges?limit=10000&neighbours=5&min_similarity=0.40`, {
       signal: controller.signal,
       headers: { Accept: 'application/json' },
     })
@@ -80,7 +81,7 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
         const data: ApiResponse = await res.json();
         if (cancelled) return;
 
-        setTotalEdges(data.total ?? data.total_edges ?? 0);
+        setTotalEdges(data.total_knowledge_graph_edges ?? data.total ?? data.total_edges ?? 0);
 
         const nodeId = (
           node: ApiRepoNode | undefined,
@@ -154,8 +155,11 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
     [router, onGraphNodeSelect],
   );
 
-  // Don't render anything if graph fails to load
-  if (error) return null;
+  // Don't render anything if graph fails to load (logged for debugging)
+  if (error) {
+    if (typeof window !== 'undefined') console.warn('[HomeGraphWidget] Graph load failed:', error);
+    return null;
+  }
 
   return (
     <div className="rounded-xl border border-zinc-800 bg-[#0a0a0f] overflow-hidden">
@@ -165,7 +169,7 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
           <p className="text-xs text-zinc-500 mt-0.5">
             {loading
               ? 'Loading constellation...'
-              : `${nodeCount} repos \u00b7 ${edges.length.toLocaleString()} similarity edges`}
+              : `${nodeCount} repos \u00b7 ${(totalEdges || edges.length).toLocaleString()} connections`}
           </p>
         </div>
       </div>

--- a/src/components/KnowledgeGraph3D.tsx
+++ b/src/components/KnowledgeGraph3D.tsx
@@ -28,7 +28,7 @@ import {
   forceCollide,
   type SimulationNodeDatum,
   type SimulationLinkDatum,
-} from 'd3-force';
+} from 'd3-force-3d';
 import {
   getCategoryColor,
   getCategoryLabel,
@@ -67,29 +67,88 @@ interface GLink extends SimulationLinkDatum<GNode> {
 // Helpers
 // ---------------------------------------------------------------------------
 function nodeRadius(connections: number): number {
-  return 1.0 + Math.min(connections * 0.35, 3.5);
+  // Log-scale for high-connection nodes to prevent a few giant spheres
+  return 1.3 + Math.min(Math.sqrt(connections) * 0.6, 4.0);
 }
+
+/**
+ * Edge-type quadrant seeding:
+ *  DEPENDS_ON     → +X +Z
+ *  COMPATIBLE_WITH → -X +Z
+ *  ALTERNATIVE_TO → +X -Z
+ *  EXTENDS        → -X -Z
+ *  SIMILAR_TO     → no quadrant bias (centroid only)
+ * Y axis = scaled connection count (more connected = higher Y)
+ */
+const QUADRANT_SEEDS: Record<string, { xSign: number; zSign: number }> = {
+  DEPENDS_ON:      { xSign:  1, zSign:  1 },
+  COMPATIBLE_WITH: { xSign: -1, zSign:  1 },
+  ALTERNATIVE_TO:  { xSign:  1, zSign: -1 },
+  EXTENDS:         { xSign: -1, zSign: -1 },
+};
 
 function buildNodes(
   edges: GraphEdge[],
   metadata: Map<string, NodeMeta>,
 ): GNode[] {
   const connCount = new Map<string, number>();
+  // Track which typed edges each node participates in (for quadrant seeding)
+  const nodeEdgeTypes = new Map<string, Map<string, number>>();
   for (const e of edges) {
     connCount.set(e.source, (connCount.get(e.source) ?? 0) + 1);
     connCount.set(e.target, (connCount.get(e.target) ?? 0) + 1);
+    const t = (e.edge_type ?? '').toUpperCase();
+    if (QUADRANT_SEEDS[t]) {
+      // Count typed edges per node
+      if (!nodeEdgeTypes.has(e.source)) nodeEdgeTypes.set(e.source, new Map());
+      if (!nodeEdgeTypes.has(e.target)) nodeEdgeTypes.set(e.target, new Map());
+      nodeEdgeTypes.get(e.source)!.set(t, (nodeEdgeTypes.get(e.source)!.get(t) ?? 0) + 1);
+      nodeEdgeTypes.get(e.target)!.set(t, (nodeEdgeTypes.get(e.target)!.get(t) ?? 0) + 1);
+    }
   }
+
+  // Find max connections for Y-axis scaling
+  let maxConn = 1;
+  for (const c of connCount.values()) if (c > maxConn) maxConn = c;
+
+  const SPREAD = 120; // quadrant offset magnitude
+  const JITTER = 80;  // random scatter within quadrant
+
   const nodes: GNode[] = [];
   for (const [id, count] of connCount) {
     const meta = metadata.get(id);
+    const typeCounts = nodeEdgeTypes.get(id);
+
+    // Determine dominant typed edge for this node (if any)
+    let seedX = 0, seedZ = 0;
+    if (typeCounts && typeCounts.size > 0) {
+      // Weight the quadrant position by how many of each type the node has
+      let totalTyped = 0;
+      for (const [t, n] of typeCounts) {
+        const q = QUADRANT_SEEDS[t];
+        if (q) {
+          seedX += q.xSign * n;
+          seedZ += q.zSign * n;
+          totalTyped += n;
+        }
+      }
+      if (totalTyped > 0) {
+        seedX = (seedX / totalTyped) * SPREAD;
+        seedZ = (seedZ / totalTyped) * SPREAD;
+      }
+    }
+
+    // Y from connection count: more connections = higher (positive Y)
+    const yBase = (Math.log2(count + 1) / Math.log2(maxConn + 1)) * 200 - 100;
+
     nodes.push({
       id,
       label: id.includes('/') ? id.split('/').pop()! : id,
       category: meta?.category ?? null,
       connections: count,
-      x: (Math.random() - 0.5) * 300,
-      y: (Math.random() - 0.5) * 300,
-      z: (Math.random() - 0.5) * 300,
+      x: seedX + (Math.random() - 0.5) * JITTER,
+      y: yBase + (Math.random() - 0.5) * JITTER,
+      z: seedZ + (Math.random() - 0.5) * JITTER,
     });
   }
   return nodes;
@@ -139,64 +198,110 @@ function hexToRGB(hex: string): THREE.Color {
   return new THREE.Color(hex);
 }
 
-// 3D force: apply z-axis forces manually using random sampling for efficiency
-function force3D(nodes: GNode[], alpha: number) {
-  const n = nodes.length;
+// Canonical edge-type colors — single source of truth for 3D rendering AND legend.
+// IMPORTANT: These MUST NOT collide with any category color in categoryColors.ts.
+// Category palette uses: blue, amber, violet, red, green, teal, cyan, indigo,
+// lime, orange, pink, purple, sky, fuchsia, rose, stone.
+// Edge types use: warm-white, mint, steel-blue, coral — distinct from all 16.
+const EDGE_TYPE_HEX: Record<string, string> = {
+  ALTERNATIVE_TO:  '#fbbf24', // warm gold (distinct from agents amber #f59e0b)
+  COMPATIBLE_WITH: '#34d399', // mint/emerald (distinct from evals green #22c55e)
+  DEPENDS_ON:      '#60a5fa', // light blue-400 (distinct from foundation blue #3b82f6)
+  EXTENDS:         '#fb923c', // orange-400 (distinct from pink #ec4899 and orange #f97316)
+};
+
+
+// force3D removed — d3-force-3d handles X/Y/Z natively with octree Barnes-Hut
+
+/**
+ * Category clustering force — pulls same-category nodes toward their
+ * centroid, but ONLY for nodes that participate in SIMILAR_TO edges.
+ * Typed edges (DEPENDS_ON, etc.) have their own quadrant seeding.
+ */
+function forceCategoryClustering(
+  nodes: GNode[],
+  alpha: number,
+  similarNodeIds: Set<string>,
+) {
+  // Compute category centroids from SIMILAR_TO-connected nodes only
+  const centroids = new Map<string, { sx: number; sy: number; sz: number; n: number }>();
   for (const node of nodes) {
-    if (node.z === undefined) node.z = 0;
-    if (node.vz === undefined) node.vz = 0;
-    // Weak centering force toward z=0
-    node.vz += -node.z * 0.008 * alpha;
-    node.vz *= 0.88;
-    node.z += node.vz;
+    if (!similarNodeIds.has(node.id)) continue;
+    const cat = node.category ?? '__none__';
+    const c = centroids.get(cat) ?? { sx: 0, sy: 0, sz: 0, n: 0 };
+    c.sx += node.x ?? 0;
+    c.sy += node.y ?? 0;
+    c.sz += node.z ?? 0;
+    c.n++;
+    centroids.set(cat, c);
   }
-  // Random-sampled z repulsion — covers all nodes proportionally
-  const samples = Math.min(n * 4, 4000);
-  for (let k = 0; k < samples; k++) {
-    const i = Math.floor(Math.random() * n);
-    const j = Math.floor(Math.random() * n);
-    if (i === j) continue;
-    const a = nodes[i];
-    const b = nodes[j];
-    const dz = (a.z ?? 0) - (b.z ?? 0);
-    const dx = (a.x ?? 0) - (b.x ?? 0);
-    const dy = (a.y ?? 0) - (b.y ?? 0);
-    const dist2 = dx * dx + dy * dy + dz * dz + 1;
-    const force = (alpha * 40) / dist2;
-    const fz = dz * force;
-    a.vz = (a.vz ?? 0) + fz;
-    b.vz = (b.vz ?? 0) - fz;
+  // Pull each SIMILAR_TO node toward its category centroid
+  const PULL = 0.012;
+  for (const node of nodes) {
+    if (!similarNodeIds.has(node.id)) continue;
+    const cat = node.category ?? '__none__';
+    const c = centroids.get(cat);
+    if (!c || c.n < 3) continue;
+    const cx = c.sx / c.n;
+    const cy = c.sy / c.n;
+    const cz = c.sz / c.n;
+    node.vx = (node.vx ?? 0) + (cx - (node.x ?? 0)) * PULL * alpha;
+    node.vy = (node.vy ?? 0) + (cy - (node.y ?? 0)) * PULL * alpha;
+    node.vz = (node.vz ?? 0) + (cz - (node.z ?? 0)) * PULL * alpha;
   }
 }
 
 /** Create a text sprite for cluster labels */
-function createTextSprite(text: string, color: string, fontSize = 22, alpha = 0.6, scale: [number, number, number] = [30, 7.5, 1]): THREE.Sprite {
+function createTextSprite(text: string, color: string, fontSize = 36, alpha = 0.9, scale: [number, number, number] = [80, 20, 1]): THREE.Sprite {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d')!;
-  canvas.width = 512;
-  canvas.height = 64;
-  ctx.clearRect(0, 0, 512, 64);
+  canvas.width = 1024;
+  canvas.height = 128;
+  ctx.clearRect(0, 0, 1024, 128);
+
+  // Background pill for readability
   ctx.font = `bold ${fontSize}px Inter, sans-serif`;
+  const textWidth = ctx.measureText(text).width;
+  const pillW = textWidth + 40;
+  const pillH = fontSize + 20;
+  const pillX = (1024 - pillW) / 2;
+  const pillY = (128 - pillH) / 2;
+  ctx.globalAlpha = 0.75;
+  ctx.fillStyle = '#0a0a0f';
+  ctx.beginPath();
+  ctx.roundRect(pillX, pillY, pillW, pillH, pillH / 2);
+  ctx.fill();
+  // Color border — category accent
+  ctx.globalAlpha = 0.9;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.roundRect(pillX, pillY, pillW, pillH, pillH / 2);
+  ctx.stroke();
+
+  // Text — always white for maximum legibility on dark backgrounds
+  ctx.globalAlpha = alpha;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillStyle = color;
-  ctx.globalAlpha = alpha;
-  ctx.fillText(text, 256, 32);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(text, 512, 64);
   const texture = new THREE.CanvasTexture(canvas);
   texture.needsUpdate = true;
   const mat = new THREE.SpriteMaterial({
     map: texture,
     transparent: true,
     depthWrite: false,
+    depthTest: false, // always visible, rendered on top
   });
   const sprite = new THREE.Sprite(mat);
   sprite.scale.set(...scale);
+  sprite.renderOrder = 999; // render on top of nodes/edges
   return sprite;
 }
 
 /** Create a smaller name label sprite for node hover labels */
 function createNodeLabel(text: string, color: string): THREE.Sprite {
-  return createTextSprite(text, color, 28, 0.95, [18, 3.5, 1]);
+  return createTextSprite(text, color, 32, 0.95, [28, 6, 1]);
 }
 
 /** Quadratic bezier point at parameter t between src (a) and tgt (c) via control (b) */
@@ -282,6 +387,14 @@ export function KnowledgeGraph3D({
   const [hoveredNode, setHoveredNode] = useState<GNode | null>(null);
   const [selectedNode, setSelectedNode] = useState<GNode | null>(null);
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+  // Cluster halo hover state
+  const [hoveredCluster, setHoveredCluster] = useState<{
+    category: string;
+    nodeCount: number;
+    topRepos: string[];
+  } | null>(null);
+  const [clusterTooltipPos, setClusterTooltipPos] = useState<{ x: number; y: number } | null>(null);
+  const hoveredClusterRef = useRef<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isAutoRotating, setIsAutoRotating] = useState(true);
   const [hiddenCategories, setHiddenCategories] = useState<Set<string>>(new Set());
@@ -358,12 +471,13 @@ export function KnowledgeGraph3D({
     // Scene
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#0a0a0f');
-    scene.fog = new THREE.FogExp2('#0a0a0f', 0.0006);
+    scene.fog = new THREE.FogExp2('#0a0a0f', 0.0003);
     sceneRef.current = scene;
 
     // Camera
     const camera = new THREE.PerspectiveCamera(60, width / h, 0.1, 4000);
-    camera.position.set(0, 0, compact ? 700 : 900);
+    // Slightly elevated + angled for 3D depth perception (not straight-on)
+    camera.position.set(0, compact ? 60 : 80, compact ? 600 : 750);
     cameraRef.current = camera;
 
     // Renderer
@@ -446,10 +560,10 @@ export function KnowledgeGraph3D({
 
     // ── Split links by edge type ──────────────────────────────────────────────
     const TYPED_RGB: Record<string, THREE.Color> = {
-      ALTERNATIVE_TO: new THREE.Color(0.95, 0.60, 0.05), // amber
-      COMPATIBLE_WITH: new THREE.Color(0.10, 0.75, 0.25), // green
-      DEPENDS_ON:      new THREE.Color(0.20, 0.50, 1.00), // blue
-      EXTENDS:         new THREE.Color(0.95, 0.28, 0.60), // pink
+      ALTERNATIVE_TO:  new THREE.Color(EDGE_TYPE_HEX.ALTERNATIVE_TO),
+      COMPATIBLE_WITH: new THREE.Color(EDGE_TYPE_HEX.COMPATIBLE_WITH),
+      DEPENDS_ON:      new THREE.Color(EDGE_TYPE_HEX.DEPENDS_ON),
+      EXTENDS:         new THREE.Color(EDGE_TYPE_HEX.EXTENDS),
     };
     const simLinks: GLink[]    = [];
     const compatLinks: GLink[] = [];
@@ -490,30 +604,23 @@ export function KnowledgeGraph3D({
     depEdgeIdxRef.current    = buildTypeIdx(depLinks);
     extEdgeIdxRef.current    = buildTypeIdx(extLinks);
 
-    // Node id → category RGB (for SIMILAR_TO edge coloring by source cluster)
-    const nodeCatColor = new Map<string, THREE.Color>();
-    for (const node of nodes) {
-      nodeCatColor.set(node.id, hexToRGB(getCategoryColor(node.category)));
-    }
-
-    // ── SIMILAR_TO: thin straight LineSegments (most numerous) ───────────────
+    // ── SIMILAR_TO: thin straight LineSegments — neutral dim grey only ─────
+    const SIM_EDGE_COLOR = new THREE.Color('#333333');
     const lineGeo = new THREE.BufferGeometry();
     const positions = new Float32Array(simLinks.length * 6);
     const colors = new Float32Array(simLinks.length * 6);
     for (let i = 0; i < simLinks.length; i++) {
       const idx = i * 6;
-      const srcId = simLinks[i].source as string;
-      const cat = nodeCatColor.get(srcId) ?? new THREE.Color('#8888aa');
-      const dim = 0.45;
-      colors[idx]     = colors[idx + 3] = cat.r * dim;
-      colors[idx + 1] = colors[idx + 4] = cat.g * dim;
-      colors[idx + 2] = colors[idx + 5] = cat.b * dim;
+      colors[idx]     = colors[idx + 3] = SIM_EDGE_COLOR.r;
+      colors[idx + 1] = colors[idx + 4] = SIM_EDGE_COLOR.g;
+      colors[idx + 2] = colors[idx + 5] = SIM_EDGE_COLOR.b;
     }
     lineGeo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
     lineGeo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
     baseEdgeColorsRef.current = new Float32Array(colors);
-    const lineMat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.5 });
+    const lineMat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.2, depthWrite: false });
     const lineSegments = new THREE.LineSegments(lineGeo, lineMat);
+    lineSegments.renderOrder = 0; // render first (behind typed edges)
     scene.add(lineSegments);
     lineRef.current = lineSegments;
 
@@ -535,8 +642,9 @@ export function KnowledgeGraph3D({
       const geo = new THREE.BufferGeometry();
       geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
       geo.setAttribute('color',    new THREE.BufferAttribute(col, 3));
-      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.65 });
+      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.8 });
       const ls = new THREE.LineSegments(geo, mat);
+      ls.renderOrder = 1;
       scene.add(ls);
       compatLineRef.current = ls;
     }
@@ -559,8 +667,9 @@ export function KnowledgeGraph3D({
       const geo = new THREE.BufferGeometry();
       geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
       geo.setAttribute('color',    new THREE.BufferAttribute(col, 3));
-      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.65 });
+      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.8 });
       const ls = new THREE.LineSegments(geo, mat);
+      ls.renderOrder = 1;
       scene.add(ls);
       altLineRef.current = ls;
     }
@@ -580,8 +689,9 @@ export function KnowledgeGraph3D({
       const geo = new THREE.BufferGeometry();
       geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
       geo.setAttribute('color',    new THREE.BufferAttribute(col, 3));
-      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.65 });
+      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.8 });
       const ls = new THREE.LineSegments(geo, mat);
+      ls.renderOrder = 1;
       scene.add(ls);
       depLineRef.current = ls;
 
@@ -589,9 +699,9 @@ export function KnowledgeGraph3D({
         const coneGeo = new THREE.ConeGeometry(1.5, 5, 6);
         const coneMat = new THREE.MeshBasicMaterial({ color: TYPED_RGB.DEPENDS_ON, transparent: true, opacity: 0.8 });
         const cones = new THREE.InstancedMesh(coneGeo, coneMat, depLinks.length);
-        // Init instanceColor so we can update it per-instance later
         for (let i = 0; i < depLinks.length; i++) cones.setColorAt(i, TYPED_RGB.DEPENDS_ON);
         cones.instanceColor!.needsUpdate = true;
+        cones.renderOrder = 2;
         scene.add(cones);
         depConesRef.current = cones;
       }
@@ -614,8 +724,9 @@ export function KnowledgeGraph3D({
       const geo = new THREE.BufferGeometry();
       geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
       geo.setAttribute('color',    new THREE.BufferAttribute(col, 3));
-      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.65 });
+      const mat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.8 });
       const ls = new THREE.LineSegments(geo, mat);
+      ls.renderOrder = 1;
       scene.add(ls);
       extLineRef.current = ls;
     }
@@ -636,9 +747,53 @@ export function KnowledgeGraph3D({
 
     // Category cluster labels — computed after simulation settles
     const clusterSprites: THREE.Sprite[] = [];
+    // Invisible cluster hit-targets for hover tooltips (no visual halos)
+    const clusterHitSpheres: THREE.Mesh[] = [];
     let clustersCreated = false;
 
-    // Force simulation
+    // ── Edge flow particles for high-degree nodes ──────────────────────────
+    // Identify the top edges by source+target degree for particle animation
+    const nodeDegreeSorted = [...nodes].sort((a, b) => b.connections - a.connections);
+    const highDegreeIds = new Set(nodeDegreeSorted.slice(0, Math.max(20, Math.floor(nodes.length * 0.08))).map(n => n.id));
+    // Collect edges where BOTH endpoints are high-degree
+    const particleEdges: { link: GLink; weight: number }[] = [];
+    for (const l of links) {
+      const sId = typeof l.source === 'string' ? l.source : (l.source as unknown as GNode).id;
+      const tId = typeof l.target === 'string' ? l.target : (l.target as unknown as GNode).id;
+      if (highDegreeIds.has(sId) || highDegreeIds.has(tId)) {
+        particleEdges.push({ link: l, weight: l.weight ?? 0.5 });
+      }
+    }
+    // Cap to avoid GPU overload
+    const MAX_PARTICLES = 500;
+    const selectedParticleEdges = particleEdges
+      .sort((a, b) => b.weight - a.weight)
+      .slice(0, MAX_PARTICLES);
+
+    let particlePoints: THREE.Points | null = null;
+    const particlePositions = new Float32Array(selectedParticleEdges.length * 3);
+    const particleSpeeds = new Float32Array(selectedParticleEdges.length); // 0..1 t parameter
+    const particleWeights = new Float32Array(selectedParticleEdges.length);
+    if (selectedParticleEdges.length > 0) {
+      for (let i = 0; i < selectedParticleEdges.length; i++) {
+        particleSpeeds[i] = Math.random(); // random start position along edge
+        particleWeights[i] = 0.3 + (selectedParticleEdges[i].weight) * 0.7; // speed factor
+      }
+      const particleGeo = new THREE.BufferGeometry();
+      particleGeo.setAttribute('position', new THREE.BufferAttribute(particlePositions, 3));
+      const particleMat = new THREE.PointsMaterial({
+        color: 0xffffff,
+        size: 1.8,
+        transparent: true,
+        opacity: 0.6,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      });
+      particlePoints = new THREE.Points(particleGeo, particleMat);
+      scene.add(particlePoints);
+    }
+
+    // Force simulation — d3-force-3d with native 3D octree Barnes-Hut
     const nodeMap = new Map(nodes.map((n) => [n.id, n]));
     const forceLinks = links.map((l) => ({
       source: l.source as string,
@@ -646,20 +801,33 @@ export function KnowledgeGraph3D({
       weight: l.weight,
     }));
 
-    const sim = forceSimulation<GNode>(nodes)
-      .force('charge', forceManyBody().strength(-60).distanceMax(300))
+    // Build set of nodes connected by SIMILAR_TO edges (for category clustering)
+    const similarNodeIds = new Set<string>();
+    for (const l of links) {
+      const t = (l.edge_type ?? '').toUpperCase();
+      if (t === 'SIMILAR_TO' || t === '' || !QUADRANT_SEEDS[t]) {
+        const sId = typeof l.source === 'string' ? l.source : (l.source as unknown as GNode).id;
+        const tId = typeof l.target === 'string' ? l.target : (l.target as unknown as GNode).id;
+        similarNodeIds.add(sId);
+        similarNodeIds.add(tId);
+      }
+    }
+
+    // numDimensions=3 → octree-based repulsion, 3D link springs, 3D centering
+    const sim = forceSimulation<GNode>(nodes, 3)
+      .force('charge', forceManyBody().strength(-90).distanceMax(400))
       .force(
         'link',
         forceLink<GNode, SimulationLinkDatum<GNode>>(forceLinks as SimulationLinkDatum<GNode>[])
           .id((d) => (d as GNode).id)
-          .distance(30)
-          .strength(0.3),
+          .distance(25)
+          .strength(0.35),
       )
-      .force('center', forceCenter(0, 0).strength(0.04))
-      .force('collide', forceCollide<GNode>().radius((d) => nodeRadius(d.connections) + 2))
-      .alphaDecay(0.015)
+      .force('center', forceCenter(0, 0, 0).strength(0.02))
+      .force('collide', forceCollide<GNode>().radius((d) => nodeRadius(d.connections) + 3))
+      .alphaDecay(0.012)
       .on('tick', () => {
-        force3D(nodes, sim.alpha());
+        forceCategoryClustering(nodes, sim.alpha(), similarNodeIds);
 
         for (let i = 0; i < nodes.length; i++) {
           const n = nodes[i];
@@ -803,8 +971,8 @@ export function KnowledgeGraph3D({
           clickSpheres[i].position.set(nodes[i].x??0, nodes[i].y??0, nodes[i].z??0);
         }
 
-        // Create cluster labels once simulation is mostly settled
-        if (!clustersCreated && sim.alpha() < 0.15) {
+        // Create cluster labels once simulation has begun settling
+        if (!clustersCreated && sim.alpha() < 0.35) {
           clustersCreated = true;
           const catPositions = new Map<string, { sx: number; sy: number; sz: number; count: number }>();
           for (const n of nodes) {
@@ -817,18 +985,79 @@ export function KnowledgeGraph3D({
             catPositions.set(n.category, entry);
           }
           for (const [cat, pos] of catPositions) {
-            if (pos.count < 3) continue; // skip tiny clusters
+            if (pos.count < 5) continue; // skip tiny clusters
             const label = getCategoryLabel(cat);
             const color = getCategoryColor(cat);
             const sprite = createTextSprite(label, color);
             sprite.position.set(
               pos.sx / pos.count,
-              pos.sy / pos.count + 8, // offset above centroid
+              pos.sy / pos.count + 25, // offset above centroid
               pos.sz / pos.count,
             );
             sprite.userData = { category: cat };
             scene.add(sprite);
             clusterSprites.push(sprite);
+          }
+
+          // ── Invisible cluster hit-target spheres for hover tooltips ──────────
+          for (const [cat, pos] of catPositions) {
+            if (pos.count < 5) continue;
+            const cx = pos.sx / pos.count;
+            const cy = pos.sy / pos.count;
+            const cz = pos.sz / pos.count;
+            // Compute cluster spread for hit-sphere radius
+            let totalDist = 0;
+            let catCount = 0;
+            for (const n of nodes) {
+              if (n.category !== cat) continue;
+              const dx = (n.x ?? 0) - cx;
+              const dy = (n.y ?? 0) - cy;
+              const dz = (n.z ?? 0) - cz;
+              totalDist += Math.sqrt(dx * dx + dy * dy + dz * dz);
+              catCount++;
+            }
+            const avgDist = totalDist / catCount;
+            if (avgDist < 3) continue;
+            const hitGeo = new THREE.SphereGeometry(avgDist * 0.8, 8, 6);
+            const hitMat = new THREE.MeshBasicMaterial({ visible: false });
+            const hitSphere = new THREE.Mesh(hitGeo, hitMat);
+            hitSphere.position.set(cx, cy, cz);
+            hitSphere.userData = { category: cat, isClusterHit: true, nodeCount: pos.count };
+            scene.add(hitSphere);
+            clusterHitSpheres.push(hitSphere);
+          }
+        }
+
+        // Continuously update cluster label positions to follow centroid drift
+        if (clustersCreated && sim.alpha() > 0.01) {
+          const catPositions = new Map<string, { sx: number; sy: number; sz: number; count: number }>();
+          for (const n of nodes) {
+            if (!n.category) continue;
+            const entry = catPositions.get(n.category) ?? { sx: 0, sy: 0, sz: 0, count: 0 };
+            entry.sx += n.x ?? 0;
+            entry.sy += n.y ?? 0;
+            entry.sz += n.z ?? 0;
+            entry.count++;
+            catPositions.set(n.category, entry);
+          }
+          for (const sprite of clusterSprites) {
+            const cat = sprite.userData.category as string;
+            const pos = catPositions.get(cat);
+            if (pos && pos.count > 0) {
+              sprite.position.set(
+                pos.sx / pos.count,
+                pos.sy / pos.count + 15,
+                pos.sz / pos.count,
+              );
+            }
+          }
+          // Keep invisible cluster hit-spheres centered on their cluster
+          for (const hs of clusterHitSpheres) {
+            const cat = hs.userData.category as string;
+            const pos = catPositions.get(cat);
+            if (pos && pos.count > 0) {
+              hs.position.set(pos.sx / pos.count, pos.sy / pos.count, pos.sz / pos.count);
+            }
           }
         }
       });
@@ -870,13 +1099,134 @@ export function KnowledgeGraph3D({
       const col = ls.geometry.attributes.color.array as Float32Array;
       for (let i = 0; i < col.length; i++) col[i] = baseCol[i];
       ls.geometry.attributes.color.needsUpdate = true;
-      (ls.material as THREE.LineBasicMaterial).opacity = 0.65;
+      (ls.material as THREE.LineBasicMaterial).opacity = 0.8;
     }
 
     // Animation loop with highlight logic
+    const animClock = new THREE.Clock();
+
     function animate() {
       animFrameRef.current = requestAnimationFrame(animate);
       controls.update();
+
+      // ── Visual motion: pulse nodes proportional to connection count ──────
+      const elapsed = animClock.getElapsedTime();
+      for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        // More connections → faster & larger pulse
+        const intensity = Math.min(n.connections / 40, 1.0); // 0..1
+        const speed = 0.6 + intensity * 1.8; // 0.6..2.4 Hz — organic breathing
+        const amplitude = 0.04 + intensity * 0.14; // 4%..18% scale variation
+        // Each node gets a phase offset based on index for organic feel
+        const phase = i * 0.37;
+        const pulse = 1 + Math.sin(elapsed * speed + phase) * amplitude;
+
+        // Scale the node mesh
+        meshes[i].scale.setScalar(pulse);
+
+        // Glow breathes with inverse phase (expands when node contracts)
+        const glowPulse = 1 + Math.sin(elapsed * speed * 0.7 + phase + Math.PI * 0.5) * amplitude * 1.8;
+        glows[i].scale.setScalar(glowPulse);
+
+        // Emissive pulse — highly connected repos glow brighter
+        const mat = meshes[i].material as THREE.MeshPhongMaterial;
+        mat.emissiveIntensity = 0.7 + intensity * 0.5 * (0.5 + 0.5 * Math.sin(elapsed * speed * 0.5 + phase));
+
+        // Ambient micro-drift — ALL nodes get subtle continuous motion so graph feels alive
+        // Magnitude: 0.05 base + connection-proportional bonus (up to 0.8 total)
+        const driftBase = 0.05;
+        const driftConn = intensity * 0.75;
+        const drift = driftBase + driftConn;
+        const dx = Math.sin(elapsed * 0.5 + phase) * drift;
+        const dy = Math.cos(elapsed * 0.6 + phase * 1.3) * drift;
+        const dz = Math.sin(elapsed * 0.4 + phase * 0.7) * drift;
+        meshes[i].position.set((n.x ?? 0) + dx, (n.y ?? 0) + dy, (n.z ?? 0) + dz);
+        glows[i].position.copy(meshes[i].position);
+      }
+
+      // ── Animated flowing edges — energy pulses along connections ───────────
+      // SIMILAR_TO: wave of brightness flows through edges
+      {
+        const simCol = lineSegments.geometry.attributes.color.array as Float32Array;
+        const simBase = baseEdgeColorsRef.current;
+        const waveSpeed = 1.2;
+        for (let i = 0; i < simLinks.length; i++) {
+          const idx = i * 6;
+          // Each edge gets a unique phase from its index
+          const edgePhase = i * 0.13;
+          const wave = 0.5 + 0.5 * Math.sin(elapsed * waveSpeed + edgePhase);
+          const brightness = 0.6 + wave * 0.6; // range 0.6..1.2
+          simCol[idx]     = simBase[idx]     * brightness;
+          simCol[idx + 1] = simBase[idx + 1] * brightness;
+          simCol[idx + 2] = simBase[idx + 2] * brightness;
+          simCol[idx + 3] = simBase[idx + 3] * brightness;
+          simCol[idx + 4] = simBase[idx + 4] * brightness;
+          simCol[idx + 5] = simBase[idx + 5] * brightness;
+        }
+        lineSegments.geometry.attributes.color.needsUpdate = true;
+      }
+
+      // Typed edges: flowing dash-like pulse animation (brightness cascades along segments)
+      function animateTypedEdge(
+        ls: THREE.LineSegments | null,
+        baseCol: Float32Array,
+        linkCount: number,
+        vertsPerEdge: number,
+        speed: number,
+        phaseScale: number,
+      ) {
+        if (!ls || linkCount === 0) return;
+        const col = ls.geometry.attributes.color.array as Float32Array;
+        for (let i = 0; i < linkCount; i++) {
+          const edgePhase = i * phaseScale;
+          for (let v = 0; v < vertsPerEdge; v++) {
+            const segPhase = v / vertsPerEdge; // 0..1 along the edge
+            // Traveling wave: brightness moves along the edge over time
+            const wave = 0.4 + 0.6 * Math.max(0, Math.sin(elapsed * speed - segPhase * Math.PI * 3 + edgePhase));
+            const off = (i * vertsPerEdge + v) * 3;
+            col[off]     = baseCol[off]     * wave;
+            col[off + 1] = baseCol[off + 1] * wave;
+            col[off + 2] = baseCol[off + 2] * wave;
+          }
+        }
+        ls.geometry.attributes.color.needsUpdate = true;
+      }
+
+      animateTypedEdge(compatLineRef.current, compatBaseColRef.current, compatLinks.length, COMPAT_VPE, 2.5, 0.23);
+      animateTypedEdge(altLineRef.current,    altBaseColRef.current,    altLinks.length,    ALT_VPE,    3.0, 0.19);
+      animateTypedEdge(depLineRef.current,    depBaseColRef.current,    depLinks.length,    2,          2.0, 0.31);
+      animateTypedEdge(extLineRef.current,    extBaseColRef.current,    extLinks.length,    EXT_VPE,    2.8, 0.17);
+
+      // Animated dep arrow cones — pulse opacity
+      if (depConesRef.current && depLinks.length > 0) {
+        const conePulse = 0.5 + 0.5 * Math.sin(elapsed * 2.0);
+        (depConesRef.current.material as THREE.MeshBasicMaterial).opacity = 0.5 + conePulse * 0.4;
+      }
+
+      // ── Edge flow particles — travel along high-degree edges ──────────────
+      if (particlePoints && selectedParticleEdges.length > 0) {
+        const pPos = particlePoints.geometry.attributes.position.array as Float32Array;
+        const dt = 0.008; // base speed per frame
+        for (let i = 0; i < selectedParticleEdges.length; i++) {
+          const pe = selectedParticleEdges[i];
+          const l = pe.link;
+          const sId = typeof l.source === 'string' ? l.source : (l.source as unknown as GNode).id;
+          const tId = typeof l.target === 'string' ? l.target : (l.target as unknown as GNode).id;
+          const src = nodeMap.get(sId);
+          const tgt = nodeMap.get(tId);
+          if (!src || !tgt) continue;
+          // Advance t — speed proportional to edge weight
+          particleSpeeds[i] = (particleSpeeds[i] + dt * particleWeights[i]) % 1.0;
+          const t = particleSpeeds[i];
+          // Lerp position along edge
+          const sx = src.x ?? 0, sy = src.y ?? 0, sz = src.z ?? 0;
+          const tx = tgt.x ?? 0, ty = tgt.y ?? 0, tz = tgt.z ?? 0;
+          pPos[i * 3]     = sx + (tx - sx) * t;
+          pPos[i * 3 + 1] = sy + (ty - sy) * t;
+          pPos[i * 3 + 2] = sz + (tz - sz) * t;
+        }
+        particlePoints.geometry.attributes.position.needsUpdate = true;
+      }
 
       const activeNode = selectedNodeRef.current ?? hoveredNodeRef.current;
       const hidden = hiddenCategoriesRef.current;
@@ -905,13 +1255,14 @@ export function KnowledgeGraph3D({
           }
         }
 
-        // SIMILAR_TO edges
+        // SIMILAR_TO edges — highlight as bright neutral white, dim as near-black
+        const SIM_HIGHLIGHT = new THREE.Color('#999999');
         for (let i = 0; i < simLinks.length; i++) {
           const idx = i * 6;
           if (simConnSet.has(i)) {
-            colArr[idx]=colArr[idx+3]=activeColor.r*0.8;
-            colArr[idx+1]=colArr[idx+4]=activeColor.g*0.8;
-            colArr[idx+2]=colArr[idx+5]=activeColor.b*0.8;
+            colArr[idx]=colArr[idx+3]=SIM_HIGHLIGHT.r;
+            colArr[idx+1]=colArr[idx+4]=SIM_HIGHLIGHT.g;
+            colArr[idx+2]=colArr[idx+5]=SIM_HIGHLIGHT.b;
           } else {
             colArr[idx]=colArr[idx+3]=baseCol[idx]*0.12;
             colArr[idx+1]=colArr[idx+4]=baseCol[idx+1]*0.12;
@@ -919,17 +1270,17 @@ export function KnowledgeGraph3D({
           }
         }
         lineSegments.geometry.attributes.color.needsUpdate = true;
-        lineMat.opacity = 0.9;
+        lineMat.opacity = 0.35; // slightly brighter during hover, but still subtle
 
-        // Typed edges
+        // Typed edges — highlight with their OWN type color, not category color
         const compatConn = new Set(compatEdgeIdxRef.current.get(activeNode.id) ?? []);
         const altConn    = new Set(altEdgeIdxRef.current.get(activeNode.id) ?? []);
         const depConn    = new Set(depEdgeIdxRef.current.get(activeNode.id) ?? []);
         const extConn    = new Set(extEdgeIdxRef.current.get(activeNode.id) ?? []);
-        applyTypedHighlight(compatLineRef.current, compatLinks, compatConn, compatBaseColRef.current, COMPAT_VPE, activeColor, 0.12);
-        applyTypedHighlight(altLineRef.current,    altLinks,    altConn,    altBaseColRef.current,    ALT_VPE,    activeColor, 0.12);
-        applyTypedHighlight(depLineRef.current,    depLinks,    depConn,    depBaseColRef.current,    2,          activeColor, 0.12);
-        applyTypedHighlight(extLineRef.current,    extLinks,    extConn,    extBaseColRef.current,    EXT_VPE,    activeColor, 0.12);
+        applyTypedHighlight(compatLineRef.current, compatLinks, compatConn, compatBaseColRef.current, COMPAT_VPE, TYPED_RGB.COMPATIBLE_WITH, 0.12);
+        applyTypedHighlight(altLineRef.current,    altLinks,    altConn,    altBaseColRef.current,    ALT_VPE,    TYPED_RGB.ALTERNATIVE_TO, 0.12);
+        applyTypedHighlight(depLineRef.current,    depLinks,    depConn,    depBaseColRef.current,    2,          TYPED_RGB.DEPENDS_ON, 0.12);
+        applyTypedHighlight(extLineRef.current,    extLinks,    extConn,    extBaseColRef.current,    EXT_VPE,    TYPED_RGB.EXTENDS, 0.12);
 
         // Dep cones: per-instance highlight
         if (depConesRef.current) {
@@ -954,22 +1305,12 @@ export function KnowledgeGraph3D({
           nodeLabels[i].visible = false;
         }
 
-        // Reset SIMILAR_TO colors
-        for (let i = 0; i < colArr.length; i++) colArr[i] = baseCol[i];
-        lineSegments.geometry.attributes.color.needsUpdate = true;
-        lineMat.opacity = 0.5;
-
-        // Reset typed edge colors
-        resetTypedColors(compatLineRef.current, compatBaseColRef.current);
-        resetTypedColors(altLineRef.current,    altBaseColRef.current);
-        resetTypedColors(depLineRef.current,    depBaseColRef.current);
-        resetTypedColors(extLineRef.current,    extBaseColRef.current);
-
-        // Reset cone colors
-        if (depConesRef.current) {
-          for (let i = 0; i < depLinks.length; i++) depConesRef.current.setColorAt(i, TYPED_RGB.DEPENDS_ON);
-          depConesRef.current.instanceColor!.needsUpdate = true;
-        }
+        // Edge colors already set by the flowing animation above — just restore opacity
+        lineMat.opacity = 0.2;
+        if (compatLineRef.current) (compatLineRef.current.material as THREE.LineBasicMaterial).opacity = 0.8;
+        if (altLineRef.current)    (altLineRef.current.material as THREE.LineBasicMaterial).opacity = 0.8;
+        if (depLineRef.current)    (depLineRef.current.material as THREE.LineBasicMaterial).opacity = 0.8;
+        if (extLineRef.current)    (extLineRef.current.material as THREE.LineBasicMaterial).opacity = 0.8;
       }
 
       // Hide cluster labels for hidden categories
@@ -978,7 +1319,7 @@ export function KnowledgeGraph3D({
         sprite.visible = !hidden.has(cat);
       }
 
-      // Raycasting for hover — use click spheres (larger target area)
+      // Raycasting for hover — check nodes first, then cluster halos
       raycasterRef.current.setFromCamera(mouseRef.current, camera);
       const intersects = raycasterRef.current.intersectObjects(clickSpheres);
       if (intersects.length > 0) {
@@ -994,13 +1335,57 @@ export function KnowledgeGraph3D({
           setHoveredNode(node);
           setTooltipPos({ x, y });
           if (container) container.style.cursor = 'pointer';
+          // Clear cluster hover when hovering a node
+          if (hoveredClusterRef.current) {
+            hoveredClusterRef.current = null;
+            setHoveredCluster(null);
+            setClusterTooltipPos(null);
+          }
         }
       } else {
         if (hoveredNodeRef.current) {
           setHoveredNode(null);
           setTooltipPos(null);
         }
-        if (container) container.style.cursor = 'grab';
+        // Check invisible cluster hit-spheres when no node is hit
+        if (clusterHitSpheres.length > 0) {
+          const clusterIntersects = raycasterRef.current.intersectObjects(clusterHitSpheres);
+          if (clusterIntersects.length > 0) {
+            const hitObj = clusterIntersects[0].object;
+            const cat = hitObj.userData.category as string;
+            if (!hidden.has(cat) && hoveredClusterRef.current !== cat) {
+              hoveredClusterRef.current = cat;
+              // Compute top 3 most-connected repos in this category
+              const catNodes = nodes
+                .filter((n) => n.category === cat)
+                .sort((a, b) => b.connections - a.connections);
+              const topRepos = catNodes.slice(0, 3).map((n) => n.label);
+              setHoveredCluster({
+                category: cat,
+                nodeCount: hitObj.userData.nodeCount as number,
+                topRepos,
+              });
+              // Project cluster centroid to screen
+              const vec = hitObj.position.clone().project(camera);
+              const cw = containerSizeRef.current.w;
+              const ch = containerSizeRef.current.h;
+              setClusterTooltipPos({
+                x: (vec.x * 0.5 + 0.5) * cw,
+                y: (-vec.y * 0.5 + 0.5) * ch,
+              });
+            }
+            if (container) container.style.cursor = 'pointer';
+          } else {
+            if (hoveredClusterRef.current) {
+              hoveredClusterRef.current = null;
+              setHoveredCluster(null);
+              setClusterTooltipPos(null);
+            }
+            if (container) container.style.cursor = 'grab';
+          }
+        } else {
+          if (container) container.style.cursor = 'grab';
+        }
       }
 
       renderer.render(scene, camera);
@@ -1177,6 +1562,36 @@ export function KnowledgeGraph3D({
         </div>
       )}
 
+      {/* Cluster halo hover tooltip */}
+      {hoveredCluster && clusterTooltipPos && !selectedNode && !hoveredNode && (
+        <div
+          className="absolute pointer-events-none z-20 rounded-lg border border-zinc-700/80 bg-zinc-900/95 px-3 py-2.5 shadow-xl backdrop-blur-md"
+          style={{
+            left: Math.min(clusterTooltipPos.x + 16, (containerSizeRef.current.w) - 260),
+            top: Math.max(clusterTooltipPos.y - 60, 8),
+          }}
+        >
+          <p className="flex items-center gap-1.5 text-sm font-medium text-zinc-100">
+            <span
+              className="inline-block w-2.5 h-2.5 rounded-full"
+              style={{ backgroundColor: getCategoryColor(hoveredCluster.category) }}
+            />
+            {getCategoryLabel(hoveredCluster.category)}
+          </p>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            {hoveredCluster.nodeCount} repos in cluster
+          </p>
+          {hoveredCluster.topRepos.length > 0 && (
+            <div className="mt-1.5 border-t border-zinc-800 pt-1.5">
+              <p className="text-[10px] text-zinc-600 uppercase tracking-wider mb-1">Top connected</p>
+              {hoveredCluster.topRepos.map((name) => (
+                <p key={name} className="text-xs text-zinc-400 font-mono truncate">{name}</p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Selected node info panel */}
       {selectedNode && (
         <div
@@ -1278,32 +1693,37 @@ export function KnowledgeGraph3D({
         </div>
       )}
 
-      {/* Bottom legend bar — edge types above, category filters below */}
+      {/* Bottom legend bar — two clearly labeled sections */}
       <div className={`absolute ${
         isFullscreen ? 'bottom-4 left-2 right-2 sm:left-4 sm:right-4' : 'bottom-2 left-2 right-2'
-      } rounded-lg bg-zinc-900/80 backdrop-blur-sm px-2 sm:px-3 py-1.5 sm:py-2 z-10`}>
+      } rounded-lg bg-zinc-900/85 backdrop-blur-sm px-2 sm:px-3 py-1.5 sm:py-2 z-10`}>
 
-        {/* Edge type legend row */}
-        <div className="flex flex-wrap justify-center gap-x-3 gap-y-0.5 items-center border-b border-zinc-800 pb-1.5 mb-1.5">
+        {/* ── EDGE TYPES section ──────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 pb-1.5">
+          <span className="text-[9px] font-semibold uppercase tracking-wider text-zinc-500 mr-1">Edges</span>
           {[
-            { color: '#f59e0b', label: 'Alternative' },
-            { color: '#22c55e', label: 'Compatible'  },
-            { color: '#3b82f6', label: 'Dependency'  },
-            { color: '#f472b6', label: 'Extends'     },
+            { color: EDGE_TYPE_HEX.ALTERNATIVE_TO,  label: 'Alternative' },
+            { color: EDGE_TYPE_HEX.COMPATIBLE_WITH,  label: 'Compatible'  },
+            { color: EDGE_TYPE_HEX.DEPENDS_ON,       label: 'Dependency'  },
+            { color: EDGE_TYPE_HEX.EXTENDS,           label: 'Extends'     },
           ].map(({ color, label }) => (
-            <span key={label} className="inline-flex items-center gap-1.5 text-[9px] text-zinc-500">
-              <span className="inline-block w-4 h-px rounded" style={{ backgroundColor: color, opacity: 0.9 }} />
+            <span key={label} className="inline-flex items-center gap-1.5 text-[9px] text-zinc-400">
+              <span className="inline-block w-5 h-[2px] rounded-full" style={{ backgroundColor: color }} />
               {label}
             </span>
           ))}
-          <span className="inline-flex items-center gap-1.5 text-[9px] text-zinc-600">
-            <span className="inline-block w-4 h-px rounded bg-gradient-to-r from-violet-400 via-teal-400 to-amber-400 opacity-70" />
-            Similarity by cluster
+          <span className="inline-flex items-center gap-1.5 text-[9px] text-zinc-500">
+            <span className="inline-block w-5 h-[2px] rounded-full bg-gradient-to-r from-violet-400 via-teal-400 to-amber-400 opacity-70" />
+            Similarity
           </span>
         </div>
 
-        {/* Category filter row */}
-        <div className="flex flex-wrap justify-center gap-x-2 sm:gap-x-3 gap-y-1 items-center pb-0.5 sm:pb-0">
+        {/* Divider */}
+        <div className="border-t border-zinc-700/60 mb-1.5" />
+
+        {/* ── CATEGORIES section ──────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center justify-center gap-x-2 sm:gap-x-3 gap-y-1 pb-0.5 sm:pb-0">
+          <span className="text-[9px] font-semibold uppercase tracking-wider text-zinc-500 mr-1">Nodes</span>
           {activeCategories.map((cat) => {
             const isHidden = hiddenCategories.has(cat);
             return (
@@ -1324,7 +1744,6 @@ export function KnowledgeGraph3D({
                     opacity: isHidden ? 0.3 : 1,
                   }}
                 />
-                {/* Label hidden on mobile — dots only save ~40px of legend height */}
                 <span className={`hidden sm:inline ${isHidden ? 'text-zinc-600 line-through' : 'text-zinc-400'}`}>
                   {getCategoryLabel(cat)}
                 </span>

--- a/src/components/RepoCardMinimal.tsx
+++ b/src/components/RepoCardMinimal.tsx
@@ -76,8 +76,10 @@ export function RepoCardMinimal({ repo, onSelect, isSelected, isRelated, anySele
       onHoverEnd={() => setHovered(false)}
       style={{
         borderRadius: '0.5rem',
-        border: `1px solid ${borderColor}`,
         borderTop: `3px solid ${topBorderColor}`,
+        borderRight: `1px solid ${borderColor}`,
+        borderBottom: `1px solid ${borderColor}`,
+        borderLeft: `1px solid ${borderColor}`,
         boxShadow,
         backgroundColor: bgColor,
         backdropFilter: 'blur(20px) saturate(160%)',

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -67,7 +67,10 @@
   /* background-color set via inline style for category tint; glass fallback here */
   background: rgba(255,255,255,0.05);
   border-radius: 20px;
-  border: 1px solid rgba(255,255,255,0.12);
+  border-top: 1px solid rgba(255,255,255,0.12);
+  border-right: 1px solid rgba(255,255,255,0.12);
+  border-bottom: 1px solid rgba(255,255,255,0.12);
+  border-left: 1px solid rgba(255,255,255,0.12);
   box-shadow:
     0 8px 32px rgba(0,0,0,0.30),
     inset 0 1px 0 rgba(255,255,255,0.15),


### PR DESCRIPTION
## Summary

Recovers stashed work from April 9 that was never committed. Builds on the visual overhaul from PR #193 with a deeper physics and animation overhaul.

- **d3-force-3d** replaces `d3-force` — true native 3D Barnes-Hut octree physics, no more manual z-axis hack (`force3D` removed)
- **Quadrant seeding**: initial node positions seeded by dominant edge type (DEPENDS_ON→+X+Z, COMPATIBLE_WITH→-X+Z, ALTERNATIVE_TO→+X-Z, EXTENDS→-X-Z), Y from log2(connections)
- **Traveling wave animation** on all typed edges — brightness flows along edge direction per type
- **Edge flow particles** travel along high-degree edges when a node is selected
- **Cluster halo hover tooltips** — hovering a category halo shows category name, node count, top 3 most-connected repos
- **EDGE_TYPE_HEX** canonical hex map (single source of truth for 3D rendering + legend)
- **10,000 edge limit** option + `total_knowledge_graph_edges` counter in header
- SIMILAR_TO highlight as neutral white (not active-node category color)
- Typed edge highlight uses its own type color (not node category color)
- Legend: "Edges" / "Nodes" section labels, thicker 2px swatches

## Recovery context

Work was in `stash@{1}` on the local dev branch — stashed at `79a2845` before PR #193 landed, never re-applied. Cherry-picked onto main with one conflict resolved (HomeGraphWidget API_URL import → existing throw pattern).

## Test plan

- [ ] Graph page loads, nodes spread in 3D space (not vertical line)
- [ ] Edge type colors: ALTERNATIVE_TO=gold, COMPATIBLE_WITH=mint, DEPENDS_ON=blue, EXTENDS=orange
- [ ] Edges animate with traveling brightness wave
- [ ] Hover a category cluster halo → tooltip appears with count + top repos
- [ ] Select a node → flow particles animate along connected edges
- [ ] 10,000 edge option appears in limit dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)