### PR TITLE
KAN-164: Brighten Similarity legend entry to match other edge types

### DIFF
--- a/src/components/KnowledgeGraph3D.tsx
+++ b/src/components/KnowledgeGraph3D.tsx
@@ -1809,8 +1809,8 @@ export function KnowledgeGraph3D({
                 </span>
               ))}
             {presentEdgeTypes.has('SIMILAR_TO') && (
-              <span className="inline-flex items-center gap-1.5 text-[9px] text-zinc-500">
-                <span className="inline-block w-5 h-[2px] rounded-full bg-gradient-to-r from-violet-400 via-teal-400 to-amber-400 opacity-70" />
+              <span className="inline-flex items-center gap-1.5 text-[9px] text-zinc-400">
+                <span className="inline-block w-5 h-[2px] rounded-full bg-gradient-to-r from-violet-400 via-teal-400 to-amber-400" />
                 Similarity
               </span>
             )}


### PR DESCRIPTION
## Summary
- Aligns Similarity legend entry styling with Alternative/Dependency so all present edge types render at equal visual weight
- Removes `text-zinc-500` + swatch `opacity-70` (was too dim) → uses `text-zinc-400` + full-opacity gradient swatch

## Why hotfix to main
Per CLAUDE.md: "Hotfixes can go direct to main when urgent." Users currently see `Alternative` and `Dependency` keys but Similarity (the largest edge population) appears washed out / missing. This is a 2-line CSS-only change with no logic risk.

## Test plan
- [ ] Vercel preview renders Similarity entry at same brightness as Alternative/Dependency
- [ ] No regression on `/graph` page legend
- [ ] DOM check: `presentEdgeTypes.has('SIMILAR_TO')` branch still renders the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)