### PR TITLE
fix(ai-native): widen desktop slides, tighten mobile padding

### DIFF
--- a/src/components/ai-native/SlideWrapper.tsx
+++ b/src/components/ai-native/SlideWrapper.tsx
@@ -37,7 +37,7 @@ export function SlideWrapper({ children, id, className = '', bg = '' }: SlideWra
   return (
     <section
       id={id}
-      className={`relative flex h-[100svh] w-screen flex-col items-center justify-center overflow-y-auto px-6 sm:px-10 md:px-16 ${bg} ${className}`}
+      className={`relative flex h-[100svh] w-screen flex-col items-center justify-center overflow-y-auto px-4 sm:px-8 md:px-12 lg:px-16 xl:px-20 ${bg} ${className}`}
       style={{ scrollSnapAlign: 'start' }}
     >
       {/* Scanline overlay */}
@@ -51,7 +51,7 @@ export function SlideWrapper({ children, id, className = '', bg = '' }: SlideWra
       />
 
       <motion.div
-        className="relative z-10 w-full max-w-5xl py-12 sm:py-16"
+        className="relative z-10 w-full max-w-5xl py-6 sm:py-8 md:py-10 lg:max-w-6xl lg:py-12 xl:max-w-7xl 2xl:max-w-[88rem]"
         variants={shouldReduce ? undefined : containerVariants}
         initial={shouldReduce ? false : 'hidden'}
         whileInView={shouldReduce ? undefined : 'visible'}


### PR DESCRIPTION
## Problem
/ai-native slides felt small on desktop with too much empty space on the sides; mobile padding was unnecessarily wide.

## Root cause
`SlideWrapper.tsx` (shared by all 11 slides) capped content at `max-w-5xl` (1024px) with `py-12 sm:py-16`:
- 1920px desktop → ~900px of dead horizontal space
- Vertical padding too large for 100svh snap slides, making content feel cramped vertically

## Change (padding/max-width only — no content changes)
```
Outer section
- px-6 sm:px-10 md:px-16
+ px-4 sm:px-8 md:px-12 lg:px-16 xl:px-20

Inner wrapper
- max-w-5xl py-12 sm:py-16
+ max-w-5xl py-6 sm:py-8 md:py-10 lg:max-w-6xl lg:py-12 xl:max-w-7xl 2xl:max-w-[88rem]
```

Max-width now scales **1024 → 1152 → 1280 → 1408** at lg/xl/2xl.

## Test plan
- [ ] Vercel preview: verify 1920px desktop uses more horizontal space
- [ ] Vercel preview: verify iPhone SE (375px) still readable, no horizontal scroll
- [ ] Navigate all 11 slides, confirm no content overflow/clipping