### PR TITLE
fix(frontend): forward X-App-Token, correct similar route, per-dimension taxonomy fetch

### DIFF
--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -61,10 +61,15 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
   const provider = createDataProvider();
   if (provider.mode === 'production') {
     const p = provider as import('@/lib/dataProvider').DataProvider & {
-      getTaxonomyAllValues?: (limit?: number) => Promise<TaxonomyEntry[]>
+      getTaxonomyValuesByDimensions?: (
+        dims: readonly string[],
+        limit?: number,
+      ) => Promise<TaxonomyEntry[]>
     }
-    if (typeof p.getTaxonomyAllValues === 'function') {
-      return p.getTaxonomyAllValues(500)
+    // Fetch each dimension individually (parallel) so high-cardinality dimensions
+    // like tags don't starve the others under a global top-N cap.
+    if (typeof p.getTaxonomyValuesByDimensions === 'function') {
+      return p.getTaxonomyValuesByDimensions(DIMENSIONS.map(d => d.key), 100)
     }
   }
   return []
@@ -77,31 +82,12 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
  */
 async function getDerivedDimensionValues(dimension: 'tags' | 'categories'): Promise<TaxonomyEntry[]> {
   try {
-    // Fetch all pages of the library to build counts
-    const firstRes = await fetch(`${API_URL}/library/full?page=1&page_size=500`, {
-      next: { revalidate: 300 },
-      headers: { Accept: 'application/json' },
-    });
-    if (!firstRes.ok) return [];
-    const firstPage = await firstRes.json() as { repos: Array<{ enrichedTags?: string[]; allCategories?: string[]; dbCategory?: string | null }>; totalPages?: number };
-    const totalPages: number = firstPage.totalPages ?? 1;
-
-    // Fetch remaining pages in parallel
-    const extraPages = totalPages > 1
-      ? await Promise.all(
-          Array.from({ length: totalPages - 1 }, (_, i) =>
-            fetch(`${API_URL}/library/full?page=${i + 2}&page_size=500`, {
-              next: { revalidate: 300 },
-              headers: { Accept: 'application/json' },
-            }).then(r => r.ok ? r.json() as Promise<{ repos: typeof firstPage.repos }> : { repos: [] })
-          )
-        )
-      : [];
-
-    const allRepos = [firstPage, ...extraPages].flatMap(p => (p as typeof firstPage).repos ?? []);
+    const provider = createDataProvider();
+    const library = await provider.getLibrary();
+    const repos = library.repos ?? [];
 
     const counts = new Map<string, number>();
-    for (const repo of allRepos) {
+    for (const repo of repos) {
       if (dimension === 'tags') {
         for (const tag of repo.enrichedTags ?? []) {
           counts.set(tag, (counts.get(tag) ?? 0) + 1);

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -244,12 +244,28 @@ class ApiDataProvider implements DataProvider {
     this.fallback = new JsonDataProvider()
   }
 
+  /**
+   * Build request headers, attaching `X-App-Token` when the NEXT_PUBLIC_APP_API_TOKEN
+   * env var is inlined at build time (see next.config.js). Without this header,
+   * protected endpoints (e.g. /intelligence/portfolio-insights) silently 403 and
+   * callers fall through to the JSON fallback path.
+   */
+  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      ...(extra ?? {}),
+    }
+    const token = process.env.NEXT_PUBLIC_APP_API_TOKEN
+    if (token) headers['X-App-Token'] = token
+    return headers
+  }
+
   private async apiFetch<T>(path: string, timeoutMs = 30_000): Promise<T> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
-        headers: { 'Accept': 'application/json' },
+        headers: this.buildHeaders(),
         signal: controller.signal,
       })
       if (!res.ok) throw new Error(`API error: ${res.status}`)
@@ -265,10 +281,7 @@ class ApiDataProvider implements DataProvider {
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
         method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        },
+        headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(body),
         signal: controller.signal,
       })
@@ -468,7 +481,14 @@ class ApiDataProvider implements DataProvider {
 
   async getSimilarRepos(name: string, limit = 5): Promise<SimilarRepo[]> {
     try {
-      return await this.apiFetch<SimilarRepo[]>(`/repos/${encodeURIComponent(name)}/similar?limit=${limit}`)
+      // API exposes `/intelligence/similar/{name}` returning { source_repo, similar, total }.
+      // The legacy `/repos/{name}/similar` path no longer exists. Unwrap `.similar`
+      // to preserve the raw-array contract existing call sites rely on.
+      const data = await this.apiFetch<{ similar?: SimilarRepo[] } | SimilarRepo[]>(
+        `/intelligence/similar/${encodeURIComponent(name)}?limit=${limit}`
+      )
+      if (Array.isArray(data)) return data
+      return (data as { similar?: SimilarRepo[] }).similar ?? []
     } catch {
       return this.fallback.getSimilarRepos(name, limit)
     }
@@ -496,6 +516,32 @@ class ApiDataProvider implements DataProvider {
     } catch {
       return []
     }
+  }
+
+  /**
+   * Fetch values per-dimension in parallel, then flatten to the `{dimension, value, repo_count}`
+   * shape expected by the taxonomy explorer. Avoids the global-top-N cap of `/taxonomy/values`
+   * which lets a single high-cardinality dimension starve all others.
+   */
+  async getTaxonomyValuesByDimensions(
+    dimensions: readonly string[],
+    perDimensionLimit = 100,
+  ): Promise<{ dimension: string; value: string; repo_count?: number; count?: number }[]> {
+    const results = await Promise.all(
+      dimensions.map(async (dim) => {
+        try {
+          const values = await this.getTaxonomyValues(dim)
+          return values.slice(0, perDimensionLimit).map((v) => ({
+            dimension: dim,
+            value: v.name,
+            repo_count: v.repo_count,
+          }))
+        } catch {
+          return []
+        }
+      })
+    )
+    return results.flat()
   }
 
   async getGapTaxonomy(minRepos = 1): Promise<{ dimension: string; value: string; repo_count: number; gap_score?: number }[]> {

--- a/tests/TaxonomyPage.test.tsx
+++ b/tests/TaxonomyPage.test.tsx
@@ -21,31 +21,58 @@ describe('TaxonomyPage', () => {
     process.env = originalEnv;
   });
 
+  // Per-dimension seed values used by the fetch mock below.
+  const dimSeed: Record<string, { name: string; repo_count: number }> = {
+    skill_area: { name: 'Agents', repo_count: 10 },
+    industry: { name: 'Healthcare', repo_count: 7 },
+    use_case: { name: 'Code generation', repo_count: 6 },
+    modality: { name: 'Text', repo_count: 9 },
+    ai_trend: { name: 'Agentic AI', repo_count: 8 },
+    deployment_context: { name: 'Cloud', repo_count: 5 },
+    tags: { name: 'production-ready', repo_count: 4 },
+    maturity_level: { name: 'production', repo_count: 3 },
+  };
+
+  function buildFetchMock(opts: { dimHasValues: boolean; gaps: Array<Record<string, unknown>> }) {
+    return jest.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      // Per-dimension taxonomy endpoint: /taxonomy/{dim}
+      const dimMatch = url.match(/\/taxonomy\/([a-z_]+)(?:$|\?)/);
+      if (dimMatch) {
+        const dim = dimMatch[1];
+        const seed = dimSeed[dim];
+        return {
+          ok: true,
+          json: async () => ({
+            dimension: dim,
+            values: opts.dimHasValues && seed
+              ? [{ id: 1, dimension: dim, name: seed.name, repo_count: seed.repo_count }]
+              : [],
+          }),
+        };
+      }
+      if (url.includes('/gaps/taxonomy')) {
+        return { ok: true, json: async () => ({ gaps: opts.gaps }) };
+      }
+      if (url.includes('/library/full')) {
+        // getDerivedDimensionValues routes through getLibrary()
+        return {
+          ok: true,
+          json: async () => ({ repos: [], totalPages: 1, totalRepos: 0 }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  }
+
   test('renders 8 dimension cards', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          { dimension: 'skill_area', value: 'Agents', repo_count: 10 },
-          { dimension: 'industry', value: 'Healthcare', repo_count: 7 },
-          { dimension: 'use_case', value: 'Code generation', repo_count: 6 },
-          { dimension: 'modality', value: 'Text', repo_count: 9 },
-          { dimension: 'ai_trend', value: 'Agentic AI', repo_count: 8 },
-          { dimension: 'deployment_context', value: 'Cloud', repo_count: 5 },
-          { dimension: 'tags', value: 'production-ready', repo_count: 4 },
-          { dimension: 'maturity_level', value: 'production', repo_count: 3 },
-        ],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-            { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: true,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+        { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);
@@ -61,20 +88,12 @@ describe('TaxonomyPage', () => {
   });
 
   test('renders gap chips with the expected labels', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: false,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);


### PR DESCRIPTION
## Summary
Three surgical frontend data-layer fixes landed as one PR targeting dev.

- **apiFetch X-App-Token forwarding** — `apiFetch()` / `apiPost()` now attach `X-App-Token` from `NEXT_PUBLIC_APP_API_TOKEN` when set. Without this header, protected endpoints like `/intelligence/portfolio-insights` silently 403 and fall through to the JSON fallback, rendering the live endpoint effectively unused. (This does not address the separate architectural concern that the token is publicly inlined — tracked separately. For now, if the token is in the bundle anyway, use it correctly.)
- **Similar repos route corrected** — `getSimilarRepos()` called the non-existent `/repos/{name}/similar`. Now calls `/intelligence/similar/{name}` and unwraps `.similar` to preserve the raw-array contract existing call sites rely on. `SimilarReposPanel` already preferred `getIntelligenceSimilar()`, so no call-site changes were required beyond `dataProvider.ts`.
- **Per-dimension taxonomy fetch** — `/taxonomy/page.tsx` fetched `/taxonomy/values?limit=500` once, which is globally sorted by `repo_count`. High-cardinality dimensions filled the 500 rows, leaving other cards showing "No values indexed yet". Added `ApiDataProvider.getTaxonomyValuesByDimensions()` which fans out per dimension (`/taxonomy/{dim}`) in parallel with a 100/dim cap. Also routed the derived-tags/categories fallback through `provider.getLibrary()` instead of a broken direct fetch that referenced an undefined `API_URL`.

## Test plan
- [x] `npm test` — 226 passed, 28 suites
- [x] `npm run build` — static export completes cleanly
- [ ] After deploy: verify `/taxonomy` shows values in all 8 dimension cards (no more "No values indexed yet" for Skill Areas / Use Cases etc.)
- [ ] After deploy: check network tab for `X-App-Token` on `/intelligence/*` requests; confirm `/intelligence/portfolio-insights` returns 200 rather than 403
- [ ] After deploy: open a repo detail page; confirm Similar Repos panel renders (request should go to `/intelligence/similar/{name}`)

Generated with [Claude Code](https://claude.com/claude-code)