### PR TITLE
fix(ui): banner stickiness — clear provider degraded state on Dismiss

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -838,7 +838,10 @@ export function HomePageClient() {
               <p>Live data is unavailable right now — showing your last cached snapshot.</p>
               <button
                 type="button"
-                onClick={() => setApiDegraded(false)}
+                onClick={() => {
+                  provider.clearDegradedState()
+                  setApiDegraded(false)
+                }}
                 className="shrink-0 rounded border border-amber-800/60 px-2 py-1 text-xs text-amber-100 transition-colors hover:bg-amber-900/30"
               >
                 Dismiss

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -23,6 +23,7 @@ export interface DataProvider {
   getOwnedLibrary(): Promise<LibraryData | null>
   getLibrary(onProgress?: (p: LoadProgress) => void): Promise<LibraryData>
   getDegradedState(): boolean
+  clearDegradedState(): void
   getTrends(): Promise<TrendData | null>
   getGaps(): Promise<GapAnalysis | null>
   getRepo(name: string): Promise<EnrichedRepo | null>
@@ -45,6 +46,10 @@ class JsonDataProvider implements DataProvider {
 
   getDegradedState(): boolean {
     return false
+  }
+
+  clearDegradedState(): void {
+    // no-op: JsonDataProvider is never degraded relative to itself
   }
 
   private estimateActivityScore(repo: EnrichedRepo): number {
@@ -330,6 +335,14 @@ class ApiDataProvider implements DataProvider {
 
   getDegradedState(): boolean {
     return this.degraded
+  }
+
+  clearDegradedState(): void {
+    // Reset the degraded flag so the "Live data is unavailable" banner does not
+    // re-appear after the user dismisses it and then navigates within the SPA.
+    // Without this, `this.degraded` latches true until _fetchLibrary() runs
+    // again — which is skipped whenever libraryCache is populated.
+    this.degraded = false
   }
 
   async getLibrary(onProgress?: (p: LoadProgress) => void): Promise<LibraryData> {


### PR DESCRIPTION
## Summary

Fixes the \"Live data is unavailable — showing your last cached snapshot\" banner reappearing after the user dismisses it and navigates within the SPA.

**Root cause:** Dismiss cleared local React state but not the module-scope `ApiDataProvider.degraded` flag. On re-mount, `getLibrary()` returned from cache without re-running `_fetchLibrary()` (the only place that resets the flag), so `getDegradedState()` still returned `true`.

**Fix (Option A, 4 lines of logic per `.audit/2026-04-22/banner-stickiness-plan.md`):**
- Add `clearDegradedState(): void` to the `DataProvider` interface
- `ApiDataProvider`: sets `this.degraded = false`
- `JsonDataProvider`: no-op (never degraded)
- Dismiss button (`HomePageClient.tsx:841`) calls `provider.clearDegradedState()` before local state clear

Option B (also cache the fallback data so we stop retrying) deferred; tracked in the scope doc. Option A is the minimum change that removes the user-visible bug without mutating cache behavior.

## Test plan

Manual (production API mode, network throttling in DevTools):
- [ ] Block `/library/full` → banner appears
- [ ] Click **Dismiss** → banner disappears
- [ ] Navigate to `/ai-native` and back to `/` → banner does **not** reappear
- [ ] Full page reload with API still blocked → banner reappears (expected — provider re-instantiated)
- [ ] After API comes back and user refreshes → banner does not appear
- [ ] `npx tsc --noEmit` clean (verified locally)

## Follow-ups (not in this PR)

- Assign a real JIRA ticket (`KAN-NEW` placeholder in commit — please re-write or amend with the real number before merge)
- Option B (cache fallback result) can be a follow-up if we ever see repeated retry-fail in production telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)