### PR TITLE
promote: dev → main (taxonomy API_URL, X-App-Token forwarding, similar route)

### DIFF
--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -61,10 +61,15 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
   const provider = createDataProvider();
   if (provider.mode === 'production') {
     const p = provider as import('@/lib/dataProvider').DataProvider & {
-      getTaxonomyAllValues?: (limit?: number) => Promise<TaxonomyEntry[]>
+      getTaxonomyValuesByDimensions?: (
+        dims: readonly string[],
+        limit?: number,
+      ) => Promise<TaxonomyEntry[]>
     }
-    if (typeof p.getTaxonomyAllValues === 'function') {
-      return p.getTaxonomyAllValues(500)
+    // Fetch each dimension individually (parallel) so high-cardinality dimensions
+    // like tags don't starve the others under a global top-N cap.
+    if (typeof p.getTaxonomyValuesByDimensions === 'function') {
+      return p.getTaxonomyValuesByDimensions(DIMENSIONS.map(d => d.key), 100)
     }
   }
   return []
@@ -77,31 +82,12 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
  */
 async function getDerivedDimensionValues(dimension: 'tags' | 'categories'): Promise<TaxonomyEntry[]> {
   try {
-    // Fetch all pages of the library to build counts
-    const firstRes = await fetch(`${API_URL}/library/full?page=1&page_size=500`, {
-      next: { revalidate: 300 },
-      headers: { Accept: 'application/json' },
-    });
-    if (!firstRes.ok) return [];
-    const firstPage = await firstRes.json() as { repos: Array<{ enrichedTags?: string[]; allCategories?: string[]; dbCategory?: string | null }>; totalPages?: number };
-    const totalPages: number = firstPage.totalPages ?? 1;
-
-    // Fetch remaining pages in parallel
-    const extraPages = totalPages > 1
-      ? await Promise.all(
-          Array.from({ length: totalPages - 1 }, (_, i) =>
-            fetch(`${API_URL}/library/full?page=${i + 2}&page_size=500`, {
-              next: { revalidate: 300 },
-              headers: { Accept: 'application/json' },
-            }).then(r => r.ok ? r.json() as Promise<{ repos: typeof firstPage.repos }> : { repos: [] })
-          )
-        )
-      : [];
-
-    const allRepos = [firstPage, ...extraPages].flatMap(p => (p as typeof firstPage).repos ?? []);
+    const provider = createDataProvider();
+    const library = await provider.getLibrary();
+    const repos = library.repos ?? [];
 
     const counts = new Map<string, number>();
-    for (const repo of allRepos) {
+    for (const repo of repos) {
       if (dimension === 'tags') {
         for (const tag of repo.enrichedTags ?? []) {
           counts.set(tag, (counts.get(tag) ?? 0) + 1);

--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -50,6 +50,7 @@ const DIMENSIONS = [
   { key: 'ai_trend',            label: 'AI Trends',           color: 'border-cyan-700/40 bg-cyan-900/20 text-cyan-300',        badge: 'border-cyan-700/30 bg-cyan-900/30 text-cyan-300' },
   { key: 'deployment_context',  label: 'Deployment Context',  color: 'border-orange-700/40 bg-orange-900/20 text-orange-300',  badge: 'border-orange-700/30 bg-orange-900/30 text-orange-300' },
   { key: 'tags',                label: 'Tags',                color: 'border-zinc-700 bg-zinc-800/40 text-zinc-300',           badge: 'border-zinc-700 bg-zinc-800/70 text-zinc-200' },
+  { key: 'categories',          label: 'Categories',          color: 'border-rose-700/40 bg-rose-900/20 text-rose-300',        badge: 'border-rose-700/30 bg-rose-900/30 text-rose-300' },
   { key: 'maturity_level',      label: 'Maturity Level',      color: 'border-emerald-700/40 bg-emerald-900/20 text-emerald-300', badge: 'border-emerald-700/30 bg-emerald-900/30 text-emerald-300' },
 ] as const;
 

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -244,12 +244,28 @@ class ApiDataProvider implements DataProvider {
     this.fallback = new JsonDataProvider()
   }
 
+  /**
+   * Build request headers, attaching `X-App-Token` when the NEXT_PUBLIC_APP_API_TOKEN
+   * env var is inlined at build time (see next.config.js). Without this header,
+   * protected endpoints (e.g. /intelligence/portfolio-insights) silently 403 and
+   * callers fall through to the JSON fallback path.
+   */
+  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      ...(extra ?? {}),
+    }
+    const token = process.env.NEXT_PUBLIC_APP_API_TOKEN
+    if (token) headers['X-App-Token'] = token
+    return headers
+  }
+
   private async apiFetch<T>(path: string, timeoutMs = 30_000): Promise<T> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
-        headers: { 'Accept': 'application/json' },
+        headers: this.buildHeaders(),
         signal: controller.signal,
       })
       if (!res.ok) throw new Error(`API error: ${res.status}`)
@@ -265,10 +281,7 @@ class ApiDataProvider implements DataProvider {
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
         method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        },
+        headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(body),
         signal: controller.signal,
       })
@@ -468,7 +481,14 @@ class ApiDataProvider implements DataProvider {
 
   async getSimilarRepos(name: string, limit = 5): Promise<SimilarRepo[]> {
     try {
-      return await this.apiFetch<SimilarRepo[]>(`/repos/${encodeURIComponent(name)}/similar?limit=${limit}`)
+      // API exposes `/intelligence/similar/{name}` returning { source_repo, similar, total }.
+      // The legacy `/repos/{name}/similar` path no longer exists. Unwrap `.similar`
+      // to preserve the raw-array contract existing call sites rely on.
+      const data = await this.apiFetch<{ similar?: SimilarRepo[] } | SimilarRepo[]>(
+        `/intelligence/similar/${encodeURIComponent(name)}?limit=${limit}`
+      )
+      if (Array.isArray(data)) return data
+      return (data as { similar?: SimilarRepo[] }).similar ?? []
     } catch {
       return this.fallback.getSimilarRepos(name, limit)
     }
@@ -496,6 +516,32 @@ class ApiDataProvider implements DataProvider {
     } catch {
       return []
     }
+  }
+
+  /**
+   * Fetch values per-dimension in parallel, then flatten to the `{dimension, value, repo_count}`
+   * shape expected by the taxonomy explorer. Avoids the global-top-N cap of `/taxonomy/values`
+   * which lets a single high-cardinality dimension starve all others.
+   */
+  async getTaxonomyValuesByDimensions(
+    dimensions: readonly string[],
+    perDimensionLimit = 100,
+  ): Promise<{ dimension: string; value: string; repo_count?: number; count?: number }[]> {
+    const results = await Promise.all(
+      dimensions.map(async (dim) => {
+        try {
+          const values = await this.getTaxonomyValues(dim)
+          return values.slice(0, perDimensionLimit).map((v) => ({
+            dimension: dim,
+            value: v.name,
+            repo_count: v.repo_count,
+          }))
+        } catch {
+          return []
+        }
+      })
+    )
+    return results.flat()
   }
 
   async getGapTaxonomy(minRepos = 1): Promise<{ dimension: string; value: string; repo_count: number; gap_score?: number }[]> {

--- a/tests/TaxonomyPage.test.tsx
+++ b/tests/TaxonomyPage.test.tsx
@@ -21,31 +21,58 @@ describe('TaxonomyPage', () => {
     process.env = originalEnv;
   });
 
+  // Per-dimension seed values used by the fetch mock below.
+  const dimSeed: Record<string, { name: string; repo_count: number }> = {
+    skill_area: { name: 'Agents', repo_count: 10 },
+    industry: { name: 'Healthcare', repo_count: 7 },
+    use_case: { name: 'Code generation', repo_count: 6 },
+    modality: { name: 'Text', repo_count: 9 },
+    ai_trend: { name: 'Agentic AI', repo_count: 8 },
+    deployment_context: { name: 'Cloud', repo_count: 5 },
+    tags: { name: 'production-ready', repo_count: 4 },
+    maturity_level: { name: 'production', repo_count: 3 },
+  };
+
+  function buildFetchMock(opts: { dimHasValues: boolean; gaps: Array<Record<string, unknown>> }) {
+    return jest.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      // Per-dimension taxonomy endpoint: /taxonomy/{dim}
+      const dimMatch = url.match(/\/taxonomy\/([a-z_]+)(?:$|\?)/);
+      if (dimMatch) {
+        const dim = dimMatch[1];
+        const seed = dimSeed[dim];
+        return {
+          ok: true,
+          json: async () => ({
+            dimension: dim,
+            values: opts.dimHasValues && seed
+              ? [{ id: 1, dimension: dim, name: seed.name, repo_count: seed.repo_count }]
+              : [],
+          }),
+        };
+      }
+      if (url.includes('/gaps/taxonomy')) {
+        return { ok: true, json: async () => ({ gaps: opts.gaps }) };
+      }
+      if (url.includes('/library/full')) {
+        // getDerivedDimensionValues routes through getLibrary()
+        return {
+          ok: true,
+          json: async () => ({ repos: [], totalPages: 1, totalRepos: 0 }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  }
+
   test('renders 8 dimension cards', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          { dimension: 'skill_area', value: 'Agents', repo_count: 10 },
-          { dimension: 'industry', value: 'Healthcare', repo_count: 7 },
-          { dimension: 'use_case', value: 'Code generation', repo_count: 6 },
-          { dimension: 'modality', value: 'Text', repo_count: 9 },
-          { dimension: 'ai_trend', value: 'Agentic AI', repo_count: 8 },
-          { dimension: 'deployment_context', value: 'Cloud', repo_count: 5 },
-          { dimension: 'tags', value: 'production-ready', repo_count: 4 },
-          { dimension: 'maturity_level', value: 'production', repo_count: 3 },
-        ],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-            { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: true,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+        { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);
@@ -61,20 +88,12 @@ describe('TaxonomyPage', () => {
   });
 
   test('renders gap chips with the expected labels', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: false,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);


### PR DESCRIPTION
## Summary
Promotes PR #259 from dev to main. Closes three open Codex P1/P2 audit findings against remote main:

- **P1**: `src/app/taxonomy/page.tsx` references undefined `API_URL` — getDerivedDimensionValues now routes through provider.getLibrary()
- **P2**: `/intelligence/portfolio-insights` silently 403s → empty fallback — apiFetch now attaches X-App-Token via buildHeaders()
- **P2**: getSimilarRepos calls dead `/repos/{name}/similar` — rewired to `/intelligence/similar/{name}` with .similar unwrap

Single-commit promotion (#259 is the only diff between dev and main).

## Test plan
- [ ] Vercel preview builds on this PR (TypeScript compile validates API_URL fix)
- [ ] Taxonomy page loads tags + categories dims without fallback-to-empty
- [ ] SimilarReposPanel returns non-empty for a known repo
- [ ] Portfolio insights endpoint returns data (not the JSON fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)