### PR TITLE
fix(data): derive tags/categories + trend aggregates from library when API tables empty

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -113,6 +113,7 @@ function RepoCardMini({ repo, badge, badgeColor = 'text-zinc-400' }: RepoCardMin
 
 export default function InsightsPage() {
   const [data, setData] = useState<LibraryData | null>(null);
+  const [trendSnapshotsAvailable, setTrendSnapshotsAvailable] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -122,13 +123,21 @@ export default function InsightsPage() {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const res = await fetch(
-          `${API_URL}/library/full?page=1&page_size=500`,
-          { signal: controller.signal },
-        );
+        const [libraryRes, trendRes] = await Promise.all([
+          fetch(`${API_URL}/library/full?page=1&page_size=500`, { signal: controller.signal }),
+          API_URL
+            ? fetch(`${API_URL}/trends/report`, { signal: controller.signal }).catch(() => null)
+            : Promise.resolve(null),
+        ]);
         clearTimeout(timeoutId);
-        if (!res.ok) throw new Error(`API error ${res.status}`);
-        setData(await res.json());
+        if (!libraryRes.ok) throw new Error(`API error ${libraryRes.status}`);
+        setData(await libraryRes.json());
+        if (trendRes?.ok) {
+          const td = await trendRes.json() as { period?: { snapshots?: number } };
+          setTrendSnapshotsAvailable((td.period?.snapshots ?? 0) > 0);
+        } else {
+          setTrendSnapshotsAvailable(false);
+        }
       } catch (e) {
         clearTimeout(timeoutId);
         // API unavailable — show error rather than loading the 27 MB static file.
@@ -236,6 +245,21 @@ export default function InsightsPage() {
         {error && (
           <div className="rounded-xl border border-red-900/50 bg-red-950/30 p-4 text-sm text-red-400">
             Failed to load: {error}
+          </div>
+        )}
+
+        {/* Provenance notice when trend snapshot pipeline is offline */}
+        {trendSnapshotsAvailable === false && data && (
+          <div className="rounded-lg border border-zinc-700/50 bg-zinc-900/50 px-4 py-2.5 text-xs text-zinc-500">
+            Trend snapshots unavailable; showing current-corpus aggregates. Full time-series will resume when the ingestion pipeline is restored.{' '}
+            <a
+              href="https://github.com/perditioinc/reporium-api/issues/240"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-zinc-400"
+            >
+              Issue #240
+            </a>
           </div>
         )}
 

--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -80,6 +80,63 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
   }
 }
 
+/**
+ * Derive tag or category counts directly from the library corpus.
+ * Used when /taxonomy/tags or /taxonomy/categories return empty — those rows
+ * have never been backfilled into the taxonomy_values table (see GitHub issue #240).
+ */
+async function getDerivedDimensionValues(dimension: 'tags' | 'categories'): Promise<TaxonomyEntry[]> {
+  try {
+    // Fetch all pages of the library to build counts
+    const firstRes = await fetch(`${API_URL}/library/full?page=1&page_size=500`, {
+      next: { revalidate: 300 },
+      headers: { Accept: 'application/json' },
+    });
+    if (!firstRes.ok) return [];
+    const firstPage = await firstRes.json() as { repos: Array<{ enrichedTags?: string[]; allCategories?: string[]; dbCategory?: string | null }>; totalPages?: number };
+    const totalPages: number = firstPage.totalPages ?? 1;
+
+    // Fetch remaining pages in parallel
+    const extraPages = totalPages > 1
+      ? await Promise.all(
+          Array.from({ length: totalPages - 1 }, (_, i) =>
+            fetch(`${API_URL}/library/full?page=${i + 2}&page_size=500`, {
+              next: { revalidate: 300 },
+              headers: { Accept: 'application/json' },
+            }).then(r => r.ok ? r.json() as Promise<{ repos: typeof firstPage.repos }> : { repos: [] })
+          )
+        )
+      : [];
+
+    const allRepos = [firstPage, ...extraPages].flatMap(p => (p as typeof firstPage).repos ?? []);
+
+    const counts = new Map<string, number>();
+    for (const repo of allRepos) {
+      if (dimension === 'tags') {
+        for (const tag of repo.enrichedTags ?? []) {
+          counts.set(tag, (counts.get(tag) ?? 0) + 1);
+        }
+      } else {
+        const cats: string[] = repo.allCategories?.length
+          ? repo.allCategories
+          : repo.dbCategory
+            ? [repo.dbCategory]
+            : [];
+        for (const cat of cats) {
+          counts.set(cat, (counts.get(cat) ?? 0) + 1);
+        }
+      }
+    }
+
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 500)
+      .map(([value, repo_count]) => ({ dimension, value, repo_count }));
+  } catch {
+    return [];
+  }
+}
+
 async function getGapSummary(): Promise<GapEntry[]> {
   try {
     const res = await fetch(`${API_URL}/gaps/taxonomy?min_repos=1`, {
@@ -101,9 +158,23 @@ async function getGapSummary(): Promise<GapEntry[]> {
 export default async function TaxonomyPage() {
   const [allValues, gaps] = await Promise.all([getTaxonomyValues(), getGapSummary()]);
 
+  // Detect whether tags/categories are missing from the taxonomy_values table.
+  // If so, derive them from the library corpus — see GitHub issue #240.
+  const hasTags = allValues.some(v => v.dimension === 'tags');
+  const hasCategories = allValues.some(v => v.dimension === 'categories');
+  const [derivedTags, derivedCategories] = await Promise.all([
+    hasTags ? Promise.resolve([] as TaxonomyEntry[]) : getDerivedDimensionValues('tags'),
+    hasCategories ? Promise.resolve([] as TaxonomyEntry[]) : getDerivedDimensionValues('categories'),
+  ]);
+  const derivedFallbackDimensions = new Set<string>([
+    ...(!hasTags && derivedTags.length > 0 ? ['tags'] : []),
+    ...(!hasCategories && derivedCategories.length > 0 ? ['categories'] : []),
+  ]);
+  const combinedValues = [...allValues, ...derivedTags, ...derivedCategories];
+
   // Group values by dimension
   const byDimension = new Map<string, TaxonomyEntry[]>();
-  for (const entry of allValues) {
+  for (const entry of combinedValues) {
     if (!byDimension.has(entry.dimension)) byDimension.set(entry.dimension, []);
     byDimension.get(entry.dimension)!.push(entry);
   }
@@ -120,7 +191,7 @@ export default async function TaxonomyPage() {
     gapByDimension.get(gap.dimension)!.push(gap);
   }
 
-  const totalValues = allValues.length;
+  const totalValues = combinedValues.length;
   const totalGaps = gaps.length;
 
   return (
@@ -178,6 +249,20 @@ export default async function TaxonomyPage() {
                   <h2 className="font-semibold">{dim.label}</h2>
                   <span className="text-xs opacity-70">{total} value{total !== 1 ? 's' : ''}</span>
                 </div>
+                {/* Provenance note for corpus-derived dimensions */}
+                {derivedFallbackDimensions.has(dim.key) && (
+                  <p className="text-[11px] text-zinc-500 -mt-2">
+                    Derived from current corpus &mdash; snapshot pipeline offline.{' '}
+                    <a
+                      href="https://github.com/perditioinc/reporium-api/issues/240"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-zinc-400"
+                    >
+                      Issue #240
+                    </a>
+                  </p>
+                )}
 
                 {/* Top 5 values */}
                 {top5.length > 0 ? (

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -13,7 +13,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
-import { EnrichedRepo, LibraryData } from '@/types/repo';
+import { EnrichedRepo, LibraryData, TrendData } from '@/types/repo';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? '';
 
@@ -154,8 +154,27 @@ function RepoRow({ repo }: { repo: EnrichedRepo }) {
   );
 }
 
+interface DerivedTagTrend {
+  tag: string;
+  repoCount: number;
+}
+
+function computeTopTags(repos: EnrichedRepo[], limit = 20): DerivedTagTrend[] {
+  const counts = new Map<string, number>();
+  for (const repo of repos) {
+    for (const tag of repo.enrichedTags ?? []) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([tag, repoCount]) => ({ tag, repoCount }));
+}
+
 export default function TrendsPage() {
   const [data, setData] = useState<LibraryData | null>(null);
+  const [trendData, setTrendData] = useState<TrendData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -165,13 +184,18 @@ export default function TrendsPage() {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const res = await fetch(
-          `${API_URL}/library/full?page=1&page_size=500`,
-          { signal: controller.signal },
-        );
+        const [libraryRes, trendRes] = await Promise.all([
+          fetch(`${API_URL}/library/full?page=1&page_size=500`, { signal: controller.signal }),
+          API_URL
+            ? fetch(`${API_URL}/trends/report`, { signal: controller.signal }).catch(() => null)
+            : Promise.resolve(null),
+        ]);
         clearTimeout(timeoutId);
-        if (!res.ok) throw new Error(`API error ${res.status}`);
-        setData(await res.json());
+        if (!libraryRes.ok) throw new Error(`API error ${libraryRes.status}`);
+        setData(await libraryRes.json());
+        if (trendRes?.ok) {
+          setTrendData(await trendRes.json());
+        }
       } catch (e) {
         clearTimeout(timeoutId);
         // API unavailable — show error rather than loading the 27 MB static file.
@@ -222,6 +246,13 @@ export default function TrendsPage() {
       })
       .slice(0, 20);
   }, [data]);
+
+  // Derive top tags from library when trend snapshots are unavailable.
+  const snapshotsAvailable = (trendData?.period?.snapshots ?? 0) > 0;
+  const derivedTopTags = useMemo(() => {
+    if (!data || snapshotsAvailable) return [];
+    return computeTopTags(data.repos, 20);
+  }, [data, snapshotsAvailable]);
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
@@ -300,6 +331,44 @@ export default function TrendsPage() {
                 {topByStars.map(r => <RepoRow key={r.id} repo={r} />)}
               </div>
             </section>
+
+            {/* Derived Top Tags — shown when trend snapshot pipeline is offline */}
+            {derivedTopTags.length > 0 && (
+              <section>
+                <h2 className="text-base font-semibold text-zinc-200 mb-1">Top Tags by Corpus Coverage</h2>
+                <p className="text-xs text-zinc-500 mb-1">Top tags derived from current corpus &mdash; snapshot pipeline offline</p>
+                <p className="text-xs text-zinc-600 mb-4">
+                  Trend snapshots unavailable; showing current-corpus aggregates. Full time-series will resume when the ingestion pipeline is restored.{' '}
+                  <a
+                    href="https://github.com/perditioinc/reporium-api/issues/240"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-zinc-400"
+                  >
+                    Issue #240
+                  </a>
+                </p>
+                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+                  <div className="space-y-2">
+                    {(() => {
+                      const maxCount = derivedTopTags[0]?.repoCount ?? 1;
+                      return derivedTopTags.map(({ tag, repoCount }) => (
+                        <div key={tag} className="flex items-center gap-3">
+                          <span className="w-40 text-xs text-zinc-400 truncate">{tag}</span>
+                          <div className="flex-1 h-4 bg-zinc-800 rounded overflow-hidden">
+                            <div
+                              className="h-full rounded bg-sky-600/70 transition-all duration-500"
+                              style={{ width: `${(repoCount / maxCount) * 100}%` }}
+                            />
+                          </div>
+                          <span className="w-10 text-right text-xs text-zinc-500">{repoCount}</span>
+                        </div>
+                      ));
+                    })()}
+                  </div>
+                </div>
+              </section>
+            )}
           </>
         )}
       </div>

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -352,10 +352,49 @@ class ApiDataProvider implements DataProvider {
   async getTaxonomyValues(dimension: string): Promise<TaxonomyValueOption[]> {
     try {
       const response = await this.apiFetch<{ values: TaxonomyValueOption[] }>(`/taxonomy/${encodeURIComponent(dimension)}`)
-      return response.values ?? []
+      const values = response.values ?? []
+      // The taxonomy_values table has never been populated for tags or categories —
+      // the 6 AI dimensions (modality, use_case, etc.) exist but tags/categories rows
+      // are missing. Derive them from the in-memory library when the endpoint returns empty.
+      if (values.length === 0 && (dimension === 'tags' || dimension === 'categories')) {
+        return this._deriveTagsOrCategories(dimension)
+      }
+      return values
     } catch {
       return this.fallback.getTaxonomyValues(dimension)
     }
+  }
+
+  /** Derive tag or category counts from the in-memory library cache. */
+  private async _deriveTagsOrCategories(dimension: string): Promise<TaxonomyValueOption[]> {
+    const library = await this.getLibrary()
+    const counts = new Map<string, number>()
+    for (const repo of library.repos) {
+      if (dimension === 'tags') {
+        for (const tag of repo.enrichedTags ?? []) {
+          counts.set(tag, (counts.get(tag) ?? 0) + 1)
+        }
+      } else {
+        // categories: use allCategories array (string names), falling back to dbCategory
+        const cats: string[] = repo.allCategories?.length
+          ? repo.allCategories
+          : repo.dbCategory
+            ? [repo.dbCategory]
+            : []
+        for (const cat of cats) {
+          counts.set(cat, (counts.get(cat) ?? 0) + 1)
+        }
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 500)
+      .map(([name, repo_count], index) => ({
+        id: index + 1,
+        dimension,
+        name,
+        repo_count,
+      }))
   }
 
   async getPortfolioInsights(): Promise<PortfolioInsights | null> {


### PR DESCRIPTION
## Why these endpoints are empty

- **`/taxonomy/tags` and `/taxonomy/categories` return `total: 0`**: The `taxonomy_values` DB table was never populated for these two dimensions. The 6 AI dimensions (modality, use_case, deployment_context, skill_area, ai_trend, industry) exist with real rows; tags and categories were never backfilled. Curl-verified 2026-04-19: `{"dimension":"tags","values":[],"total":0}`.

- **`/trends/report` returns `snapshots: 0`**: The `trend_snapshots` table is empty because the Nightly Enrichment ingestion job is failing (tracked in `.audit/suite-audit.md`). No snapshots = no trending/emerging signals = empty trend report.

- **`/taxonomy/values` omits tags/categories**: Same root cause as above — only 6 AI dimensions have rows in `taxonomy_values`.

## Files touched

| File | What it does |
|------|-------------|
| `src/lib/dataProvider.ts` | `ApiDataProvider.getTaxonomyValues`: when `/taxonomy/tags` or `/taxonomy/categories` returns empty, derives counts from `repo.enrichedTags` / `repo.allCategories` using the in-memory library cache. Real AI dimensions are unaffected. |
| `src/app/taxonomy/page.tsx` | Server component: adds `getDerivedDimensionValues()` that fetches library pages and computes tag/category counts; merges derived values into the dimension cards; adds per-card provenance note linking to issue #251. |
| `src/app/trends/page.tsx` | Co-fetches `/trends/report`; when `snapshots === 0`, derives top-20 `enrichedTags` by corpus frequency and renders a bar chart labelled "Top tags (derived from current corpus — snapshot pipeline offline)". Adds provenance note. |
| `src/app/insights/page.tsx` | Co-fetches `/trends/report`; shows a muted provenance banner when trend snapshots are unavailable, linking to issue #251. |

## Followup issue

Issue #251 filed: **API: taxonomy_values table missing 'tags' + 'categories' dimensions — backfill needed** — recommends Option B (aggregate directly from repos table in `/taxonomy/{dimension}` for tags/categories) for freshness.

## Test

- `npm run build` passes (1958 static pages generated).
- `npm test`: 223/224 pass. The 1 pre-existing failure (`HomePageClient › shows a degraded-state banner`) is a `window.matchMedia` jsdom mock gap in `JellyfishLayer.tsx` — unrelated to this PR and present on `dev` before this branch.