### PR TITLE
security: CSP + HSTS + Permissions-Policy headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,10 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()" },
         { "key": "X-DNS-Prefetch-Control", "value": "on" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data:; connect-src 'self' https://reporium-api-573778300586.us-central1.run.app https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.vercel.app; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://browser.sentry-cdn.com https://*.ingest.sentry.io https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data: blob:; connect-src 'self' https://reporium-api-573778300586.us-central1.run.app https://*.ingest.sentry.io https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.vercel.app wss:; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Addresses Phase 9 audit finding (`.audit/2026-04-20/phase-9-10-perf-docs.md`): CSP, HSTS, and Permissions-Policy headers were incomplete or missing Sentry/wss origins.

**Changes to `vercel.json` (merged, not overwritten):**
- **CSP** — expanded from existing policy:
  - `script-src`: added `https://browser.sentry-cdn.com` and `https://*.ingest.sentry.io` (defensive — Sentry SDK referenced in `next.config.js` instrumentation)
  - `img-src`: added `blob:` (needed for canvas/blob image URLs)
  - `connect-src`: added `https://*.ingest.sentry.io` and `wss:` (WebSocket connections)
  - `font-src`: added `data:` (inline font data URIs)
  - Added `upgrade-insecure-requests` directive
- **HSTS** — already present (`max-age=63072000; includeSubDomains; preload`), no change needed; eligible for submission to hstspreload.org after this merges to main
- **Permissions-Policy** — expanded from `camera=(), microphone=(), geolocation=()` to also include `payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()`

## CSP tradeoff note

CSP uses `'unsafe-inline'` for `script-src` due to Next.js static-export inline bootstrap — this is the industry-standard tradeoff for `output: export` deployments. `strict-dynamic` + nonces are not compatible with static export. `frame-ancestors 'none'` aligns with the existing `X-Frame-Options: DENY` header.

## Validation performed

- `src/app/layout.tsx` reviewed — no third-party `<Script>` components; uses Next.js `<head>` with preconnect links to Cloud Run API only
- `src/lib/dataProvider.ts` reviewed — only calls `reporium-api-573778300586.us-central1.run.app` (already in connect-src)
- `src/lib/apiUrl.ts` reviewed — dev proxy (`/api/proxy`) routes through self; production uses the Cloud Run URL
- GitHub avatar URLs (`https://avatars.githubusercontent.com`) preserved from existing CSP
- Google Fonts (`https://fonts.googleapis.com`, `https://fonts.gstatic.com`) preserved from existing CSP
- Local build: `npm run build` passed (1958 pages, 0 errors)

## Test plan

- [ ] After Vercel preview deploys, open browser DevTools → Console and check for any CSP violation errors
- [ ] Check Network tab for any blocked requests
- [ ] If violations appear, identify the blocked origin and add it to the appropriate CSP directive before promoting to main
- [ ] Rollback: `git revert 8b65736` if CSP breaks functionality

## Notes

- Headers in `vercel.json` only take effect in Vercel deployments (not `next dev` or `next start` locally — Next.js static export ignores `headers()` config and `vercel.json` headers are applied at the CDN layer)
- HSTS `preload` flag: after this merges to main and the site is confirmed stable, submit to https://hstspreload.org for browser preload list inclusion