### PR TITLE
KAN: mobile polish — backdrop-blur gating, jellyfish visibility, lazy avatars

### DIFF
--- a/src/components/JellyfishLayer.tsx
+++ b/src/components/JellyfishLayer.tsx
@@ -149,6 +149,7 @@ function Jellyfish({ size = 60 }: { size?: number }) {
 export function JellyfishLayer() {
   const [jellies, setJellies] = useState<JellyDef[]>([]);
   const [reduced, setReduced] = useState(false);
+  const [paused, setPaused] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -161,7 +162,15 @@ export function JellyfishLayer() {
     const onChange = () => setReduced(mq.matches);
     mq.addEventListener('change', onChange);
 
-    return () => mq.removeEventListener('change', onChange);
+    function onVis() {
+      setPaused(document.visibilityState === 'hidden');
+    }
+    document.addEventListener('visibilitychange', onVis);
+
+    return () => {
+      mq.removeEventListener('change', onChange);
+      document.removeEventListener('visibilitychange', onVis);
+    };
   }, []);
 
   if (jellies.length === 0) return null;
@@ -184,7 +193,7 @@ export function JellyfishLayer() {
             filter: `hue-rotate(${j.hue}deg)`,
             animationDelay: `${j.delay}s`,
             animationDuration: `${j.bobDuration}s`,
-            animationPlayState: reduced ? 'paused' : 'running',
+            animationPlayState: reduced || paused ? 'paused' : 'running',
             // @ts-expect-error CSS custom property
             '--jelly-drift': `${j.driftX}px`,
           }}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -450,6 +450,8 @@ export const RepoCard = memo(function RepoCard({ repo, similarCount, onTagClick,
               src={`https://avatars.githubusercontent.com/${builder.login}`}
               alt={builder.name ?? builder.login}
               className="w-4 h-4 rounded-full"
+              width={16}
+              height={16}
               loading="lazy"
               decoding="async"
             />

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -929,7 +929,7 @@ export function StickyAskBar() {
   return (
     <motion.div
       data-tour="ask"
-      className="fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-zinc-950/95 backdrop-blur-md border-t border-zinc-800 overflow-hidden"
+      className="fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-zinc-950/95 md:bg-zinc-950/80 md:backdrop-blur-md border-t border-zinc-800 overflow-hidden"
       initial={{ height: 56 }}
       animate={{ height: heightValue }}
       transition={heightTransition}

--- a/src/components/StickyNavBar.tsx
+++ b/src/components/StickyNavBar.tsx
@@ -133,7 +133,7 @@ export function StickyNavBar({ widgetTabs }: StickyNavBarProps) {
   const isHome = pathname === '/';
 
   return (
-    <nav className="sticky top-0 z-40 bg-zinc-950/95 backdrop-blur-sm border-b border-zinc-800">
+    <nav className="sticky top-0 z-40 bg-zinc-950/95 md:bg-zinc-950/80 md:backdrop-blur-sm border-b border-zinc-800">
       <div className="flex items-center justify-between px-3 sm:px-4 md:px-6 h-10">
         {/* Logo + GitHub — doubles as home link */}
         <div className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
## Summary
P1 mobile performance polish pass (follows #217 nav safety and #218 streaming perf).

- **StickyAskBar / StickyNavBar**: gate `backdrop-blur-{md,sm}` behind `md:` breakpoint to avoid GPU compositing cost on mobile; mobile keeps `bg-zinc-950/95` for legibility while desktop retains translucent blur at `/80`.
- **JellyfishLayer**: pause animation when tab is hidden via `document.visibilitychange` — mirrors the existing `AmbientBubbles` pattern.
- **RepoCard**: add explicit `width`/`height` on avatar `<img>` (already has `loading="lazy"` / `decoding="async"`) to avoid CLS.

Additive-only, low-risk, revertable.

## Test plan
- [x] `npm run build` clean
- [ ] Vercel preview — verify sticky bars remain legible on mobile viewports
- [ ] Verify jellyfish pause when switching tabs
- [ ] No CLS regression on repo cards

Hotfix allowance per CLAUDE.md (direct to main).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>