### PR TITLE
fix(a11y): quick wins — aria-labels, heading structure, helper contrast

### DIFF
--- a/src/components/AskBar.tsx
+++ b/src/components/AskBar.tsx
@@ -323,7 +323,7 @@ export function AskBar({ apiUrl }: AskBarProps) {
             placeholder="Ask anything about the repo library..."
             maxLength={500}
             disabled={atMinuteLimit || atDayLimit}
-            className="w-full rounded-lg border border-zinc-700 bg-zinc-900 py-2.5 pl-8 pr-4 text-base sm:text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-50"
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-900 py-2.5 pl-8 pr-4 text-base sm:text-sm text-zinc-200 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-50"
           />
         </div>
         <button
@@ -344,10 +344,10 @@ export function AskBar({ apiUrl }: AskBarProps) {
 
       {/* Loading status */}
       {loading && sources.length === 0 && (
-        <p className="text-xs text-zinc-500">Searching repos and finding the best matches…</p>
+        <p className="text-xs text-zinc-400">Searching repos and finding the best matches…</p>
       )}
       {loading && sources.length > 0 && !hasAnswer && (
-        <p className="text-xs text-zinc-500">Generating answer from {sources.length} repos…</p>
+        <p className="text-xs text-zinc-400">Generating answer from {sources.length} repos…</p>
       )}
 
       {/* Rate limit warning */}
@@ -369,7 +369,7 @@ export function AskBar({ apiUrl }: AskBarProps) {
       {/* Source repos — shown as soon as we have them (before generation completes) */}
       {sources.length > 0 && (
         <div className="space-y-1.5">
-          <p className="text-xs text-zinc-500 font-medium uppercase tracking-wider">
+          <p className="text-xs text-zinc-400 font-medium uppercase tracking-wider">
             Sources · {sources.length} repos
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
@@ -389,17 +389,17 @@ export function AskBar({ apiUrl }: AskBarProps) {
                     <span className="text-xs font-mono text-zinc-300 group-hover:text-zinc-100 truncate">
                       {upstream}
                     </span>
-                    <span className="shrink-0 text-xs text-zinc-600">
+                    <span className="shrink-0 text-xs text-zinc-400">
                       {score}% match
                     </span>
                   </div>
                   {repo.description && (
-                    <p className="mt-1 text-xs text-zinc-500 line-clamp-2">
+                    <p className="mt-1 text-xs text-zinc-400 line-clamp-2">
                       {repo.description}
                     </p>
                   )}
                   {repo.stars != null && (
-                    <p className="mt-1 text-xs text-zinc-600">
+                    <p className="mt-1 text-xs text-zinc-400">
                       ★ {repo.stars.toLocaleString()}
                     </p>
                   )}

--- a/src/components/EcosystemStackCard.tsx
+++ b/src/components/EcosystemStackCard.tsx
@@ -21,6 +21,7 @@ export function EcosystemStackCard({ stack, defaultExpanded = false }: Ecosystem
         className="w-full text-left px-5 py-4 flex items-start gap-4"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
+        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${stack.title} tech stack`}
       >
         {/* Icon */}
         <span className="text-2xl shrink-0 mt-0.5">{stack.icon}</span>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -260,92 +260,92 @@ export function FilterBar({
           {selectedAiTrends.map(trend => (
             <span key={trend} className="flex items-center gap-1 rounded-full bg-sky-900/30 border border-sky-700/50 px-2.5 py-1 text-xs font-medium text-sky-300">
               {trend}
-              <button onClick={() => onAiTrendToggle?.(trend)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onAiTrendToggle?.(trend)} className="ml-1 hover:opacity-70" aria-label={`Remove ${trend} filter`}>×</button>
             </span>
           ))}
           {/* AI Dev Skill pills */}
           {selectedAiDevSkills.map(skill => (
             <span key={skill} className="flex items-center gap-1 rounded-full bg-emerald-900/30 border border-emerald-700/50 px-2.5 py-1 text-xs font-medium text-emerald-300">
               {skill}
-              <button onClick={() => onAiDevSkillToggle?.(skill)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onAiDevSkillToggle?.(skill)} className="ml-1 hover:opacity-70" aria-label={`Remove AI Dev Skill filter: ${skill}`}>×</button>
             </span>
           ))}
           {/* PM Skill pills */}
           {selectedPmSkills.map(skill => (
             <span key={skill} className="flex items-center gap-1 rounded-full bg-purple-900/30 border border-purple-700/50 px-2.5 py-1 text-xs font-medium text-purple-300">
               {skill}
-              <button onClick={() => onPmSkillToggle?.(skill)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onPmSkillToggle?.(skill)} className="ml-1 hover:opacity-70" aria-label={`Remove PM Skill filter: ${skill}`}>×</button>
             </span>
           ))}
           {/* Industry pills */}
           {selectedIndustries.map(ind => (
             <span key={ind} className="flex items-center gap-1 rounded-full bg-amber-900/30 border border-amber-700/50 px-2.5 py-1 text-xs font-medium text-amber-300">
               {ind}
-              <button onClick={() => onIndustryToggle?.(ind)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onIndustryToggle?.(ind)} className="ml-1 hover:opacity-70" aria-label={`Remove Industry filter: ${ind}`}>×</button>
             </span>
           ))}
           {selectedUseCases.map(value => (
             <span key={value} className="flex items-center gap-1 rounded-full bg-fuchsia-900/30 border border-fuchsia-700/50 px-2.5 py-1 text-xs font-medium text-fuchsia-300">
               {value}
-              <button onClick={() => onUseCaseToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onUseCaseToggle?.(value)} className="ml-1 hover:opacity-70" aria-label={`Remove Use Case filter: ${value}`}>×</button>
             </span>
           ))}
           {selectedModalities.map(value => (
             <span key={value} className="flex items-center gap-1 rounded-full bg-teal-900/30 border border-teal-700/50 px-2.5 py-1 text-xs font-medium text-teal-300">
               {value}
-              <button onClick={() => onModalityToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onModalityToggle?.(value)} className="ml-1 hover:opacity-70" aria-label={`Remove Modality filter: ${value}`}>×</button>
             </span>
           ))}
           {selectedDeploymentContexts.map(value => (
             <span key={value} className="flex items-center gap-1 rounded-full bg-orange-900/30 border border-orange-700/50 px-2.5 py-1 text-xs font-medium text-orange-300">
               {value}
-              <button onClick={() => onDeploymentContextToggle?.(value)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onDeploymentContextToggle?.(value)} className="ml-1 hover:opacity-70" aria-label={`Remove Deployment Context filter: ${value}`}>×</button>
             </span>
           ))}
           {/* Builder pills */}
           {selectedBuilders.map(builder => (
             <span key={builder} className="flex items-center gap-1 rounded-full bg-cyan-900/30 border border-cyan-700/50 px-2.5 py-1 text-xs font-medium text-cyan-300">
               {builder}
-              <button onClick={() => onBuilderToggle?.(builder)} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onBuilderToggle?.(builder)} className="ml-1 hover:opacity-70" aria-label={`Remove Builder filter: ${builder}`}>×</button>
             </span>
           ))}
           {/* Claude Plugins pill */}
           {showClaudePluginsOnly && (
             <span className="flex items-center gap-1 rounded-full bg-orange-900/40 border border-orange-600/60 px-2.5 py-1 text-xs font-medium text-orange-300">
               🔌 MCP / Plugins
-              <button onClick={() => onPluginToggle?.()} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onPluginToggle?.()} className="ml-1 hover:opacity-70" aria-label="Remove Claude Plugins filter">×</button>
             </span>
           )}
           {/* Security risk pill */}
           {selectedSecurityRisk !== 'all' && (
             <span className="flex items-center gap-1 rounded-full bg-red-900/40 border border-red-700/60 px-2.5 py-1 text-xs font-medium text-red-300">
               🛡️ {selectedSecurityRisk === 'incident' ? 'Has Incident' : selectedSecurityRisk.toUpperCase()}
-              <button onClick={() => onSecurityRiskChange?.('all')} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onSecurityRiskChange?.('all')} className="ml-1 hover:opacity-70" aria-label={`Remove Security Risk filter: ${selectedSecurityRisk === 'incident' ? 'Has Incident' : selectedSecurityRisk.toUpperCase()}`}>×</button>
             </span>
           )}
           {/* Other active filters */}
           {selectedType !== 'all' && (
             <span className="flex items-center gap-1 rounded-full bg-zinc-700/50 border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300">
               {selectedType}
-              <button onClick={() => onTypeChange('all')} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onTypeChange('all')} className="ml-1 hover:opacity-70" aria-label={`Remove Repo Type filter: ${selectedType}`}>×</button>
             </span>
           )}
           {selectedLanguage && (
             <span className="flex items-center gap-1 rounded-full bg-zinc-700/50 border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300">
               {selectedLanguage}
-              <button onClick={() => onLanguageChange('')} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onLanguageChange('')} className="ml-1 hover:opacity-70" aria-label={`Remove Language filter: ${selectedLanguage}`}>×</button>
             </span>
           )}
           {selectedActivity !== 'all' && (
             <span className="flex items-center gap-1 rounded-full bg-zinc-700/50 border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300">
               {selectedActivity}
-              <button onClick={() => onActivityChange('all')} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onActivityChange('all')} className="ml-1 hover:opacity-70" aria-label={`Remove Activity filter: ${selectedActivity}`}>×</button>
             </span>
           )}
           {selectedSyncStatus !== 'all' && (
             <span className="flex items-center gap-1 rounded-full bg-zinc-700/50 border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300">
               {selectedSyncStatus}
-              <button onClick={() => onSyncStatusChange('all')} className="ml-1 hover:opacity-70">×</button>
+              <button onClick={() => onSyncStatusChange('all')} className="ml-1 hover:opacity-70" aria-label={`Remove Sync Status filter: ${selectedSyncStatus}`}>×</button>
             </span>
           )}
           <span className="ml-auto text-xs text-zinc-500">{filteredCount} repos matching</span>

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -1257,7 +1257,7 @@ export function HomePageClient() {
           <footer className="mx-3 sm:mx-4 md:mx-6 mt-8 border-t border-zinc-800 pt-6 pb-4">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 text-xs text-zinc-500">
               <div>
-                <h4 className="text-zinc-300 font-medium mb-2">Explore</h4>
+                <h3 className="text-zinc-300 font-medium mb-2">Explore</h3>
                 <ul className="space-y-1.5">
                   <li><Link href="/graph" className="hover:text-zinc-300 transition-colors">Knowledge Graph</Link></li>
                   <li><Link href="/trends" className="hover:text-zinc-300 transition-colors">Trends</Link></li>
@@ -1266,7 +1266,7 @@ export function HomePageClient() {
                 </ul>
               </div>
               <div>
-                <h4 className="text-zinc-300 font-medium mb-2">Intelligence</h4>
+                <h3 className="text-zinc-300 font-medium mb-2">Intelligence</h3>
                 <ul className="space-y-1.5">
                   <li><Link href="/insights" className="hover:text-zinc-300 transition-colors">Insights</Link></li>
                   <li><Link href="/architecture" className="hover:text-zinc-300 transition-colors">Architecture</Link></li>
@@ -1275,7 +1275,7 @@ export function HomePageClient() {
                 </ul>
               </div>
               <div>
-                <h4 className="text-zinc-300 font-medium mb-2">Wiki</h4>
+                <h3 className="text-zinc-300 font-medium mb-2">Wiki</h3>
                 <ul className="space-y-1.5">
                   <li><Link href="/wiki/roadmap" className="hover:text-zinc-300 transition-colors">Roadmap</Link></li>
                   <li><Link href="/wiki/categories/transformer-architecture" className="hover:text-zinc-300 transition-colors">Categories</Link></li>

--- a/src/components/WikiSidebar.tsx
+++ b/src/components/WikiSidebar.tsx
@@ -102,7 +102,7 @@ export function WikiSidebar() {
       >
         <div className="p-4 border-b border-zinc-800 flex items-center gap-2">
           <span className="text-zinc-100 font-bold text-sm">📚 Reporium Wiki</span>
-          <button onClick={toggle} className="ml-auto text-zinc-500 hover:text-zinc-300">✕</button>
+          <button onClick={toggle} className="ml-auto text-zinc-500 hover:text-zinc-300" aria-label="Close Wiki sidebar">✕</button>
         </div>
 
         <nav className="p-2">


### PR DESCRIPTION
## Summary
Quick wins accessibility audit fixes targeting WCAG 2.1 Level AA compliance.
- Added contextual aria-labels to 14 filter pill close buttons in FilterBar
- Fixed 3 orphaned h4 headings (demoted to h3) in HomePageClient footer
- Upgraded 6 low-contrast helper text instances from text-zinc-500/600 to text-zinc-400
- Added aria-label to WikiSidebar close button and EcosystemStackCard expand toggle

## Changes by File

| File | Line | Change | Before | After |
|------|------|--------|--------|-------|
| FilterBar.tsx | 263 | AI Trends filter close button | `<button>×</button>` | `<button aria-label="Remove {trend} filter">×</button>` |
| FilterBar.tsx | 270 | AI Dev Skills filter close button | `<button>×</button>` | `<button aria-label="Remove AI Dev Skill filter: {skill}">×</button>` |
| FilterBar.tsx | 277 | PM Skills filter close button | `<button>×</button>` | `<button aria-label="Remove PM Skill filter: {skill}">×</button>` |
| FilterBar.tsx | 284 | Industry filter close button | `<button>×</button>` | `<button aria-label="Remove Industry filter: {ind}">×</button>` |
| FilterBar.tsx | 290 | Use Case filter close button | `<button>×</button>` | `<button aria-label="Remove Use Case filter: {value}">×</button>` |
| FilterBar.tsx | 296 | Modality filter close button | `<button>×</button>` | `<button aria-label="Remove Modality filter: {value}">×</button>` |
| FilterBar.tsx | 302 | Deployment Context filter close button | `<button>×</button>` | `<button aria-label="Remove Deployment Context filter: {value}">×</button>` |
| FilterBar.tsx | 309 | Builder filter close button | `<button>×</button>` | `<button aria-label="Remove Builder filter: {builder}">×</button>` |
| FilterBar.tsx | 316 | Claude Plugins filter close button | `<button>×</button>` | `<button aria-label="Remove Claude Plugins filter">×</button>` |
| FilterBar.tsx | 323 | Security Risk filter close button | `<button>×</button>` | `<button aria-label="Remove Security Risk filter: {risk}">×</button>` |
| FilterBar.tsx | 330 | Repo Type filter close button | `<button>×</button>` | `<button aria-label="Remove Repo Type filter: {type}">×</button>` |
| FilterBar.tsx | 336 | Language filter close button | `<button>×</button>` | `<button aria-label="Remove Language filter: {language}">×</button>` |
| FilterBar.tsx | 342 | Activity filter close button | `<button>×</button>` | `<button aria-label="Remove Activity filter: {activity}">×</button>` |
| FilterBar.tsx | 348 | Sync Status filter close button | `<button>×</button>` | `<button aria-label="Remove Sync Status filter: {status}">×</button>` |
| WikiSidebar.tsx | 105 | Close button aria-label | (missing) | `aria-label="Close Wiki sidebar"` |
| HomePageClient.tsx | 1260 | Explore footer heading | `<h4>Explore</h4>` | `<h3>Explore</h3>` |
| HomePageClient.tsx | 1269 | Intelligence footer heading | `<h4>Intelligence</h4>` | `<h3>Intelligence</h3>` |
| HomePageClient.tsx | 1278 | Wiki footer heading | `<h4>Wiki</h4>` | `<h3>Wiki</h3>` |
| AskBar.tsx | 326 | Placeholder text contrast | `placeholder:text-zinc-600` | `placeholder:text-zinc-400` |
| AskBar.tsx | 347,350 | Loading helper text contrast | `text-zinc-500` | `text-zinc-400` |
| AskBar.tsx | 372 | Sources label contrast | `text-zinc-500` | `text-zinc-400` |
| AskBar.tsx | 392,397,402 | Source metadata contrast | `text-zinc-600/500` | `text-zinc-400` |
| EcosystemStackCard.tsx | 23 | Expand toggle aria-label | `aria-expanded={expanded}` | `aria-expanded={expanded} aria-label="Expand/Collapse {title} tech stack"` |

## Test Plan
- [x] `npm run build` passes
- [x] `npm test` passes (1 pre-existing failure in HomePageClient unrelated to these changes)
- [ ] Manual screen reader testing (NVDA/JAWS) to verify button announcements

## References
- Refs: `.audit/a11y-baseline.md` Quick Wins section
- WCAG 2.1 Level AA compliance
- Impact: 14 high-priority button labels + 6 contrast fixes + 3 heading structure fixes

Generated with Claude Code