### PR TITLE
UI regressions: keyboard scroll + loading bubbles + home flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Site-wide keyboard scrolling** — new `GlobalKeyboardScroll` component makes ArrowUp/ArrowDown/PageUp/PageDown/Home/End/Space scroll the primary `.overflow-y-auto` container on every route. Pages using the `flex h-screen overflow-hidden` chrome (home, wiki, graph, etc.) previously had no keyboard scrolling because `window` has no scroll range — arrow keys fired against it and did nothing. Handler opts out on `/ai-native` so that page's own slide-nav handler remains authoritative. Inputs, textareas, contenteditable, and `role="dialog"`/`role="menu"` descendants are excluded to preserve form/modal behavior.
+- **Home-page flicker on return navigation** — removed `setData(null)` from `HomePageClient` load effect; the `provider` caches library data at module scope, so a repeat mount (user navigates back to `/` from another page) resolves synchronously from cache instead of briefly blanking the UI.
+
+### Added
+- **Loading cursor bubbles** — new `LoadingCursorBubbles` component emits small purple bubble particles at the cursor position while a Next.js route transition is in flight. Complements the existing top-of-page `RouteProgress` bar: people look at their cursor, not the top of the viewport, so loading now registers in peripheral vision. Bubble-emission is tied to the same internal-link click heuristic as `RouteProgress`; each bubble floats up and fades over 900ms via CSS animation. `pointer-events-none` / `aria-hidden` so it can't intercept clicks or pollute the a11y tree.
+
 ### Changed
 - **/ai-native: framework-first rewrite** — stripped presentation logistics and Workato-centric framing; removed hardcoded stats (1,641 repos, $5.28 spend, 10 days to ship); replaced Live Demo slide with "What Makes Reporium AI-Native" architecture slide; expanded AI-Native Test from 3 to 4 questions to map 1:1 to the 4 AI-native layers; LLM references now model-agnostic (Claude/GPT/local); replaced CEO byline with neutral "A framework from building Reporium".
 

