### PR TITLE
fix(cls): explicit img dimensions to eliminate layout shift

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -438,6 +438,8 @@ export default async function RepoDetailPage({
                     src={`https://github.com/${builder.login}.png?size=48`}
                     alt={builder.display_name ?? builder.login}
                     className="h-12 w-12 rounded-full border border-zinc-700"
+                    width={48}
+                    height={48}
                   />
                   <div>
                     <p className="text-sm font-medium text-zinc-100">

--- a/src/app/wiki/builders/[builder]/page.tsx
+++ b/src/app/wiki/builders/[builder]/page.tsx
@@ -42,6 +42,8 @@ export default async function BuilderPage({ params }: { params: Promise<{ builde
             src={`https://avatars.githubusercontent.com/${builder}`}
             alt={displayName}
             className="w-16 h-16 rounded-full border border-zinc-700"
+            width={64}
+            height={64}
           />
           <div>
             <p className="text-xs text-zinc-500 mb-0.5">Builder</p>

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -124,7 +124,7 @@ export default function WikiPage() {
                 className="flex items-center gap-2 rounded-full border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors"
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={b.avatarUrl} alt={b.displayName} className="w-4 h-4 rounded-full" />
+                <img src={b.avatarUrl} alt={b.displayName} className="w-4 h-4 rounded-full" width={16} height={16} />
                 {b.displayName}
                 <span className="text-zinc-500">({b.repoCount})</span>
               </a>

--- a/src/app/wiki/skills/[skill]/page.tsx
+++ b/src/app/wiki/skills/[skill]/page.tsx
@@ -225,7 +225,7 @@ export default async function SkillPage({ params }: { params: Promise<{ skill: s
                   className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/50 px-3 py-2.5 hover:border-zinc-700 transition-colors"
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={`https://github.com/${e.owner}.png?size=16`} alt={e.owner} className="w-4 h-4 rounded-full" />
+                  <img src={`https://github.com/${e.owner}.png?size=16`} alt={e.owner} className="w-4 h-4 rounded-full" width={16} height={16} />
                   <span className="text-sm font-medium text-zinc-300">{e.owner}/{e.repo}</span>
                   <span className="text-xs text-zinc-500 flex-1">{e.reason}</span>
                   <span className="text-xs text-zinc-600">↗</span>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -657,7 +657,7 @@ export function FilterBar({
                           }`}
                         >
                           {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img src={b.avatarUrl} alt={b.displayName} className="w-3.5 h-3.5 rounded-full" loading="lazy" decoding="async" />
+                          <img src={b.avatarUrl} alt={b.displayName} className="w-3.5 h-3.5 rounded-full" loading="lazy" decoding="async" width={14} height={14} />
                           <span>{b.displayName}</span>
                           <span className={isSelected ? 'text-cyan-200' : 'text-zinc-600'}>{b.repoCount}</span>
                         </button>

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -214,7 +214,7 @@ export function StatsBar({ data, tagMetrics, onTagClick }: StatsBarProps) {
                 className="flex items-center gap-1.5 rounded-full bg-zinc-800 border border-zinc-700 px-2.5 py-1 text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors"
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={b.avatarUrl} alt={b.displayName} className="w-4 h-4 rounded-full" loading="lazy" decoding="async" />
+                <img src={b.avatarUrl} alt={b.displayName} className="w-4 h-4 rounded-full" loading="lazy" decoding="async" width={16} height={16} />
                 <span>{b.displayName}</span>
                 <span className="text-zinc-500">{b.repoCount}</span>
               </button>

--- a/src/components/WikiRepoCard.tsx
+++ b/src/components/WikiRepoCard.tsx
@@ -23,6 +23,8 @@ export function WikiRepoCard({ repo }: WikiRepoCardProps) {
           src={`https://github.com/${builder.login}.png?size=16`}
           alt={builder.name ?? builder.login}
           className="w-4 h-4 rounded-full flex-shrink-0"
+          width={16}
+          height={16}
         />
       )}
       <span className="text-sm font-medium text-zinc-200 flex-1 truncate">{repo.name}</span>


### PR DESCRIPTION
## Summary
Add explicit width/height attributes to all `<img>` elements to prevent layout shift (CLS) per issue #225.

## Changes
All 7 image tags are GitHub avatars with pre-determined dimensions. Added HTML attributes matching Tailwind CSS classes:
- w-4 h-4 (16px): wiki page, skills page, stats bar, wiki repo card
- w-3.5 h-3.5 (14px): filter bar
- w-12 h-12 (48px): repo detail page
- w-16 h-16 (64px): builder detail page

## Files Modified
1. src/app/repo/[name]/page.tsx
2. src/app/wiki/builders/[builder]/page.tsx
3. src/app/wiki/page.tsx
4. src/app/wiki/skills/[skill]/page.tsx
5. src/components/FilterBar.tsx
6. src/components/StatsBar.tsx
7. src/components/WikiRepoCard.tsx

**Impact**: Low — 7 offenders, all fixed. No functional changes, CSS dimensions already reserved via Tailwind classes.

Closes #225