### PR TITLE
Promote dev to main (includes KAN-ask a11y)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ next-env.d.ts
 public/data/cache.json
 public/data/repo-cache.json
 public/data/meta.json
+
+# local audit/baseline artifacts (ephemeral, never commit)
+.audit-status-*.md
+.baseline-*.md

--- a/DIGEST.md
+++ b/DIGEST.md
@@ -1,19 +1,19 @@
 # Reporium Daily Digest
-**perditioinc's GitHub Knowledge Library** · Generated April 16, 2026
+**perditioinc's GitHub Knowledge Library** · Generated April 17, 2026
 
 ---
 
 ## Trending This Week
 These areas in your library are seeing accelerating activity:
 
-**Log Analytics** (+96000% vs last week)
-ClickHouse, vector, doris are most active.
+**AI Automation** (+14300% vs last week)
+paperclip, composio are most active.
 
-**Real-time AI** (+94600% vs last week)
-opencv, redis, ClickHouse are most active.
+**Autonomous Systems** (+12300% vs last week)
+paperclip are most active.
 
-**AdTech** (+93500% vs last week)
-ClickHouse, doris are most active.
+**Business Automation** (+12300% vs last week)
+paperclip are most active.
 
 ---
 
@@ -26,7 +26,7 @@ ClickHouse, doris are most active.
 
 ## 30-Day Summary
 - **📦 Other AI / ML** most active category (70055 commits across 1425 repos)
-- **Log Analytics** fastest growing (+96000% commit velocity)
+- **AI Automation** fastest growing (+14300% commit velocity)
 
 ---
 