--- a/src/components/GlobalKeyboardScroll.tsx
+++ b/src/components/GlobalKeyboardScroll.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Site-wide keyboard scrolling (ArrowUp/ArrowDown/PageUp/PageDown/Space/Home/End).
+ *
+ * Why: home, wiki, graph etc. use a flex column with `h-screen overflow-hidden`
+ * and an inner `.overflow-y-auto` child as the actual scroll container. That
+ * inner child never receives focus, so arrow keys fire against `window` which
+ * has nothing to scroll — body is clipped. Site felt broken on keyboard.
+ *
+ * /ai-native owns its own arrow-key handler (slide nav), so this hook opts
+ * out on that route to avoid double-actioning.
+ */
+function isEditable(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  return false;
+}
+
+/** Largest visible `.overflow-y-auto` container that actually overflows. */
+function findScrollEl(): HTMLElement | null {
+  const candidates = Array.from(document.querySelectorAll<HTMLElement>('.overflow-y-auto'));
+  let best: HTMLElement | null = null;
+  let bestArea = 0;
+  for (const c of candidates) {
+    if (c.scrollHeight > c.clientHeight + 2) {
+      const rect = c.getBoundingClientRect();
+      const area = rect.width * rect.height;
+      if (area > bestArea) {
+        bestArea = area;
+        best = c;
+      }
+    }
+  }
+  return best;
+}
+
+export function GlobalKeyboardScroll() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // /ai-native runs its own slide-nav key handler — don't double-handle.
+    if (pathname?.startsWith('/ai-native')) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isEditable(e.target)) return;
+      // Modal / menu components own their own keyboard handling.
+      const active = document.activeElement as HTMLElement | null;
+      if (active?.closest('[role="dialog"], [aria-modal="true"], [role="menu"], [role="listbox"]')) return;
+
+      const key = e.key;
+      const step = window.innerHeight * 0.85;
+      let dy = 0;
+      let toTop = false;
+      let toBottom = false;
+
+      if (key === 'ArrowDown') dy = 80;
+      else if (key === 'ArrowUp') dy = -80;
+      else if (key === 'PageDown' || (key === ' ' && !e.shiftKey)) dy = step;
+      else if (key === 'PageUp' || (key === ' ' && e.shiftKey)) dy = -step;
+      else if (key === 'Home') toTop = true;
+      else if (key === 'End') toBottom = true;
+      else return;
+
+      const el = findScrollEl();
+
+      // Always use instant scroll for keyboard nav — users expect immediate
+      // response, and some container configurations ignore smooth-scroll
+      // requests silently (headless preview confirmed this behavior).
+      const behavior: ScrollBehavior = 'auto';
+
+      if (toTop) {
+        if (el) el.scrollTo({ top: 0, behavior });
+        else window.scrollTo({ top: 0, behavior });
+      } else if (toBottom) {
+        if (el) el.scrollTo({ top: el.scrollHeight, behavior });
+        else window.scrollTo({ top: document.body.scrollHeight, behavior });
+      } else if (el) {
+        el.scrollBy({ top: dy, behavior });
+      } else {
+        window.scrollBy({ top: dy, behavior });
+      }
+      e.preventDefault();
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -170,7 +170,10 @@ export function HomePageClient() {
       setIsLoading(true);
       setError(null);
       setApiDegraded(false);
-      setData(null);
+      // Note: we deliberately do NOT setData(null) here. The provider caches
+      // library data at module scope, so a repeat mount (e.g. user navigates
+      // back to "/" from another page) resolves synchronously from cache —
+      // blanking first causes a visible flicker when returning home.
 
       // Stage 1: load owned repos (~5KB) — shows YOUR repos instantly
       const owned = await provider.getOwnedLibrary().catch(() => null);

--- a/src/components/LayoutShell.tsx
+++ b/src/components/LayoutShell.tsx
@@ -3,11 +3,15 @@
 import { StickyAskBar } from './StickyAskBar';
 import { StickyNavBar } from './StickyNavBar';
 import { RouteProgress } from './RouteProgress';
+import { GlobalKeyboardScroll } from './GlobalKeyboardScroll';
+import { LoadingCursorBubbles } from './LoadingCursorBubbles';
 
 export function LayoutShell({ children }: { children: React.ReactNode }) {
   return (
     <>
       <RouteProgress />
+      <LoadingCursorBubbles />
+      <GlobalKeyboardScroll />
       <StickyNavBar />
       <div className="pb-14">{children}</div>
       <StickyAskBar />

--- a/src/components/LoadingCursorBubbles.tsx
+++ b/src/components/LoadingCursorBubbles.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Shows floating bubble particles around the cursor while a route is loading.
+ *
+ * Why: Next.js App Router offers no native visual feedback between a Link
+ * click and the new page being ready. The RouteProgress bar is at the top of
+ * the viewport and easy to miss — people look at their cursor. Bubbling at
+ * the cursor makes loading legible in peripheral vision.
+ *
+ * How: intercept internal-link clicks (same heuristic as RouteProgress) to
+ * enter "loading" state, exit ~250ms after the pathname commit. While loading
+ * we track mousemove and emit a new bubble particle every ~80ms; each bubble
+ * floats up and fades out over 900ms via CSS animation.
+ */
+type Bubble = {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  drift: number;
+};
+
+export function LoadingCursorBubbles() {
+  const pathname = usePathname();
+  const [loading, setLoading] = useState(false);
+  const [bubbles, setBubbles] = useState<Bubble[]>([]);
+  const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const lastEmit = useRef(0);
+  const firstRender = useRef(true);
+  const idRef = useRef(0);
+  const timers = useRef<number[]>([]);
+
+  const clearTimers = () => {
+    timers.current.forEach((t) => window.clearTimeout(t));
+    timers.current = [];
+  };
+
+  // Track mouse position always — cheap and avoids a cold-start gap when the
+  // first bubble needs to emit.
+  useEffect(() => {
+    function onMove(e: MouseEvent) {
+      mouse.current.x = e.clientX;
+      mouse.current.y = e.clientY;
+    }
+    window.addEventListener('mousemove', onMove, { passive: true });
+    return () => window.removeEventListener('mousemove', onMove);
+  }, []);
+
+  // Start loading on internal-link click. Same filter as RouteProgress so the
+  // two stay in sync.
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const anchor = (e.target as HTMLElement | null)?.closest('a');
+      if (!anchor) return;
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) return;
+      if (anchor.target && anchor.target !== '_self') return;
+      try {
+        const url = new URL(href, window.location.href);
+        if (url.origin !== window.location.origin) return;
+        if (url.pathname === window.location.pathname) return;
+      } catch {
+        return;
+      }
+      // Seed mouse from the click event itself — move listener may not have
+      // fired yet on first interaction.
+      mouse.current.x = e.clientX;
+      mouse.current.y = e.clientY;
+      setLoading(true);
+    }
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+
+  // End loading shortly after the pathname commit.
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    clearTimers();
+    const t = window.setTimeout(() => setLoading(false), 250);
+    timers.current.push(t);
+    return () => clearTimers();
+  }, [pathname]);
+
+  // Emit bubbles while loading.
+  useEffect(() => {
+    if (!loading) {
+      // Let existing bubbles finish their animation, then drop them.
+      const t = window.setTimeout(() => setBubbles([]), 1000);
+      timers.current.push(t);
+      return;
+    }
+    let raf = 0;
+    function tick(now: number) {
+      if (now - lastEmit.current > 80) {
+        lastEmit.current = now;
+        const id = ++idRef.current;
+        const size = 6 + Math.random() * 10;
+        const drift = (Math.random() - 0.5) * 40;
+        setBubbles((prev) => [
+          ...prev.slice(-20),
+          { id, x: mouse.current.x, y: mouse.current.y, size, drift },
+        ]);
+        // Remove this bubble after its animation completes.
+        const t = window.setTimeout(
+          () => setBubbles((prev) => prev.filter((b) => b.id !== id)),
+          950
+        );
+        timers.current.push(t);
+      }
+      raf = window.requestAnimationFrame(tick);
+    }
+    raf = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(raf);
+  }, [loading]);
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[55] overflow-hidden"
+    >
+      {bubbles.map((b) => (
+        <span
+          key={b.id}
+          className="lcb-bubble"
+          style={{
+            left: b.x,
+            top: b.y,
+            width: b.size,
+            height: b.size,
+            // @ts-expect-error -- CSS custom property
+            '--lcb-drift': `${b.drift}px`,
+          }}
+        />
+      ))}
+      <style jsx>{`
+        .lcb-bubble {
+          position: absolute;
+          display: block;
+          border-radius: 9999px;
+          background: radial-gradient(
+            circle at 30% 30%,
+            rgba(236, 200, 255, 0.95),
+            rgba(168, 85, 247, 0.55) 55%,
+            rgba(168, 85, 247, 0) 72%
+          );
+          box-shadow:
+            0 0 12px rgba(168, 85, 247, 0.55),
+            inset 0 0 4px rgba(255, 255, 255, 0.5);
+          transform: translate(-50%, -50%);
+          animation: lcb-rise 900ms ease-out forwards;
+        }
+        @keyframes lcb-rise {
+          0% {
+            opacity: 0;
+            transform: translate(-50%, -50%) scale(0.4);
+          }
+          20% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0;
+            transform: translate(calc(-50% + var(--lcb-drift, 0px)), calc(-50% - 60px))
+              scale(1.1);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes three user-reported UI regressions plus adds the requested loading-cursor feature.

- **Arrow keys site-wide** — pages using `flex h-screen overflow-hidden` put the real scroll container on an inner `.overflow-y-auto` child that never receives keyboard focus. Arrow keys fired against `window` and did nothing. New [GlobalKeyboardScroll](reporium/src/components/GlobalKeyboardScroll.tsx) handles ArrowUp/ArrowDown/PageUp/PageDown/Home/End/Space at the window level; finds the largest overflowing `.overflow-y-auto` and scrolls it. Opts out on `/ai-native` (which owns its own slide-nav handler). Skips inputs/textareas/contenteditable/dialogs/menus.
- **Home-page flicker on return nav** — `HomePageClient` called `setData(null)` at the start of each load effect, blanking the UI every mount. The `provider` already caches library data at module scope, so a return visit to `/` resolves synchronously from cache — no need to clear first. Removed the blank.
- **Mouse-bubble loading indicator** (new feature) — [LoadingCursorBubbles](reporium/src/components/LoadingCursorBubbles.tsx) emits purple bubble particles at the cursor during Next.js route transitions, complementing the existing top-of-page `RouteProgress` bar. People look at their cursor, not the top of the viewport; this makes loading register in peripheral vision. Pointer-events-none + aria-hidden.
- Both new components mounted in [LayoutShell](reporium/src/components/LayoutShell.tsx).

## Verified
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` on changed files — 0 errors
- [x] `npm run build` — static export succeeds, all 1,641 repo pages generated
- [x] Preview: Arrow/Page/Home/End all scroll the home-page container as expected
- [x] Preview: bubble container mounts with correct z-index / aria-hidden / pointer-events-none
- [x] /ai-native own slide-nav handler still runs (GlobalKeyboardScroll opts out via pathname check)

## Out of scope / flagged separately
- **Pros/Cons missing on many repo detail pages** — verified this is a *data* gap, not a frontend regression. The render block at [repo/[name]/page.tsx:476](reporium/src/app/repo/[name]/page.tsx:476) works correctly; langchain shows pros/cons in prod. ~33% of repos have `evaluation` data generated; the rest return `null` from the API. Needs enricher backfill. A follow-up task has been spawned.

## Test plan
- [ ] Open Vercel preview, scroll any list page (/graph, /wiki, /) using ArrowDown — should scroll
- [ ] Press Home / End on home page — should jump to top / bottom
- [ ] Focus the Ask input, type normally — keyboard chars go to input, arrows do not hijack scroll
- [ ] Click a nav link from /graph to / — bubbles should appear briefly around cursor
- [ ] /ai-native: ArrowDown still advances slides (not double-firing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)