### PR TITLE
fix(tagger): add MDX → [docs] in LANGUAGE_TAGS (refs #P7)

### DIFF
--- a/src/lib/enrichRepo.ts
+++ b/src/lib/enrichRepo.ts
@@ -22,6 +22,7 @@ const LANGUAGE_TAGS: Record<string, string[]> = {
   Elixir: ['Elixir', 'Backend'],
   Haskell: ['Haskell', 'Systems'],
   R: ['R', 'Data Science'],
+  MDX: ['Docs'],
 };
 
 /** Topic keyword to category tag mappings */


### PR DESCRIPTION
Adds MDX language tag mapping to LANGUAGE_TAGS constant to enable language detection for MDX-language repositories.

Fixes P7 no-tag analysis finding.