### PR TITLE
hotfix: arrow-key scroll broken on 8 pages — broaden scan + fix /ai-native

### DIFF
--- a/src/app/ai-native/page.tsx
+++ b/src/app/ai-native/page.tsx
@@ -735,13 +735,16 @@ export default function AiNativePage() {
     };
   }, []);
 
-  // Scroll to slide helper
+  // Scroll to slide helper — scroll the snap container directly. scrollIntoView
+  // on a scroll-snap-mandatory container is inconsistent across browsers (Chrome
+  // 120+ sometimes snaps back, Firefox ignores smooth), so drive the container
+  // with scrollTo(top) using the slide's offsetTop.
   const scrollToSlide = useCallback((index: number) => {
     if (typeof window === 'undefined') return;
+    const container = containerRef.current;
     const el = document.getElementById(`slide-${index}`);
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth' });
-    }
+    if (!container || !el) return;
+    container.scrollTo({ top: el.offsetTop, behavior: 'smooth' });
   }, []);
 
   // Keyboard navigation
@@ -749,6 +752,12 @@ export default function AiNativePage() {
     if (typeof window === 'undefined') return;
 
     function handleKey(e: KeyboardEvent) {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      // Don't hijack arrows when user is typing in the ask bar or similar
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+
       if (e.key === 'ArrowDown' || e.key === 'PageDown') {
         e.preventDefault();
         setActiveSlide((prev) => {

--- a/src/components/GlobalKeyboardScroll.tsx
+++ b/src/components/GlobalKeyboardScroll.tsx
@@ -23,27 +23,42 @@ function isEditable(el: EventTarget | null): boolean {
 }
 
 /**
- * Largest visible scrollable container.
+ * Largest visible scrollable container anywhere on the page.
  *
- * Routes like /graph/ have no `.overflow-y-auto` element at all — their scroll
- * container is `document.body` directly. In that case `window.scrollBy` can
- * still no-op because browsers differ on whether the root scroller is `html`
- * or `body` when body is taller than html. So if the `.overflow-y-auto` scan
- * turns up nothing, we fall back to whichever of `scrollingElement` / `body` /
- * `documentElement` actually has scroll range.
+ * The earlier implementation only scanned `.overflow-y-auto`. That missed
+ * `.overflow-y-scroll`, `.overflow-auto`, inline `overflow: auto`, and any
+ * Tailwind variant that didn't match the literal class string — breaking
+ * arrow-key scroll on /ai-native (uses overflow-y-scroll), /graph,
+ * /taxonomy, /stacks, /insights, /trends, /architecture (rely on the
+ * document scroller via min-h-screen + body overflow-y: auto).
+ *
+ * Strategy:
+ *   1. Query every plausible class + inline-overflow element
+ *   2. Verify each candidate with computed style (overflow-y: auto|scroll)
+ *      and actual scroll range (scrollHeight > clientHeight + 2)
+ *   3. Pick the visible one with the largest on-screen area
+ *   4. Fall through to the document-level scroller (scrollingElement /
+ *      body / html) if nothing matched — some routes scroll the document
+ *      itself and have no inner wrapper at all.
  */
 function findScrollEl(): HTMLElement | null {
-  const candidates = Array.from(document.querySelectorAll<HTMLElement>('.overflow-y-auto'));
+  const selector =
+    '.overflow-y-auto, .overflow-y-scroll, .overflow-auto, .overflow-scroll, [style*="overflow"]';
+  const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector));
   let best: HTMLElement | null = null;
   let bestArea = 0;
   for (const c of candidates) {
-    if (c.scrollHeight > c.clientHeight + 2) {
-      const rect = c.getBoundingClientRect();
-      const area = rect.width * rect.height;
-      if (area > bestArea) {
-        bestArea = area;
-        best = c;
-      }
+    if (c.scrollHeight <= c.clientHeight + 2) continue;
+    const cs = getComputedStyle(c);
+    if (cs.overflowY !== 'auto' && cs.overflowY !== 'scroll') continue;
+    const rect = c.getBoundingClientRect();
+    // Must actually be on screen and non-trivial size
+    if (rect.width < 60 || rect.height < 60) continue;
+    if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+    const area = rect.width * rect.height;
+    if (area > bestArea) {
+      bestArea = area;
+      best = c;
     }
   }
   if (best) return best;


### PR DESCRIPTION
## Summary

Arrow keys still not scrolling on /graph, /wiki, /taxonomy, /stacks, /insights, /trends, /architecture, /ai-native despite the previous hotfix (#208/#209). Root cause was two separate bugs.

### Bug 1 — findScrollEl scan too narrow

`GlobalKeyboardScroll.findScrollEl` only matched `.overflow-y-auto`. The /ai-native snap container uses `overflow-y-scroll`, and the 7 other pages scroll the document itself via body `overflow-y: auto` from globals.css. Neither case was being found.

Widened the selector to `.overflow-y-auto, .overflow-y-scroll, .overflow-auto, .overflow-scroll, [style*="overflow"]`, then verified each hit with computed `overflowY` (`auto | scroll`) plus actual scroll range plus on-screen visibility. Document-level scrollers remain the final fallback.

### Bug 2 — /ai-native scrollToSlide fighting scroll-snap

The /ai-native slide navigator was calling `el.scrollIntoView({ behavior: 'smooth' })` on a `scrollSnapType: y mandatory` container. Chromium 120+ often snaps back to the previous slide; Firefox ignores the smooth flag silently.

Switched to `container.scrollTo({ top: el.offsetTop, behavior: 'smooth' })` directly against the snap container's ref. Also guarded the keydown handler against modifier keys and INPUT/TEXTAREA/contentEditable focus so arrows don't hijack the ask bar.

## Test plan

- [ ] Arrow Up/Down and PageUp/PageDown scroll the page on /graph, /wiki, /taxonomy, /stacks, /insights, /trends, /architecture
- [ ] Arrow Up/Down paginate slides on /ai-native (both up and down, all 9 slides)
- [ ] Arrow keys do NOT scroll when focus is in the ask bar input (/ or opening the ask bar and typing)
- [ ] Home/End jump to top/bottom on all listed routes
- [ ] Home page (/) still works as before — no regression on the baseline that was already working

🤖 Generated with [Claude Code](https://claude.com/claude-code)