--- a/public/data/trends.json
+++ b/public/data/trends.json
@@ -1,126 +1,123 @@
 {
-  "generatedAt": "2026-04-16T07:19:20.581Z",
+  "generatedAt": "2026-04-17T07:19:23.126Z",
   "period": {
     "from": "2026-03-22 16:57:33 -0700",
-    "to": "2026-04-12 07:04:18 +0000",
-    "snapshots": 25
+    "to": "2026-04-16 07:19:23 +0000",
+    "snapshots": 26
   },
   "trending": [
     {
-      "name": "Log Analytics",
+      "name": "AI Automation",
       "type": "tag",
-      "currentActivity": 961,
-      "previousActivity": 1,
-      "changePercent": 96000,
-      "repoCount": 3,
-      "representativeRepos": [
-        "ClickHouse",
-        "vector",
-        "doris"
-      ]
-    },
-    {
-      "name": "Real-time AI",
-      "type": "tag",
-      "currentActivity": 947,
-      "previousActivity": 1,
-      "changePercent": 94600,
-      "repoCount": 34,
-      "representativeRepos": [
-        "opencv",
-        "redis",
-        "ClickHouse"
-      ]
-    },
-    {
-      "name": "AdTech",
-      "type": "tag",
-      "currentActivity": 936,
-      "previousActivity": 1,
-      "changePercent": 93500,
-      "repoCount": 3,
-      "representativeRepos": [
-        "ClickHouse",
-        "doris"
-      ]
-    },
-    {
-      "name": "Marketing Analytics",
-      "type": "tag",
-      "currentActivity": 857,
+      "currentActivity": 143,
       "previousActivity": 0,
-      "changePercent": 85700,
+      "changePercent": 14300,
+      "repoCount": 10,
+      "representativeRepos": [
+        "paperclip",
+        "composio"
+      ]
+    },
+    {
+      "name": "Autonomous Systems",
+      "type": "tag",
+      "currentActivity": 123,
+      "previousActivity": 0,
+      "changePercent": 12300,
+      "repoCount": 30,
+      "representativeRepos": [
+        "paperclip"
+      ]
+    },
+    {
+      "name": "Business Automation",
+      "type": "tag",
+      "currentActivity": 123,
+      "previousActivity": 0,
+      "changePercent": 12300,
       "repoCount": 7,
       "representativeRepos": [
-        "ClickHouse",
-        "mindsdb",
-        "dbt-core"
+        "paperclip"
       ]
     },
     {
-      "name": "Statistical Computing",
+      "name": "AI Agent Coordination",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 123,
       "previousActivity": 0,
-      "changePercent": 85100,
-      "repoCount": 3,
+      "changePercent": 12300,
+      "repoCount": 8,
       "representativeRepos": [
-        "ClickHouse"
+        "paperclip"
       ]
     },
     {
-      "name": "OLAP Systems",
+      "name": "Workflow Management",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 123,
       "previousActivity": 0,
-      "changePercent": 85100,
+      "changePercent": 12300,
+      "repoCount": 7,
+      "representativeRepos": [
+        "paperclip"
+      ]
+    },
+    {
+      "name": "Autonomous Business Operations",
+      "type": "tag",
+      "currentActivity": 123,
+      "previousActivity": 0,
+      "changePercent": 12300,
       "repoCount": 1,
       "representativeRepos": [
-        "ClickHouse"
+        "paperclip"
       ]
     },
     {
-      "name": "Columnar Database Design",
+      "name": "Zero-Human Workflow Execution",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 123,
       "previousActivity": 0,
-      "changePercent": 85100,
+      "changePercent": 12300,
       "repoCount": 1,
       "representativeRepos": [
-        "ClickHouse"
+        "paperclip"
       ]
     },
     {
-      "name": "Query Optimization",
+      "name": "AI Decision Making",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 123,
       "previousActivity": 0,
-      "changePercent": 85100,
-      "repoCount": 4,
+      "changePercent": 12300,
+      "repoCount": 1,
       "representativeRepos": [
-        "ClickHouse"
+        "paperclip"
       ]
     },
     {
-      "name": "Data Warehousing",
+      "name": "infrastructure",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 96,
       "previousActivity": 0,
-      "changePercent": 85100,
-      "repoCount": 3,
+      "changePercent": 9600,
+      "repoCount": 7,
       "representativeRepos": [
-        "ClickHouse"
+        "tmux",
+        "vitess",
+        "systemd"
       ]
     },
     {
-      "name": "Distributed",
+      "name": "Local Development Environment",
       "type": "tag",
-      "currentActivity": 851,
+      "currentActivity": 82,
       "previousActivity": 0,
-      "changePercent": 85100,
-      "repoCount": 3,
+      "changePercent": 8200,
+      "repoCount": 13,
       "representativeRepos": [
-        "ClickHouse"
+        "aider",
+        "repomix"
       ]
     }
   ],
@@ -240,6 +237,6 @@
   ],
   "newReleases": [],
   "insights": [
-    "Log Analytics is the fastest-growing area this week with +96000% commit velocity."
+    "AI Automation is the fastest-growing area this week with +14300% commit velocity."
   ]
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <link rel="preconnect" href="https://reporium-api-573778300586.us-central1.run.app" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://reporium-api-573778300586.us-central1.run.app" />
+      </head>
       <body className={`${inter.className} bg-zinc-950 text-zinc-100 antialiased`}>
         <LayoutShell>{children}</LayoutShell>
       </body>

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -1034,12 +1034,22 @@ export function StickyAskBar() {
         )}
       </div>
 
+      {/* Esc-to-cancel hint — visible only during in-flight phases */}
+      {(phase === 'searching' || phase === 'reasoning' || phase === 'warming' || phase === 'sources' || phase === 'streaming') && (
+        <div className="px-4 py-1 border-t border-zinc-800/50">
+          <span className="text-xs text-zinc-500" style={{ opacity: 0.6 }} aria-hidden="true">
+            Press Esc to cancel
+          </span>
+        </div>
+      )}
+
       {/* Answer / content area — shown whenever bar is not collapsed */}
       {barState !== 'collapsed' && (
         <div
           className="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3"
           ref={answerRef}
           tabIndex={-1}
+          role="status"
           aria-live="polite"
           aria-busy={isLoading}
           aria-label="Answer area"
@@ -1093,7 +1103,11 @@ export function StickyAskBar() {
 
           {/* Error */}
           {error && (
-            <div className="rounded-lg border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-400">
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-lg border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-400"
+            >
               {error}
             </div>
           )}


### PR DESCRIPTION
Promotion PR from dev to main.

Includes:
- KAN-ask a11y additive pass (PR #215): role=status, aria-live=polite on answer region; role=alert on error; visible Esc-to-cancel hint during in-flight phases

All CI green on dev. Ready to promote.