### PR TITLE
KAN: /graph mobile fallback — skip 26MB library.json + Three.js on mobile

### DIFF
--- a/src/app/graph/GraphPageClient.tsx
+++ b/src/app/graph/GraphPageClient.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import type { GraphEdge, NodeMeta } from '@/components/KnowledgeGraph3D';
@@ -19,8 +20,37 @@ const KnowledgeGraph = dynamic(
   { ssr: false },
 );
 
+const MOBILE_QUERY = '(max-width: 767px)';
+
+function MobileGraphFallback() {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-[#0a0a0f] p-6 space-y-4">
+      <h2 className="text-lg font-semibold text-zinc-100">3D Knowledge Graph</h2>
+      <p className="text-sm text-zinc-400">
+        The interactive 3D visualization is desktop-optimized — open this page on a larger screen
+        to explore the full graph.
+      </p>
+      <div className="flex flex-wrap gap-2 pt-2">
+        <Link
+          href="/"
+          className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-2 text-sm text-zinc-100 hover:bg-zinc-800 transition-colors"
+        >
+          Browse library
+        </Link>
+        <Link
+          href="/wiki"
+          className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-2 text-sm text-zinc-100 hover:bg-zinc-800 transition-colors"
+        >
+          Open wiki
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 export function GraphPageClient() {
   const router = useRouter();
+  const [isMobile, setIsMobile] = useState(false);
   const [allEdges, setAllEdges] = useState<GraphEdge[]>([]);
   const [nodeMetadata, setNodeMetadata] = useState<Map<string, NodeMeta>>(new Map());
   const [loading, setLoading] = useState(true);
@@ -31,6 +61,18 @@ export function GraphPageClient() {
   const [limit, setLimit] = useState(10000);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia(MOBILE_QUERY);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing initial viewport match after SSR hydration
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) return;
+
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -64,7 +106,7 @@ export function GraphPageClient() {
       cancelled = true;
       controller.abort();
     };
-  }, [limit]);
+  }, [limit, isMobile]);
 
   const nodeCount = useMemo(
     () => nodeMetadata.size || new Set(allEdges.flatMap((e) => [e.source, e.target])).size,
@@ -78,6 +120,10 @@ export function GraphPageClient() {
     },
     [router],
   );
+
+  if (isMobile) {
+    return <MobileGraphFallback />;
+  }
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Mobile viewports (<768px) now render a lightweight fallback on `/graph` — CTAs to home and wiki — instead of fetching the 26 MB `library.json` and loading the 601 KB Three.js chunk.
- Desktop experience unchanged. Ask path (StickyAskBar, StickyNavBar, LayoutShell) untouched.
- Viewport detection via `window.matchMedia('(max-width: 767px)')` with SSR-safe hydration and resize listener (rotate/resize past 767px loads the graph on next effect pass).

## Test plan
- [ ] CI green
- [ ] Vercel preview: open `/graph` on mobile viewport → fallback renders, network tab shows no library.json / no Three.js chunk
- [ ] Vercel preview: open `/graph` on desktop → full 3D graph loads as before
- [ ] Prod smoke: `curl -I https://www.reporium.com/graph` returns 200
- [ ] Prod smoke: `curl -I https://www.reporium.com/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)