### PR TITLE
SEO tier 2: Breadcrumb + Dataset structured data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,12 @@ export const metadata: Metadata = {
     url: 'https://www.reporium.com',
     siteName: 'Reporium',
     type: 'website',
-    images: ['/opengraph-image.png'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Reporium - AI Dev Tool Library',
     description:
       'Browse the Reporium portfolio of AI development tools, taxonomy coverage, search results, and repo intelligence.',
-    images: ['/opengraph-image.png'],
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,14 @@ export const metadata: Metadata = {
     url: 'https://www.reporium.com',
     siteName: 'Reporium',
     type: 'website',
+    images: ['/opengraph-image.png'],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Reporium - AI Dev Tool Library',
     description:
       'Browse the Reporium portfolio of AI development tools, taxonomy coverage, search results, and repo intelligence.',
+    images: ['/opengraph-image.png'],
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,50 @@
+import { ImageResponse } from 'next/og';
+import { REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
+
+export const dynamic = 'force-static';
+
+function roundDownTo100(countStr: string): string {
+  const count = parseInt(countStr.replace(/,/g, ''), 10);
+  const rounded = Math.floor(count / 100) * 100;
+  return rounded.toLocaleString();
+}
+
+export default function Image() {
+  const reposRounded = roundDownTo100(REPOS_INDEXED_LABEL);
+
+  return new ImageResponse(
+    <div style={{
+      width: '100%',
+      height: '100%',
+      backgroundColor: '#09090b',
+      display: 'flex',
+      flexDirection: 'column' as const,
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontFamily: 'system-ui, sans-serif',
+      color: '#f4f4f5',
+      padding: '40px',
+      boxSizing: 'border-box' as const,
+    }}>
+      <p style={{ fontSize: '80px', fontWeight: 900, margin: 0, marginBottom: '20px' }}>
+        Reporium
+      </p>
+      <p style={{ fontSize: '44px', fontWeight: 500, color: '#a1a1a6', margin: 0 }}>
+        {reposRounded}+ AI dev tools
+      </p>
+    </div>,
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const alt = 'Reporium — AI dev tools directory';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,92 @@
 import type { Metadata } from 'next';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { HomePageClient } from '@/components/HomePageClient';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
 
 export const metadata: Metadata = {
   title: { absolute: 'Reporium' },
   description:
     'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+  alternates: {
+    canonical: 'https://www.reporium.com',
+  },
   openGraph: {
     title: 'Reporium',
     description:
       'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
     url: 'https://www.reporium.com',
+    images: ['/opengraph-image.png'],
   },
   twitter: {
+    card: 'summary_large_image',
     title: 'Reporium',
     description:
       'Search, filter, and explore 1,400+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+    images: ['/opengraph-image.png'],
   },
 };
 
+function getTopRepos(): Array<{ name: string; owner: string; parentStats?: { stars: number } }> {
+  try {
+    const data = JSON.parse(
+      readFileSync(join(process.cwd(), 'public', 'data', 'library.json'), 'utf-8')
+    ) as { repos: Array<{ name: string; owner?: string; parentStats?: { stars: number }; fullName?: string }> };
+    return data.repos
+      .slice(0, 10)
+      .map(repo => ({
+        name: repo.name,
+        owner: repo.parentStats?.stars ? '' : (repo.fullName?.split('/')[0] || 'unknown'),
+        parentStats: repo.parentStats,
+      }));
+  } catch {
+    return [];
+  }
+}
+
 export default function Page() {
+  const topRepos = getTopRepos();
+
+  const softwareApplicationSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Reporium',
+    description:
+      'Search, filter, and explore AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.',
+    url: 'https://www.reporium.com',
+    applicationCategory: 'DeveloperApplication',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+  };
+
+  const itemListSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Top AI Development Tools',
+    description: `Top ${Math.min(10, topRepos.length)} AI development tools in the Reporium library.`,
+    numberOfItems: Math.min(10, topRepos.length),
+    itemListElement: topRepos.map((repo, index) => ({
+      '@type': 'SoftwareSourceCode',
+      position: index + 1,
+      name: repo.name,
+      url: `https://www.reporium.com/repo/${encodeURIComponent(repo.name)}`,
+    })),
+  };
+
   return (
     <ErrorBoundary>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
+      />
       <HomePageClient />
     </ErrorBoundary>
   );

--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -280,14 +280,18 @@ export async function generateMetadata({ params }: RepoPageProps): Promise<Metad
   const repo = await getRepoDetail(name);
   const title = repo ? `${repo.owner}/${repo.name}` : name;
   const description = repo?.readme_summary ?? repo?.description ?? `Explore ${title} on Reporium.`;
+  const canonical = `https://www.reporium.com/repo/${encodeURIComponent(name)}`;
 
   return {
     title,
     description,
+    alternates: {
+      canonical,
+    },
     openGraph: {
       title,
       description,
-      url: `https://www.reporium.com/repo/${encodeURIComponent(name)}`,
+      url: canonical,
     },
     twitter: {
       title,
@@ -334,6 +338,7 @@ export default async function RepoDetailPage({
   const stars = repo.is_fork ? repo.parent_stars : repo.stargazers_count;
   const forks = repo.is_fork ? repo.parent_forks : 0;
   const builder = repo.builders?.[0] ?? null;
+  const canonicalUrl = `https://www.reporium.com/repo/${encodeURIComponent(repo.name)}`;
 
   // JSON-LD structured data for Google / schema.org
   const upstream = repo.forked_from ?? `${repo.owner}/${repo.name}`;
@@ -342,7 +347,7 @@ export default async function RepoDetailPage({
     '@type': 'SoftwareSourceCode',
     name: upstream,
     description: repo.readme_summary ?? repo.description ?? undefined,
-    url: `https://www.reporium.com/repo/${encodeURIComponent(repo.name)}`,
+    url: canonicalUrl,
     codeRepository: repo.is_fork && repo.forked_from
       ? `https://github.com/${repo.forked_from}`
       : repo.github_url,
@@ -363,11 +368,46 @@ export default async function RepoDetailPage({
     }}),
   };
 
+  // BreadcrumbList JSON-LD for SEO tier 2
+  const primaryCategory = repo.categories?.find(c => c.is_primary)?.category_name;
+  const breadcrumbItems = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Reporium',
+      item: 'https://www.reporium.com',
+    },
+  ];
+  if (primaryCategory) {
+    breadcrumbItems.push({
+      '@type': 'ListItem',
+      position: 2,
+      name: primaryCategory,
+      item: `https://www.reporium.com/wiki/categories/${encodeURIComponent(primaryCategory.toLowerCase().replace(/[^a-z0-9]+/g, '-'))}`,
+    });
+  }
+  breadcrumbItems.push({
+    '@type': 'ListItem',
+    position: primaryCategory ? 3 : 2,
+    name: repo.name,
+    item: canonicalUrl,
+  });
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbItems,
+  };
+
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c') }}
       />
       {/* KAN-159: track view for homepage recommendations */}
       <ViewTracker repoName={repo.name} />

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,4 @@
+// Re-export from opengraph-image to avoid duplication
+export { default, size, contentType, alt } from './opengraph-image';
+
+export const dynamic = 'force-static';

--- a/src/app/wiki/categories/[category]/page.tsx
+++ b/src/app/wiki/categories/[category]/page.tsx
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
 import type { LibraryData } from '@/types/repo';
 import { CATEGORIES } from '@/lib/buildCategories';
 import { WikiNavBar } from '@/components/WikiNavBar';
@@ -15,7 +16,40 @@ export async function generateStaticParams() {
   return CATEGORIES.map(c => ({ category: c.id }));
 }
 
-export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
+interface CategoryPageProps {
+  params: Promise<{ category: string }>;
+}
+
+export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {
+  const { category } = await params;
+  const cat = CATEGORIES.find(c => c.id === category);
+  if (!cat) return {};
+
+  const data = getLibraryData();
+  const repoCount = data ? data.repos.filter(r => (r.allCategories ?? []).includes(cat.name)).length : 0;
+  const canonical = `https://www.reporium.com/wiki/categories/${encodeURIComponent(cat.id)}`;
+  const title = `${cat.name} AI Development Tools | Reporium`;
+  const description = `${repoCount} curated ${cat.name.toLowerCase()} AI dev tools with deep taxonomy filtering, portfolio insights, and live repository intelligence.`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  };
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
   const { category } = await params;
   const cat = CATEGORIES.find(c => c.id === category);
   if (!cat) notFound();
@@ -27,8 +61,36 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
     .filter(r => (r.allCategories ?? []).includes(cat.name))
     .sort((a, b) => (b.parentStats?.stars ?? 0) - (a.parentStats?.stars ?? 0));
 
+  const canonicalUrl = `https://www.reporium.com/wiki/categories/${encodeURIComponent(cat.id)}`;
+
+  // Dataset JSON-LD for SEO tier 2
+  const datasetJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: `${cat.name} AI development tools`,
+    description: `Curated list of ${repos.length} ${cat.name.toLowerCase()} AI development tools with taxonomy filtering and portfolio insights.`,
+    url: canonicalUrl,
+    keywords: [
+      cat.name,
+      'AI development tools',
+      'AI tools',
+      ...(repos.slice(0, 5).flatMap(r => r.enrichedTags?.slice(0, 2) ?? [])),
+    ].filter((v, i, a) => a.indexOf(v) === i).slice(0, 20),
+    creator: {
+      '@type': 'Organization',
+      name: 'Reporium',
+      url: 'https://www.reporium.com',
+    },
+    spatialCoverage: 'Global',
+    temporalCoverage: `${new Date().getFullYear()}/`,
+  };
+
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetJsonLd).replace(/</g, '\\u003c') }}
+      />
       <WikiNavBar title={cat.name} />
       <div className="p-8 max-w-4xl mx-auto space-y-6">
         <div>


### PR DESCRIPTION
Builds on #237. Adds structured data to repo detail + category pages.

## Changes
- BreadcrumbList JSON-LD on repo detail pages (`/repo/[name]`)
- Dataset JSON-LD on category pages (`/wiki/categories/[category]`)
- Added canonical URL metadata to both routes
- Breadcrumb includes primary category when available

## Routes touched
- `src/app/repo/[name]/page.tsx` — SoftwareSourceCode + BreadcrumbList
- `src/app/wiki/categories/[category]/page.tsx` — Dataset schema + metadata