### PR TITLE
/ai-native: framework-first rewrite (strip demo logistics, add architecture diagram)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+- **/ai-native: framework-first rewrite** — stripped presentation logistics and Workato-centric framing; removed hardcoded stats (1,641 repos, $5.28 spend, 10 days to ship); replaced Live Demo slide with "What Makes Reporium AI-Native" architecture slide; expanded AI-Native Test from 3 to 4 questions to map 1:1 to the 4 AI-native layers; LLM references now model-agnostic (Claude/GPT/local); replaced CEO byline with neutral "A framework from building Reporium".
+
+### Added
+- **Architecture diagram on /ai-native** — inline SVG mapping 4 AI-native layers (Agent-accessible, Intelligence, Semantic, Compounding) and 3 cross-cutting bands (Observability, Governance, Performance) to real Reporium services from the verified reporium-api README. Responsive (1440/1024/768), accessible (aria-labels, role=img).
+
+### Removed
+- **/ai-native: Q&A close** — replaced with one-takeaway close.
+- **/ai-native: Live Demo slide** — no more Workato-centric demo script embedded in the public page.
+
 ### Added
 - **Knowledge Graph: Typed edge geometry** — Each relationship type now has a visually distinct style:
   - `SIMILAR_TO`: thin straight lines (unchanged baseline, best performance)

--- a/src/app/ai-native/page.tsx
+++ b/src/app/ai-native/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { SlideWrapper, childVariants } from '@/components/ai-native/SlideWrapper';
 import { SlideDots } from '@/components/ai-native/SlideDots';
 import { SlideProgress } from '@/components/ai-native/SlideProgress';
+import { ArchitectureDiagram } from '@/components/ai-native/ArchitectureDiagram';
 
 // ─── Inline icon components (lucide-react not installed) ──────────────────────
 
@@ -38,26 +39,17 @@ function IconLayers({ className = '', style }: { className?: string; style?: Rea
   );
 }
 
-function IconArrowRight({ className = '' }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
-      <line x1="5" y1="12" x2="19" y2="12" />
-      <polyline points="12 5 19 12 12 19" />
-    </svg>
-  );
-}
-
 // ─── Slide metadata ───────────────────────────────────────────────────────────
 
 const SLIDE_LABELS = [
-  'Title',
+  'Intro',
   'The Term Problem',
   'The AI-Native Test',
   'AI-Native vs AI-Added',
   'The Minimal Stack',
+  'What Makes Reporium AI-Native',
   '3 Mistakes',
   'How to Start',
-  'Live Demo',
   'One Takeaway',
 ];
 
@@ -99,12 +91,12 @@ function Eyebrow({ children, cyan = false }: { children: React.ReactNode; cyan?:
   );
 }
 
