### PR TITLE
hotfix: /library/full param is page_size not pageSize

### DIFF
--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -286,7 +286,7 @@ class ApiDataProvider implements DataProvider {
 
       const PAGE_SIZE = 500
       // Fetch page 1 to get totalPages + corpus aggregates
-      const page1 = await this.apiFetch<LibraryData & { totalPages?: number; totalRepos?: number }>(`/library/full?page=1&pageSize=${PAGE_SIZE}`)
+      const page1 = await this.apiFetch<LibraryData & { totalPages?: number; totalRepos?: number }>(`/library/full?page=1&page_size=${PAGE_SIZE}`)
       const totalPages = page1.totalPages ?? 1
       const totalRepos = page1.totalRepos ?? page1.repos.length
 
@@ -302,7 +302,7 @@ class ApiDataProvider implements DataProvider {
 
       const pages: LibraryData[] = []
       const remaining = Array.from({ length: totalPages - 1 }, (_, i) =>
-        this.apiFetch<LibraryData>(`/library/full?page=${i + 2}&pageSize=${PAGE_SIZE}`).then(page => {
+        this.apiFetch<LibraryData>(`/library/full?page=${i + 2}&page_size=${PAGE_SIZE}`).then(page => {
           loaded += page.repos.length
           report({ stage: 'repos', percent: Math.min(Math.round((loaded / totalRepos) * 100), 100), detail: `Loading repos (${loaded}/${totalRepos})…` })
           pages.push(page)


### PR DESCRIPTION
## Summary
Companion fix to reporium-api #381 (rate limit 5→60/min).

FastAPI endpoint expects snake_case \`page_size\`. Frontend was sending camelCase \`pageSize=500\` — silently ignored by FastAPI → API fell back to default \`page_size=200\`.

**Impact:** for the 1,825-repo corpus, frontend saw \`totalPages=10\` instead of \`totalPages=4\`. That's **10 parallel /library/full requests per page load** instead of 4 — doubles rate-limit pressure and halves effective page size.

\`getOwnedLibrary\` already used snake_case correctly; only the paginated \`getLibrary\` had the mismatch.

## Test plan
- [x] grep confirms zero \`pageSize=\` remaining
- [ ] After deploy: homepage loads show ≤5 requests to /library/full (not 11)
- [ ] Live-data-unavailable banner no longer appears on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)