### PR TITLE
fix: meta description — derive repo count from corpus constants

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,30 @@
 import type { Metadata } from 'next';
 import { HomePageClient } from '@/components/HomePageClient';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
+
+// Rounds down to the nearest 100 for marketing copy ("1,800+" not "1,825+").
+// Sourced from generated constants so meta stays fresh as corpus grows.
+function marketingCount(label: string): string {
+  const n = parseInt(label.replace(/,/g, ''), 10);
+  if (!Number.isFinite(n)) return label;
+  const rounded = Math.floor(n / 100) * 100;
+  return rounded.toLocaleString();
+}
+
+const description = `Search, filter, and explore ${marketingCount(REPOS_INDEXED_LABEL)}+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.`;
 
 export const metadata: Metadata = {
   title: { absolute: 'Reporium' },
-  description:
-    'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+  description,
   openGraph: {
     title: 'Reporium',
-    description:
-      'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+    description,
     url: 'https://www.reporium.com',
   },
   twitter: {
     title: 'Reporium',
-    description:
-      'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+    description,
   },
 };
 


### PR DESCRIPTION
## Summary
Live homepage shows fresh \`1,825 REPOS INDEXED\` in the billboard (from #228), **but meta description + OG + Twitter cards still say \`1,400+ AI development tools\`** — stale marketing copy from an older corpus size. Search previews and social cards look dated.

## Fix
- Import \`REPOS_INDEXED_LABEL\` from \`corpusConstants.generated\` (same source as billboard)
- Round down to the nearest 100 for marketing copy (\"1,800+\" not \"1,825+\") — stable across daily cron refreshes, avoids SEO churn
- All three meta locations now derive from the same constant

## Verification
- Before: \`curl reporium.com | grep '1,400+'\` → 6 matches (meta + og + twitter × 2 each)
- After: \`npm run build\` regenerates constants in prebuild → meta auto-tracks corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)