-// ─── Slide 1 — TITLE ─────────────────────────────────────────────────────────
+// ─── Slide 1 — HERO (Intro) ───────────────────────────────────────────────────
 
 function Slide1() {
   return (
     <SlideWrapper id="slide-0">
-      {/* Grid background on slide 1 */}
+      {/* Grid background */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 opacity-[0.09]"
@@ -130,63 +122,22 @@ function Slide1() {
           className="mt-4 text-3xl font-black leading-[1.1] tracking-tight sm:text-5xl md:text-6xl lg:text-7xl"
           style={{ color: '#f5d0fe', textShadow: neonFuchsia }}
         >
-          How to Build Your First
+          How to Build AI-Native Products
           <br />
-          <span style={{ color: '#a5f3fc', textShadow: neonCyan }}>AI-Native Product</span>
+          <span style={{ color: '#a5f3fc', textShadow: neonCyan }}>That Actually Work</span>
         </h1>
       </C>
 
       <C>
         <p className="mt-4 text-base text-zinc-400 sm:text-lg md:text-xl">
-          What &ldquo;AI-native&rdquo; actually means — and how to ship it
+          What AI-native actually means — and how to ship it
         </p>
       </C>
 
       <C>
         <p className="mt-2 font-mono text-sm text-zinc-500">
-          Kim Loza · CEO, Perditio Inc · Builder of Reporium
+          A framework from building Reporium
         </p>
-      </C>
-
-      {/* Stat pills */}
-      <C>
-        <div className="mt-8 flex flex-wrap gap-3">
-          {[
-            { value: '1,641', label: 'AI repos indexed' },
-            { value: '$5.28', label: 'total AI API spend' },
-            { value: '10 days', label: 'to ship v1' },
-          ].map(({ value, label }) => (
-            <div
-              key={label}
-              className="flex flex-col items-center rounded-xl border border-fuchsia-500/30 bg-fuchsia-950/30 px-5 py-3"
-              style={{ boxShadow: '0 0 20px rgba(217,70,239,0.12)' }}
-            >
-              <span
-                className="text-2xl font-black sm:text-3xl"
-                style={{ color: '#f0abfc', textShadow: neonFuchsia }}
-              >
-                {value}
-              </span>
-              <span className="mt-0.5 font-mono text-[11px] uppercase tracking-widest text-zinc-400">
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
-      </C>
-
-      {/* Badges */}
-      <C>
-        <div className="mt-6 flex flex-wrap items-center gap-2 text-xs text-zinc-500">
-          {['20 min talk', 'Live demo', 'Q&A 10 min'].map((b) => (
-            <span key={b} className="rounded-full border border-zinc-700 px-2.5 py-1">
-              {b}
-            </span>
-          ))}
-          <span className="rounded-full border border-cyan-500/40 px-2.5 py-1 text-cyan-400">
-            reporium.com
-          </span>
-        </div>
       </C>
     </SlideWrapper>
   );
@@ -262,29 +213,46 @@ function Slide2() {
 
       <C>
         <p className="mt-6 text-sm text-zinc-500 sm:text-base">
-          This talk gives you the framework to know the difference — and build the real thing.
+          This framework gives you the tools to know the difference — and build the real thing.
         </p>
       </C>
     </SlideWrapper>
   );
 }
 
-// ─── Slide 3 — THE AI-NATIVE TEST ────────────────────────────────────────────
+// ─── Slide 3 — THE AI-NATIVE TEST (4 Questions) ───────────────────────────────
 
 function Slide3() {
   const cards = [
     {
       num: '01',
+      layer: 'Intelligence layer',
+      layerColor: '#f0abfc',
+      layerBorder: 'rgba(217,70,239,0.35)',
       q: 'Does AI change the outcome — or just the interface?',
       body: 'If removing the AI leaves the product intact, you added AI. You didn\'t build AI-native.',
     },
     {
       num: '02',
-      q: 'Is intelligence a layer — or the foundation?',
-      body: 'AI-native means the data model, the query model, and the UX are all designed around how models think.',
+      layer: 'Semantic layer',
+      layerColor: '#67e8f9',
+      layerBorder: 'rgba(34,211,238,0.35)',
+      q: 'Is retrieval by meaning — or by strings?',
+      body: 'AI-native products understand queries semantically. Exact-match search is not AI-native retrieval.',
     },
     {
       num: '03',
+      layer: 'Agent-accessible layer',
+      layerColor: '#c084fc',
+      layerBorder: 'rgba(147,51,234,0.35)',
+      q: 'Can agents consume it as a first-class citizen?',
+      body: 'AI-native APIs are designed for both humans and agents. If only a browser can use it, you\'re half-done.',
+    },
+    {
+      num: '04',
+      layer: 'Compounding layer',
+      layerColor: '#6ee7b7',
+      layerBorder: 'rgba(52,211,153,0.35)',
       q: 'Does the product get smarter with use?',
       body: 'AI-native products compound. Every query, every edge, every interaction makes the next one better.',
     },
@@ -297,31 +265,38 @@ function Slide3() {
           className="text-2xl font-black sm:text-4xl md:text-5xl"
           style={{ color: '#f5d0fe', textShadow: neonFuchsia }}
         >
-          The AI-Native Test: 3 Questions
+          The AI-Native Test: 4 Questions
         </h2>
       </C>
       <C>
         <p className="mt-2 text-base text-zinc-400 sm:text-lg">
-          Ask these before you write a single line of code
+          Ask these before you write a single line of code — each maps to one of the 4 AI-native layers
         </p>
       </C>
 
       <C>
-        <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
-          {cards.map(({ num, q, body }) => (
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-4">
+          {cards.map(({ num, layer, layerColor, layerBorder, q, body }) => (
             <div
               key={num}
-              className="rounded-xl border border-cyan-500/20 bg-zinc-900/70 p-5"
+              className="rounded-xl border border-cyan-500/20 bg-zinc-900/70 p-4 flex flex-col"
               style={{ boxShadow: '0 0 16px rgba(34,211,238,0.06)' }}
             >
+              {/* Layer mini-badge */}
               <span
-                className="block font-mono text-3xl font-black"
+                className="mb-2 inline-block self-start rounded-full border px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.15em]"
+                style={{ color: layerColor, borderColor: layerBorder, background: `${layerBorder}` }}
+              >
+                {layer}
+              </span>
+              <span
+                className="block font-mono text-2xl font-black"
                 style={{ color: '#67e8f9', textShadow: neonCyan }}
               >
                 {num}
               </span>
-              <p className="mt-2 text-sm font-semibold text-zinc-100 sm:text-base">{q}</p>
-              <p className="mt-2 text-xs text-zinc-400 sm:text-sm">{body}</p>
+              <p className="mt-2 text-sm font-semibold text-zinc-100">{q}</p>
+              <p className="mt-2 text-xs text-zinc-400 flex-1">{body}</p>
             </div>
           ))}
         </div>
@@ -411,7 +386,7 @@ function Slide5() {
   const layers = [
     {
       name: 'Intelligence Layer',
-      tech: 'LLM API (Claude, GPT)',
+      tech: 'LLM API (model-agnostic — Claude, GPT, local)',
       desc: 'Answers, enrichment, classification',
       accent: '#f0abfc',
       border: 'rgba(217,70,239,0.4)',
@@ -484,16 +459,47 @@ function Slide5() {
 
       <C>
         <p className="mt-5 text-sm text-zinc-500">
-          Reporium uses this exact stack. Let me show you.
+          Reporium uses this exact stack.
         </p>
       </C>
     </SlideWrapper>
   );
 }
 
-// ─── Slide 6 — 3 MISTAKES ────────────────────────────────────────────────────
+// ─── Slide 6 — WHAT MAKES REPORIUM AI-NATIVE (Architecture) ──────────────────
 
 function Slide6() {
+  return (
+    <SlideWrapper id="slide-5">
+      <C>
+        <h2
+          className="text-2xl font-black sm:text-4xl md:text-5xl"
+          style={{ color: '#f5d0fe', textShadow: neonFuchsia }}
+        >
+          What Makes Reporium AI-Native
+        </h2>
+      </C>
+      <C>
+        <p className="mt-2 text-base text-zinc-400 sm:text-lg">
+          The framework, mapped to real services
+        </p>
+      </C>
+      <C>
+        <p className="mt-3 text-sm text-zinc-500 sm:text-base max-w-3xl">
+          Four AI-native layers — Agent-accessible, Intelligence, Semantic, Compounding — run vertically through every request. Three cross-cutting bands — Observability, Governance, Performance — span all layers to keep the system trustworthy and fast.
+        </p>
+      </C>
+
+      <C className="mt-4">
+        <ArchitectureDiagram />
+      </C>
+    </SlideWrapper>
+  );
+}
+
+// ─── Slide 7 — 3 MISTAKES ────────────────────────────────────────────────────
+
+function Slide7() {
   const mistakes = [
     {
       title: 'Starting with the model, not the problem',
@@ -507,13 +513,13 @@ function Slide6() {
     },
     {
       title: 'Making AI a feature instead of the foundation',
-      body: "A search bar that uses GPT is still just a search bar. AI-native means the product can't function without intelligence.",
+      body: "A search bar that uses an LLM is still just a search bar. AI-native means the product can't function without intelligence.",
       fix: '"Ask — if I removed the AI, does this product still exist?"',
     },
   ];
 
   return (
-    <SlideWrapper id="slide-5">
+    <SlideWrapper id="slide-6">
       <C>
         <h2
           className="text-2xl font-black sm:text-4xl md:text-5xl"
@@ -545,9 +551,9 @@ function Slide6() {
   );
 }
 
-// ─── Slide 7 — HOW TO START ───────────────────────────────────────────────────
+// ─── Slide 8 — HOW TO START ───────────────────────────────────────────────────
 
-function Slide7() {
+function Slide8() {
   const steps = [
     {
       n: '1',
@@ -562,7 +568,7 @@ function Slide7() {
     {
       n: '3',
       title: 'Pick the smallest useful model',
-      desc: 'Haiku for classification. Sonnet for answers. Don\'t over-engineer early.',
+      desc: 'Use a fast, cheap model for classification and a stronger one only when reasoning is actually needed. Don\'t over-engineer early.',
     },
     {
       n: '4',
@@ -577,7 +583,7 @@ function Slide7() {
   ];
 
   return (
-    <SlideWrapper id="slide-6">
+    <SlideWrapper id="slide-7">
       <C>
         <h2
           className="text-2xl font-black sm:text-4xl md:text-5xl"
@@ -614,88 +620,7 @@ function Slide7() {
   );
 }
 
-// ─── Slide 8 — LIVE DEMO ─────────────────────────────────────────────────────
-
-function Slide8() {
-  const steps = [
-    { n: '01', title: 'Open reporium.com', desc: '1,641 AI repos — indexed, categorized, live' },
-    { n: '02', title: 'Run a semantic query', desc: '"Show me repos that do RAG with pgvector"' },
-    {
-      n: '03',
-      title: 'Ask the intelligence endpoint',
-      desc: 'Natural language → Reporium-powered answer with citations',
-    },
-    {
-      n: '04',
-      title: '[Optional] MCP sandbox',
-      desc: 'Show how Workato tooling could surface the same data to agents',
-    },
-  ];
-
-  return (
-    <SlideWrapper id="slide-7">
-      {/* Radial glow background */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            'radial-gradient(ellipse 70% 60% at 50% 50%, rgba(34,211,238,0.07) 0%, transparent 70%)',
-        }}
-      />
-
-      <C>
-        <span
-          className="inline-block rounded-full border border-cyan-400/50 bg-cyan-950/30 px-4 py-1.5 font-mono text-sm font-bold uppercase tracking-[0.25em] sm:text-base"
-          style={{ color: '#67e8f9', textShadow: neonCyan, boxShadow: '0 0 20px rgba(34,211,238,0.25)' }}
-        >
-          ▶ LIVE DEMO
-        </span>
-      </C>
-
-      <C>
-        <a
-          href="/"
-          className="mt-4 block text-4xl font-black leading-tight tracking-tight hover:opacity-80 sm:text-6xl md:text-7xl"
-          style={{ color: '#a5f3fc', textShadow: neonCyan }}
-        >
-          reporium.com
-          <IconArrowRight className="ml-2 inline-block h-8 w-8 sm:h-12 sm:w-12" />
-        </a>
-      </C>
-
-      <C>
-        <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {steps.map(({ n, title, desc }) => (
-            <div
-              key={n}
-              className="flex items-start gap-3 rounded-xl border border-cyan-500/20 bg-zinc-900/70 p-4"
-            >
-              <span
-                className="shrink-0 font-mono text-xl font-black"
-                style={{ color: '#67e8f9', textShadow: neonCyan }}
-              >
-                {n}
-              </span>
-              <div>
-                <p className="text-sm font-semibold text-zinc-100 sm:text-base">{title}</p>
-                <p className="mt-0.5 text-xs italic text-zinc-400 sm:text-sm">{desc}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </C>
-
-      <C>
-        <p className="mt-5 text-sm italic text-zinc-500">
-          The point isn&rsquo;t Reporium. The point is what AI-native looks like when it&rsquo;s working.
-        </p>
-      </C>
-    </SlideWrapper>
-  );
-}
-
-// ─── Slide 9 — THE ONE TAKEAWAY ───────────────────────────────────────────────
+// ─── Slide 9 — ONE TAKEAWAY ───────────────────────────────────────────────────
 
 function Slide9() {
   const checks = [
@@ -754,9 +679,8 @@ function Slide9() {
 
       <C>
         <div className="mt-8 border-t border-zinc-800 pt-6">
-          <p className="font-mono text-xl font-bold text-zinc-300 sm:text-2xl">Q&amp;A</p>
-          <p className="mt-3 text-xs text-zinc-500 sm:text-sm">
-            Kim Loza · reporium.com · github.com/perditioinc
+          <p className="font-mono text-xs text-zinc-500">
+            reporium.com · github.com/perditioinc
           </p>
         </div>
       </C>

--- a/src/components/ai-native/ArchitectureDiagram.tsx
+++ b/src/components/ai-native/ArchitectureDiagram.tsx
@@ -1,0 +1,679 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+// ─── Color tokens (matching reporium.com visual style) ─────────────────────
+const LAYER_COLORS = {
+  agentAccessible: {
+    fill: 'rgba(147,51,234,0.08)',
+    stroke: 'rgba(147,51,234,0.45)',
+    text: '#c084fc',
+    badge: 'rgba(147,51,234,0.18)',
+  },
+  intelligence: {
+    fill: 'rgba(217,70,239,0.08)',
+    stroke: 'rgba(217,70,239,0.45)',
+    text: '#f0abfc',
+    badge: 'rgba(217,70,239,0.18)',
+  },
+  semantic: {
+    fill: 'rgba(34,211,238,0.08)',
+    stroke: 'rgba(34,211,238,0.45)',
+    text: '#67e8f9',
+    badge: 'rgba(34,211,238,0.18)',
+  },
+  compounding: {
+    fill: 'rgba(52,211,153,0.08)',
+    stroke: 'rgba(52,211,153,0.45)',
+    text: '#6ee7b7',
+    badge: 'rgba(52,211,153,0.18)',
+  },
+} as const;
+
+const BAND_COLORS = {
+  observability: {
+    fill: 'rgba(251,191,36,0.06)',
+    stroke: 'rgba(251,191,36,0.35)',
+    text: '#fcd34d',
+    itemColor: 'rgba(253,211,77,0.8)',
+  },
+  governance: {
+    fill: 'rgba(239,68,68,0.06)',
+    stroke: 'rgba(239,68,68,0.35)',
+    text: '#fca5a5',
+    itemColor: 'rgba(252,165,165,0.8)',
+  },
+  performance: {
+    fill: 'rgba(99,102,241,0.06)',
+    stroke: 'rgba(99,102,241,0.35)',
+    text: '#a5b4fc',
+    itemColor: 'rgba(165,180,252,0.8)',
+  },
+} as const;
+
+// ─── SVG sub-components (defined at module level to avoid react-hooks/static-components) ──
+
+interface CompBoxProps {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  label: string;
+  sublabel?: string;
+  accent: string;
+  textColor: string;
+}
+
+function CompBox({ x, y, w, h, label, sublabel, accent, textColor }: CompBoxProps) {
+  return (
+    <g>
+      <rect
+        x={x} y={y} width={w} height={h} rx={6} ry={6}
+        fill="rgba(9,9,17,0.75)"
+        stroke={accent}
+        strokeWidth={1}
+      />
+      <text x={x + 8} y={y + 14} fontSize={10} fontFamily="monospace" fill={textColor} fontWeight="600">
+        {label}
+      </text>
+      {sublabel && (
+        <text x={x + 8} y={y + 26} fontSize={8.5} fontFamily="monospace" fill="rgba(161,161,170,0.8)">
+          {sublabel}
+        </text>
+      )}
+    </g>
+  );
+}
+
+interface LayerRowProps {
+  layerX: number;
+  layerW: number;
+  y: number;
+  h: number;
+  label: string;
+  caption: string;
+  colors: (typeof LAYER_COLORS)[keyof typeof LAYER_COLORS];
+  children: React.ReactNode;
+}
+
+function LayerRow({ layerX, layerW, y, h, label, caption, colors, children }: LayerRowProps) {
+  return (
+    <g aria-label={`${label} layer`}>
+      <rect
+        x={layerX} y={y} width={layerW} height={h} rx={10} ry={10}
+        fill={colors.fill} stroke={colors.stroke} strokeWidth={1.5}
+      />
+      {/* Layer name badge */}
+      <rect x={layerX + 10} y={y + 8} width={130} height={18} rx={4} ry={4} fill={colors.badge} />
+      <text
+        x={layerX + 18} y={y + 20}
+        fontSize={9} fontFamily="monospace"
+        fill={colors.text} fontWeight="700" letterSpacing="0.08em" textAnchor="start"
+      >
+        {label.toUpperCase()}
+      </text>
+      <text
+        x={layerX + 148} y={y + 20}
+        fontSize={8.5} fontFamily="sans-serif"
+        fill="rgba(161,161,170,0.75)" fontStyle="italic"
+      >
+        {caption}
+      </text>
+      {children}
+    </g>
+  );
+}
+
+// ─── Desktop SVG (≥ 768px) ──────────────────────────────────────────────────
+
+function DesktopDiagram() {
+  const W = 960;
+  const H = 580;
+
+  const layerX = 16;
+  const layerW = 700;
+  const layerGap = 8;
+
+  const rowH = [110, 124, 144, 110];
+  const totalLayerH = rowH.reduce((a, b) => a + b, 0) + layerGap * 3;
+  const layerY = (H - totalLayerH) / 2;
+
+  const rowY: number[] = [];
+  let curY = layerY;
+  for (const h of rowH) {
+    rowY.push(curY);
+    curY += h + layerGap;
+  }
+
+  const bandX = layerX + layerW + 16;
+  const bandW = W - bandX - 16;
+  const bandH = (totalLayerH - 8) / 3;
+  const bandY0 = layerY;
+
+  const arrowId = 'arch-arrow';
+  const arrowUpId = 'arch-arrow-up';
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-labelledby="arch-title arch-desc"
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title id="arch-title">Reporium AI-Native Architecture</title>
+      <desc id="arch-desc">
+        Four AI-native layers (Agent-accessible, Intelligence, Semantic, Compounding) with three cross-cutting bands
+        (Observability, Governance, Performance) mapping to real Reporium services.
+      </desc>
+
+      <defs>
+        <marker id={arrowId} markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(34,211,238,0.7)" />
+        </marker>
+        <marker id={arrowUpId} markerWidth="8" markerHeight="8" refX="2" refY="3" orient="auto">
+          <path d="M8,0 L8,6 L0,3 z" fill="rgba(52,211,153,0.7)" />
+        </marker>
+      </defs>
+
+      {/* ── Layer 1: Agent-accessible ──────────────────────────────────── */}
+      <LayerRow
+        layerX={layerX} layerW={layerW}
+        y={rowY[0]} h={rowH[0]}
+        label="Agent-accessible"
+        caption="Agents consume this as a first-class citizen"
+        colors={LAYER_COLORS.agentAccessible}
+      >
+        <CompBox
+          x={layerX + 10} y={rowY[0] + 34} w={148} h={64}
+          label="Reporium Web" sublabel="Next.js · Vercel · human readers"
+          accent="rgba(147,51,234,0.5)" textColor="#c084fc"
+        />
+        <CompBox
+          x={layerX + 168} y={rowY[0] + 34} w={130} h={64}
+          label="reporium-mcp" sublabel="MCP protocol · agent readers"
+          accent="rgba(147,51,234,0.5)" textColor="#c084fc"
+        />
+        <CompBox
+          x={layerX + 308} y={rowY[0] + 34} w={230} h={64}
+          label="External orchestrators"
+          sublabel="Workato · LangChain · Claude Desktop · custom"
+          accent="rgba(147,51,234,0.4)" textColor="#c084fc"
+        />
+      </LayerRow>
+
+      {/* Query path arrow: Agent-accessible → Intelligence */}
+      <line
+        x1={layerX + 80} y1={rowY[0] + rowH[0]}
+        x2={layerX + 80} y2={rowY[1]}
+        stroke="rgba(34,211,238,0.55)" strokeWidth={1.5} strokeDasharray="4 3"
+        markerEnd={`url(#${arrowId})`}
+      />
+      <text
+        x={layerX + 86} y={rowY[0] + rowH[0] + 5}
+        fontSize={7.5} fontFamily="monospace" fill="rgba(34,211,238,0.6)"
+      >
+        query path ↓
+      </text>
+
+      {/* ── Layer 2: Intelligence ──────────────────────────────────────── */}
+      <LayerRow
+        layerX={layerX} layerW={layerW}
+        y={rowY[1]} h={rowH[1]}
+        label="Intelligence"
+        caption="AI is in the decision loop"
+        colors={LAYER_COLORS.intelligence}
+      >
+        {/* reporium-api box with sub-items */}
+        <rect
+          x={layerX + 10} y={rowY[1] + 34} width={200} height={78} rx={6} ry={6}
+          fill="rgba(9,9,17,0.75)" stroke="rgba(217,70,239,0.5)" strokeWidth={1}
+        />
+        <text x={layerX + 18} y={rowY[1] + 48} fontSize={10} fontFamily="monospace" fill="#f0abfc" fontWeight="600">
+          reporium-api
+        </text>
+        <text x={layerX + 18} y={rowY[1] + 60} fontSize={8.5} fontFamily="monospace" fill="rgba(161,161,170,0.8)">
+          FastAPI · Cloud Run
+        </text>
+        <text x={layerX + 18} y={rowY[1] + 74} fontSize={8} fontFamily="monospace" fill="rgba(161,161,170,0.65)">
+          public reads / ingest (keyed)
+        </text>
+        <text x={layerX + 18} y={rowY[1] + 86} fontSize={8} fontFamily="monospace" fill="rgba(161,161,170,0.65)">
+          admin (keyed) / Scalar docs
+        </text>
+        <text x={layerX + 18} y={rowY[1] + 102} fontSize={8} fontFamily="monospace" fill="rgba(161,161,170,0.65)">
+          rate-limited · Sentry-instrumented
+        </text>
+
+        <CompBox
+          x={layerX + 220} y={rowY[1] + 34} w={185} h={36}
+          label="LLM enrichment"
+          sublabel="model-agnostic — Claude, GPT, local"
+          accent="rgba(217,70,239,0.5)" textColor="#f0abfc"
+        />
+        <CompBox
+          x={layerX + 220} y={rowY[1] + 76} w={185} h={36}
+          label="Pub/Sub event bus"
+          sublabel="topic: repo-ingested"
+          accent="rgba(217,70,239,0.4)" textColor="#f0abfc"
+        />
+      </LayerRow>
+
+      {/* Query path arrow: Intelligence → Semantic */}
+      <line
+        x1={layerX + 80} y1={rowY[1] + rowH[1]}
+        x2={layerX + 80} y2={rowY[2]}
+        stroke="rgba(34,211,238,0.55)" strokeWidth={1.5} strokeDasharray="4 3"
+        markerEnd={`url(#${arrowId})`}
+      />
+
+      {/* ── Layer 3: Semantic ──────────────────────────────────────────── */}
+      <LayerRow
+        layerX={layerX} layerW={layerW}
+        y={rowY[2]} h={rowH[2]}
+        label="Semantic"
+        caption="Retrieval is by meaning, not strings"
+        colors={LAYER_COLORS.semantic}
+      >
+        <CompBox
+          x={layerX + 10} y={rowY[2] + 34} w={165} h={98}
+          label="Postgres + pgvector"
+          sublabel="Cloud SQL · managed backups"
+          accent="rgba(34,211,238,0.5)" textColor="#67e8f9"
+        />
+        {/* inner details rendered as plain text elements */}
+        <text x={layerX + 18} y={rowY[2] + 84} fontSize={8} fontFamily="monospace" fill="rgba(103,232,249,0.7)">
+          repo_embeddings
+        </text>
+        <text x={layerX + 18} y={rowY[2] + 95} fontSize={7.5} fontFamily="monospace" fill="rgba(161,161,170,0.6)">
+          384-dim · HNSW · vector_cosine_ops
+        </text>
+        <text x={layerX + 18} y={rowY[2] + 107} fontSize={8} fontFamily="monospace" fill="rgba(103,232,249,0.7)">
+          taxonomy_values
+        </text>
+        <text x={layerX + 18} y={rowY[2] + 118} fontSize={7.5} fontFamily="monospace" fill="rgba(161,161,170,0.6)">
+          8 dynamic dimensions · embedded
+        </text>
+        <text x={layerX + 18} y={rowY[2] + 129} fontSize={7.5} fontFamily="monospace" fill="rgba(161,161,170,0.6)">
+          cosine ≥ 0.65 taxonomy assignment
+        </text>
+
+        <CompBox
+          x={layerX + 185} y={rowY[2] + 34} w={200} h={40}
+          label="GCS snapshot"
+          sublabel="read fallback for /graph/edges"
+          accent="rgba(34,211,238,0.4)" textColor="#67e8f9"
+        />
+        <CompBox
+          x={layerX + 185} y={rowY[2] + 82} w={200} h={50}
+          label="Redis cache (optional)"
+          sublabel="/library/full · 5-min TTL · HNSW approx-NN"
+          accent="rgba(34,211,238,0.35)" textColor="#67e8f9"
+        />
+      </LayerRow>
+
+      {/* Ingest flow arrow: Compounding → Semantic (up) */}
+      <line
+        x1={layerX + 200} y1={rowY[3]}
+        x2={layerX + 200} y2={rowY[2] + rowH[2] + layerGap}
+        stroke="rgba(52,211,153,0.55)" strokeWidth={1.5} strokeDasharray="4 3"
+        markerEnd={`url(#${arrowUpId})`}
+      />
+      <text
+        x={layerX + 206} y={rowY[3] - 2}
+        fontSize={7.5} fontFamily="monospace" fill="rgba(52,211,153,0.6)"
+      >
+        ingest flow ↑
+      </text>
+
+      {/* ── Layer 4: Compounding ──────────────────────────────────────── */}
+      <LayerRow
+        layerX={layerX} layerW={layerW}
+        y={rowY[3]} h={rowH[3]}
+        label="Compounding"
+        caption="Every ingest makes the next query better"
+        colors={LAYER_COLORS.compounding}
+      >
+        <CompBox
+          x={layerX + 10} y={rowY[3] + 34} w={300} h={64}
+          label="reporium-ingestion"
+          sublabel="Cloud Run Job · nightly: pull → LLM enrich → POST /ingest/repos → publish repo.ingested"
+          accent="rgba(52,211,153,0.5)" textColor="#6ee7b7"
+        />
+        <CompBox
+          x={layerX + 320} y={rowY[3] + 34} w={230} h={64}
+          label="forksync"
+          sublabel="Cloud Run Job · nightly: keeps forks aligned with upstreams"
+          accent="rgba(52,211,153,0.45)" textColor="#6ee7b7"
+        />
+      </LayerRow>
+
+      {/* ── Cross-cutting bands ─────────────────────────────────────────── */}
+
+      {/* Observability */}
+      <g aria-label="Observability band">
+        <rect
+          x={bandX} y={bandY0} width={bandW} height={bandH} rx={8} ry={8}
+          fill={BAND_COLORS.observability.fill} stroke={BAND_COLORS.observability.stroke} strokeWidth={1.5}
+        />
+        <text
+          x={bandX + bandW / 2} y={bandY0 + 16}
+          fontSize={9} fontFamily="monospace"
+          fill={BAND_COLORS.observability.text} fontWeight="700" textAnchor="middle" letterSpacing="0.1em"
+        >
+          OBSERVABILITY
+        </text>
+        {[
+          '/health (DB, Redis, last ingestion)',
+          '/admin/data-quality',
+          'ingestion_log table',
+          'observability/ directory',
+          'Scalar API docs (/docs)',
+        ].map((item, i) => (
+          <text
+            key={item}
+            x={bandX + 10} y={bandY0 + 32 + i * 14}
+            fontSize={8.5} fontFamily="monospace" fill={BAND_COLORS.observability.itemColor}
+          >
+            {item}
+          </text>
+        ))}
+      </g>
+
+      {/* Governance */}
+      <g aria-label="Governance band">
+        <rect
+          x={bandX} y={bandY0 + bandH + 6} width={bandW} height={bandH} rx={8} ry={8}
+          fill={BAND_COLORS.governance.fill} stroke={BAND_COLORS.governance.stroke} strokeWidth={1.5}
+        />
+        <text
+          x={bandX + bandW / 2} y={bandY0 + bandH + 6 + 16}
+          fontSize={9} fontFamily="monospace"
+          fill={BAND_COLORS.governance.text} fontWeight="700" textAnchor="middle" letterSpacing="0.1em"
+        >
+          GOVERNANCE
+        </text>
+        {[
+          'X-Ingest-Key (ingest writes)',
+          'X-Admin-Key (admin ops)',
+          'GCP Secret Manager',
+          'SECURITY_AUDIT.md',
+        ].map((item, i) => (
+          <text
+            key={item}
+            x={bandX + 10} y={bandY0 + bandH + 6 + 32 + i * 14}
+            fontSize={8.5} fontFamily="monospace" fill={BAND_COLORS.governance.itemColor}
+          >
+            {item}
+          </text>
+        ))}
+      </g>
+
+      {/* Performance */}
+      <g aria-label="Performance band">
+        <rect
+          x={bandX} y={bandY0 + (bandH + 6) * 2} width={bandW} height={bandH} rx={8} ry={8}
+          fill={BAND_COLORS.performance.fill} stroke={BAND_COLORS.performance.stroke} strokeWidth={1.5}
+        />
+        <text
+          x={bandX + bandW / 2} y={bandY0 + (bandH + 6) * 2 + 16}
+          fontSize={9} fontFamily="monospace"
+          fill={BAND_COLORS.performance.text} fontWeight="700" textAnchor="middle" letterSpacing="0.1em"
+        >
+          PERFORMANCE
+        </text>
+        {[
+          'Redis cache (optional)',
+          '/library/full (5-min cache)',
+          'HNSW approximate-NN',
+          'GCS snapshot read fallback',
+        ].map((item, i) => (
+          <text
+            key={item}
+            x={bandX + 10} y={bandY0 + (bandH + 6) * 2 + 32 + i * 14}
+            fontSize={8.5} fontFamily="monospace" fill={BAND_COLORS.performance.itemColor}
+          >
+            {item}
+          </text>
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+// ─── Mobile SVG (< 768px): layers stacked, bands below ─────────────────────
+
+const MOBILE_LAYERS = [
+  {
+    key: 'agent',
+    label: 'Agent-accessible',
+    caption: 'Agents consume this as a first-class citizen',
+    colors: LAYER_COLORS.agentAccessible,
+    items: [
+      'Reporium Web (Next.js · human readers)',
+      'reporium-mcp (MCP protocol · agent readers)',
+      'External orchestrators',
+      '  Workato · LangChain · Claude Desktop · custom',
+    ],
+  },
+  {
+    key: 'intelligence',
+    label: 'Intelligence',
+    caption: 'AI is in the decision loop',
+    colors: LAYER_COLORS.intelligence,
+    items: [
+      'reporium-api (FastAPI · Cloud Run)',
+      '  public reads / ingest (keyed) / admin (keyed)',
+      'LLM enrichment (model-agnostic — Claude, GPT, local)',
+      'Pub/Sub event bus (topic: repo-ingested)',
+    ],
+  },
+  {
+    key: 'semantic',
+    label: 'Semantic',
+    caption: 'Retrieval is by meaning, not strings',
+    colors: LAYER_COLORS.semantic,
+    items: [
+      'Postgres + pgvector (Cloud SQL)',
+      'repo_embeddings — 384-dim · HNSW · vector_cosine_ops',
+      'taxonomy_values — 8 dynamic dimensions · embedded',
+      'cosine ≥ 0.65 taxonomy assignment',
+      'GCS snapshot (read fallback for /graph/edges)',
+    ],
+  },
+  {
+    key: 'compounding',
+    label: 'Compounding',
+    caption: 'Every ingest makes the next query better',
+    colors: LAYER_COLORS.compounding,
+    items: [
+      'reporium-ingestion (Cloud Run Job · nightly)',
+      '  pull → LLM enrich → POST /ingest/repos → publish repo.ingested',
+      'forksync (Cloud Run Job · nightly)',
+      '  keeps forks aligned with upstreams',
+    ],
+  },
+];
+
+const MOBILE_BANDS = [
+  {
+    key: 'observability',
+    label: 'OBSERVABILITY',
+    colors: BAND_COLORS.observability,
+    items: [
+      '/health (DB, Redis, last ingestion)',
+      '/admin/data-quality',
+      'ingestion_log table',
+      'observability/ directory',
+      'Scalar API docs (/docs)',
+    ],
+  },
+  {
+    key: 'governance',
+    label: 'GOVERNANCE',
+    colors: BAND_COLORS.governance,
+    items: [
+      'X-Ingest-Key (ingest writes)',
+      'X-Admin-Key (admin ops)',
+      'GCP Secret Manager',
+      'SECURITY_AUDIT.md',
+    ],
+  },
+  {
+    key: 'performance',
+    label: 'PERFORMANCE',
+    colors: BAND_COLORS.performance,
+    items: [
+      'Redis cache (optional)',
+      '/library/full (5-min cache)',
+      'HNSW approximate-NN',
+      'GCS snapshot read fallback',
+    ],
+  },
+];
+
+function MobileDiagram() {
+  const W = 480;
+  const rowH = 90;
+  const rowGap = 8;
+  const arrowH = 20;
+  const layersTotalH =
+    MOBILE_LAYERS.length * rowH + (MOBILE_LAYERS.length - 1) * (rowGap + arrowH);
+
+  const bandH = 90;
+  const bandGap = 8;
+  const bandsStartY = layersTotalH + 20;
+  const totalH =
+    bandsStartY + MOBILE_BANDS.length * bandH + (MOBILE_BANDS.length - 1) * bandGap + 10;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${totalH}`}
+      role="img"
+      aria-labelledby="arch-title-m arch-desc-m"
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title id="arch-title-m">Reporium AI-Native Architecture</title>
+      <desc id="arch-desc-m">
+        Four AI-native layers (Agent-accessible, Intelligence, Semantic, Compounding) with three
+        cross-cutting bands (Observability, Governance, Performance) mapping to real Reporium services.
+      </desc>
+
+      <defs>
+        <marker id="m-arrow-down" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(34,211,238,0.7)" />
+        </marker>
+      </defs>
+
+      {MOBILE_LAYERS.map((layer, li) => {
+        const y = li * (rowH + rowGap + arrowH);
+        return (
+          <g key={layer.key} aria-label={`${layer.label} layer`}>
+            <rect
+              x={8} y={y} width={W - 16} height={rowH} rx={8} ry={8}
+              fill={layer.colors.fill} stroke={layer.colors.stroke} strokeWidth={1.5}
+            />
+            {/* Badge */}
+            <rect x={16} y={y + 8} width={130} height={16} rx={4} ry={4} fill={layer.colors.badge} />
+            <text
+              x={24} y={y + 19}
+              fontSize={8.5} fontFamily="monospace"
+              fill={layer.colors.text} fontWeight="700" letterSpacing="0.08em"
+            >
+              {layer.label.toUpperCase()}
+            </text>
+            {/* Caption */}
+            <text
+              x={154} y={y + 19}
+              fontSize={8} fontFamily="sans-serif"
+              fill="rgba(161,161,170,0.7)" fontStyle="italic"
+            >
+              {layer.caption}
+            </text>
+            {/* Items */}
+            {layer.items.map((item, ii) => (
+              <text
+                key={`${layer.key}-item-${ii}`}
+                x={16} y={y + 36 + ii * 13}
+                fontSize={8.5} fontFamily="monospace" fill="rgba(228,228,231,0.85)"
+              >
+                {item}
+              </text>
+            ))}
+            {/* Arrow between layers */}
+            {li < MOBILE_LAYERS.length - 1 && (
+              <line
+                x1={W / 2} y1={y + rowH}
+                x2={W / 2} y2={y + rowH + arrowH}
+                stroke="rgba(34,211,238,0.5)" strokeWidth={1.5} strokeDasharray="3 2"
+                markerEnd="url(#m-arrow-down)"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      {/* Cross-cutting bands label */}
+      <text
+        x={W / 2} y={bandsStartY - 6}
+        fontSize={8.5} fontFamily="monospace"
+        fill="rgba(161,161,170,0.6)" textAnchor="middle" letterSpacing="0.12em"
+      >
+        CROSS-CUTTING CONCERNS
+      </text>
+
+      {MOBILE_BANDS.map((band, bi) => {
+        const y = bandsStartY + bi * (bandH + bandGap);
+        return (
+          <g key={band.key} aria-label={`${band.label} band`}>
+            <rect
+              x={8} y={y} width={W - 16} height={bandH} rx={8} ry={8}
+              fill={band.colors.fill} stroke={band.colors.stroke} strokeWidth={1.5}
+            />
+            <text
+              x={W / 2} y={y + 16}
+              fontSize={9} fontFamily="monospace"
+              fill={band.colors.text} fontWeight="700" textAnchor="middle" letterSpacing="0.1em"
+            >
+              {band.label}
+            </text>
+            {band.items.map((item, ii) => (
+              <text
+                key={`${band.key}-item-${ii}`}
+                x={16} y={y + 30 + ii * 14}
+                fontSize={8.5} fontFamily="monospace" fill="rgba(228,228,231,0.8)"
+              >
+                {item}
+              </text>
+            ))}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ─── Public component ────────────────────────────────────────────────────────
+
+export function ArchitectureDiagram() {
+  // Initialize to false (desktop); hydrate on mount to avoid SSR mismatch
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    // Use a callback form so we read the value once during the effect, not synchronously
+    const update = (matches: boolean) => setIsMobile(matches);
+    update(mq.matches);
+    const handler = (e: MediaQueryListEvent) => update(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return (
+    <div
+      className="w-full rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 sm:p-4"
+      style={{ boxShadow: '0 0 32px rgba(34,211,238,0.06), 0 0 64px rgba(217,70,239,0.05)' }}
+    >
+      {isMobile ? <MobileDiagram /> : <DesktopDiagram />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Rewrite `/ai-native` as a public-facing framework page instead of a Workato-interview teleprompter.
- Strip all presentation logistics, hardcoded stats, and Claude-only / Workato-centric framing.
- Replace the embedded "▶ LIVE DEMO" slide with a new "What Makes Reporium AI-Native" slide backed by an inline SVG architecture diagram that maps the 4 AI-native layers (Agent-accessible, Intelligence, Semantic, Compounding) and 3 cross-cutting bands (Observability, Governance, Performance) to real services verified against [reporium-api/README.md](https://github.com/perditioinc/reporium-api/blob/main/README.md).

## What changed

| File | Action |
|---|---|
| `src/app/ai-native/page.tsx` | Rewritten — 802 lines (down from 878). 9 slides, all framework-first. |
| `src/components/ai-native/ArchitectureDiagram.tsx` | **New.** Inline SVG with desktop + mobile variants. `role=img`, `aria-labels`. |
| `CHANGELOG.md` | New entries under `[Unreleased]`. |

### Hard constraints — grep check (all 0 hits in `src/app/ai-native/` and `src/components/ai-native/ArchitectureDiagram.tsx`)

```
grep -n "1,641\|5\.28\|10 days\|CEO\|Perditio Inc\|Q&A\|Q&amp;A\|20 min\|Live Demo\|LIVE DEMO\|3 recipes\|Haiku\|Sonnet"   src/app/ai-native/page.tsx   src/components/ai-native/ArchitectureDiagram.tsx
→ no matches
```

### Real-component verification

Every repo / endpoint / schema detail in the architecture diagram is confirmed in [reporium-api/README.md](https://github.com/perditioinc/reporium-api/blob/main/README.md):

- **Repos** (all resolve at github.com/perditioinc): `reporium`, `reporium-api`, `reporium-mcp`, `reporium-ingestion`, `forksync`.
- **Schema**: 384-dim `all-MiniLM-L6-v2`, HNSW `vector_cosine_ops`, 8 dynamic taxonomy dimensions, cosine ≥ 0.65 for taxonomy assignment.
- **Auth**: `X-Ingest-Key` / `X-Admin-Key` (both in README §Auth).
- **Endpoints**: `/health`, `/admin/data-quality`, `/library/full`, `/graph/edges`, `/docs` (all in README §Endpoints).
- **Infra**: Postgres+pgvector on Cloud SQL, GCP Pub/Sub topic `repo-ingested`, GCS snapshot fallback, Redis cache (optional), GCP Secret Manager (all in README).

Did **NOT** invent `reporium-events` / `reporium-db` / `reporium-metrics` as standalone diagram components — those are logical boxes inside `reporium-api`, not separate repos. Did **NOT** include Haiku/Sonnet tiering — not verified.

### AI-Native Test ↔ Architecture layer mapping (new in Slide 3)

The 4 test questions now map 1:1 to the 4 architecture layers in Slide 6:

| Q# | Question | Layer |
|---|---|---|
| 01 | Does AI change the outcome — or just the interface? | Intelligence |
| 02 | Is retrieval by meaning — or by strings? | Semantic |
| 03 | Can agents consume it as a first-class citizen? | Agent-accessible |
| 04 | Does the product get smarter with use? | Compounding |

## Drift flagged (NOT fixed here — follow-up needed)

The `/architecture` page (`src/app/architecture/page.tsx`) still claims:
- "16 fixed categories" (reality: 8 dynamic dimensions per reporium-api README)
- "4 edge types" (not verified — may be stale)
- Haiku/Sonnet router tiering (not verified as currently deployed)
- `reporium-events` / `reporium-db` / `reporium-metrics` as standalone services (they are logical components inside `reporium-api`)

Per the rewrite spec I did **not** silently inherit these claims into `/ai-native`. Suggest opening a separate ticket to reconcile `/architecture` against the live reporium-api README.

## Test plan

- [x] `npm run build` — passes (static export renders `/ai-native`)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/app/ai-native/page.tsx src/components/ai-native/ArchitectureDiagram.tsx` — clean
- [x] Grep checks — 0 hits for all forbidden strings
- [x] 9 slides render, 9 nav dots present
- [x] Mobile variant: layers stack, cross-cutting bands appear below
- [ ] Vercel preview visual review once this PR deploys

## Gitflow note

Branched from `dev` after fast-forwarding `dev` to `origin/main` (dev had been left behind by `bf45de8` KAN-172, `0b31a3d` library refresh, and `739cafb` email hotfix). `dev` is now at `739cafb`, and this PR targets `dev` per [CLAUDE.md](https://github.com/perditioinc/reporium/blob/main/CLAUDE.md) gitflow.