### PR TITLE
KAN-XX: thumbs up/down feedback toggle in StickyAskBar

### DIFF
--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -61,10 +61,15 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
   const provider = createDataProvider();
   if (provider.mode === 'production') {
     const p = provider as import('@/lib/dataProvider').DataProvider & {
-      getTaxonomyAllValues?: (limit?: number) => Promise<TaxonomyEntry[]>
+      getTaxonomyValuesByDimensions?: (
+        dims: readonly string[],
+        limit?: number,
+      ) => Promise<TaxonomyEntry[]>
     }
-    if (typeof p.getTaxonomyAllValues === 'function') {
-      return p.getTaxonomyAllValues(500)
+    // Fetch each dimension individually (parallel) so high-cardinality dimensions
+    // like tags don't starve the others under a global top-N cap.
+    if (typeof p.getTaxonomyValuesByDimensions === 'function') {
+      return p.getTaxonomyValuesByDimensions(DIMENSIONS.map(d => d.key), 100)
     }
   }
   return []
@@ -77,31 +82,12 @@ async function getTaxonomyValues(): Promise<TaxonomyEntry[]> {
  */
 async function getDerivedDimensionValues(dimension: 'tags' | 'categories'): Promise<TaxonomyEntry[]> {
   try {
-    // Fetch all pages of the library to build counts
-    const firstRes = await fetch(`${API_URL}/library/full?page=1&page_size=500`, {
-      next: { revalidate: 300 },
-      headers: { Accept: 'application/json' },
-    });
-    if (!firstRes.ok) return [];
-    const firstPage = await firstRes.json() as { repos: Array<{ enrichedTags?: string[]; allCategories?: string[]; dbCategory?: string | null }>; totalPages?: number };
-    const totalPages: number = firstPage.totalPages ?? 1;
-
-    // Fetch remaining pages in parallel
-    const extraPages = totalPages > 1
-      ? await Promise.all(
-          Array.from({ length: totalPages - 1 }, (_, i) =>
-            fetch(`${API_URL}/library/full?page=${i + 2}&page_size=500`, {
-              next: { revalidate: 300 },
-              headers: { Accept: 'application/json' },
-            }).then(r => r.ok ? r.json() as Promise<{ repos: typeof firstPage.repos }> : { repos: [] })
-          )
-        )
-      : [];
-
-    const allRepos = [firstPage, ...extraPages].flatMap(p => (p as typeof firstPage).repos ?? []);
+    const provider = createDataProvider();
+    const library = await provider.getLibrary();
+    const repos = library.repos ?? [];
 
     const counts = new Map<string, number>();
-    for (const repo of allRepos) {
+    for (const repo of repos) {
       if (dimension === 'tags') {
         for (const tag of repo.enrichedTags ?? []) {
           counts.set(tag, (counts.get(tag) ?? 0) + 1);

--- a/src/components/AskPanel.tsx
+++ b/src/components/AskPanel.tsx
@@ -4,6 +4,19 @@ import { useState, useRef, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { createDataProvider } from '@/lib/dataProvider';
 
+// Mirror-aware repo display — see StickyAskBar.formatRepoDisplay for rationale.
+const MIRROR_OWNER = 'perditioinc';
+
+function formatRepoDisplay(repo: { name: string; owner: string; forked_from: string | null }) {
+  if (repo.forked_from) {
+    return { label: repo.forked_from, href: `https://github.com/${repo.forked_from}`, isFork: true };
+  }
+  if (repo.owner.toLowerCase() === MIRROR_OWNER) {
+    return { label: repo.name, href: `https://github.com/${repo.owner}/${repo.name}`, isFork: true };
+  }
+  return { label: `${repo.owner}/${repo.name}`, href: `https://github.com/${repo.owner}/${repo.name}`, isFork: false };
+}
+
 // ---------------------------------------------------------------------------
 // Types matching /intelligence/ask response schema
 // ---------------------------------------------------------------------------
@@ -214,19 +227,23 @@ function AskPanelInner(_props: AskPanelProps) {
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {result.sources.map((repo) => {
                   const score = Math.round(repo.relevance_score * 100);
-                  const upstream = repo.forked_from ?? `${repo.owner}/${repo.name}`;
-                  const ghUrl = `https://github.com/${upstream}`;
+                  const display = formatRepoDisplay(repo);
                   return (
                     <a
                       key={`${repo.owner}/${repo.name}`}
-                      href={ghUrl}
+                      href={display.href}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="group block rounded-xl border border-zinc-800 bg-zinc-900/60 px-4 py-3 space-y-1.5 hover:border-zinc-600 transition-colors"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <span className="text-xs font-mono font-medium text-zinc-200 truncate group-hover:text-zinc-100">
-                          {upstream}
+                          {display.label}
+                          {display.isFork && (
+                            <span className="ml-1.5 rounded bg-zinc-800 px-1 py-0.5 text-[9px] uppercase tracking-wider text-zinc-500">
+                              fork
+                            </span>
+                          )}
                         </span>
                         <span className="shrink-0 rounded-full border border-sky-700/30 bg-sky-900/30 px-2 py-0.5 text-[10px] font-medium text-sky-300">
                           {score}%

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -89,9 +89,17 @@ interface TokensUsed {
   total: number;
 }
 
-interface SourcesEvent { type: 'sources'; sources: SourceRepo[]; cache_hit: boolean }
+interface SourcesEvent { type: 'sources'; sources: SourceRepo[]; cache_hit: boolean; route?: string }
 interface TokenEvent { type: 'token'; text: string }
-interface DoneEvent { type: 'done'; tokens: TokensUsed; cache_hit?: boolean }
+interface DoneEvent {
+  type: 'done';
+  tokens: TokensUsed;
+  model?: string;
+  latency_ms?: number;
+  route?: string;
+  cache_hit?: boolean;
+  cache_source?: string;
+}
 interface ErrorEvent { type: 'error'; message: string }
 type StreamEvent = SourcesEvent | TokenEvent | DoneEvent | ErrorEvent;
 
@@ -246,6 +254,77 @@ const AnswerSkeleton = memo(function AnswerSkeleton() {
       <ShimmerLine w="w-5/6" h="h-3" />
       <ShimmerLine w="w-4/5" h="h-3" />
       <ShimmerLine w="w-2/3" h="h-3" />
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// ResponseFooter — renders the trio (model · latency · tokens) under the
+// answer, with cache/route badges when applicable. Helps the user judge
+// cost, speed, and the path the system took to answer.
+// ---------------------------------------------------------------------------
+function shortModelName(model: string | null | undefined): string | null {
+  if (!model) return null;
+  // Trim provider date suffixes like "claude-haiku-4-5-20251001" → "haiku-4.5"
+  const m = model.toLowerCase();
+  if (m.includes('haiku')) return 'Haiku 4.5';
+  if (m.includes('sonnet')) return 'Sonnet 4';
+  if (m.includes('opus')) return 'Opus 4';
+  // Smart-router pseudo-models: "off-topic", "early-exit", route labels.
+  // Surface them so the user knows the LLM was bypassed.
+  return model;
+}
+
+function formatLatency(ms: number | null | undefined): string | null {
+  if (ms == null) return null;
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+const ResponseFooter = memo(function ResponseFooter({
+  model,
+  latencyMs,
+  tokens,
+  sourcesCount,
+  cacheHit,
+  routeLabel,
+}: {
+  model: string | null;
+  latencyMs: number | null;
+  tokens: { input: number; output: number; total: number };
+  sourcesCount: number;
+  cacheHit: boolean;
+  routeLabel: string | null;
+}) {
+  const modelLabel = shortModelName(model);
+  const latencyLabel = formatLatency(latencyMs);
+  const parts: string[] = [];
+  if (modelLabel) parts.push(modelLabel);
+  if (latencyLabel) parts.push(latencyLabel);
+  if (tokens.total > 0) parts.push(`${tokens.total.toLocaleString()} tokens`);
+  if (sourcesCount > 0) parts.push(`${sourcesCount} repos`);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500 font-mono">
+      {(cacheHit || routeLabel) && (
+        <span
+          className="rounded bg-emerald-950/40 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300/90"
+          title={routeLabel ? `Smart router: ${routeLabel}` : 'Cached response'}
+        >
+          ⚡ {routeLabel ?? 'cached'}
+        </span>
+      )}
+      {parts.map((p, i) => (
+        <span key={p}>
+          {p}
+          {i < parts.length - 1 && <span className="ml-2 text-zinc-700">·</span>}
+        </span>
+      ))}
+      {tokens.total > 0 && (tokens.input > 0 || tokens.output > 0) && (
+        <span className="text-zinc-600" title={`Input ${tokens.input} · Output ${tokens.output}`}>
+          ({tokens.input}↑ {tokens.output}↓)
+        </span>
+      )}
     </div>
   );
 });
@@ -574,6 +653,8 @@ export function StickyAskBar() {
   const [sources, setSources] = useState<SourceRepo[]>([]);
   const [revealedSourceCount, setRevealedSourceCount] = useState(0);
   const [tokensUsed, setTokensUsed] = useState<TokensUsed | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [cacheHit, setCacheHit] = useState(false);
@@ -738,6 +819,8 @@ export function StickyAskBar() {
     setSources([]);
     setRevealedSourceCount(0);
     setTokensUsed(null);
+    setModel(null);
+    setLatencyMs(null);
     setDone(false);
     setError(null);
     setCacheHit(false);
@@ -805,6 +888,8 @@ export function StickyAskBar() {
     setSources([]);
     setRevealedSourceCount(0);
     setTokensUsed(null);
+    setModel(null);
+    setLatencyMs(null);
     setDone(false);
     setCacheHit(false);
     setRouteLabel(null);
@@ -904,13 +989,17 @@ export function StickyAskBar() {
           if (event.type === 'sources') {
             setSources(event.sources);
             setPhase('sources');
-            if ('cache_hit' in event && event.cache_hit) setCacheHit(true);
-            if ('route' in event) setRouteLabel((event as Record<string, unknown>).route as string);
+            if (event.cache_hit) setCacheHit(true);
+            if (event.route) setRouteLabel(event.route);
           } else if (event.type === 'token') {
             setStreamingAnswer((prev) => prev + event.text);
             setPhase((p) => (p !== 'streaming' && p !== 'done') ? 'streaming' : p);
           } else if (event.type === 'done') {
             setTokensUsed(event.tokens);
+            if (event.model) setModel(event.model);
+            if (typeof event.latency_ms === 'number') setLatencyMs(event.latency_ms);
+            if (event.cache_hit) setCacheHit(true);
+            if (event.route) setRouteLabel(event.route);
             setDone(true);
             setPhase('done');
             setTurnCount((n) => n + 1);
@@ -1443,14 +1532,14 @@ export function StickyAskBar() {
                 </div>
               )}
               {done && tokensUsed && (
-                <p className="text-xs text-zinc-600 flex items-center gap-1.5">
-                  {(cacheHit || routeLabel) && (
-                    <span className="text-emerald-500/80">⚡ Instant</span>
-                  )}
-                  {sources.length > 0 ? `${sources.length} repos searched` : ''}
-                  {sources.length > 0 && tokensUsed.total > 0 ? ' · ' : ''}
-                  {tokensUsed.total > 0 ? `${tokensUsed.total} tokens` : ''}
-                </p>
+                <ResponseFooter
+                  model={model}
+                  latencyMs={latencyMs}
+                  tokens={tokensUsed}
+                  sourcesCount={sources.length}
+                  cacheHit={cacheHit}
+                  routeLabel={routeLabel}
+                />
               )}
             </div>
           )}

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -96,6 +96,45 @@ interface ErrorEvent { type: 'error'; message: string }
 type StreamEvent = SourcesEvent | TokenEvent | DoneEvent | ErrorEvent;
 
 // ---------------------------------------------------------------------------
+// Repo card display — never surface "perditioinc/<name>" for forks. The
+// perditioinc account is a mirror, not the project home; the parent owner
+// (forked_from) is what users want to see and click through to.
+// ---------------------------------------------------------------------------
+const MIRROR_OWNER = 'perditioinc';
+
+function formatRepoDisplay(repo: { name: string; owner: string; forked_from: string | null }): {
+  label: string;
+  href: string;
+  isFork: boolean;
+} {
+  const isMirror = repo.owner.toLowerCase() === MIRROR_OWNER;
+  // Parent known: link to and label as upstream.
+  if (repo.forked_from) {
+    return {
+      label: repo.forked_from,
+      href: `https://github.com/${repo.forked_from}`,
+      isFork: true,
+    };
+  }
+  // Orphan mirror (forked_from missing) — drop the misleading owner prefix
+  // and tag visually as a fork. Backend hydration will fill forked_from
+  // for new ingests; this prevents stale rows from showing the mirror name.
+  if (isMirror) {
+    return {
+      label: repo.name,
+      href: `https://github.com/${repo.owner}/${repo.name}`,
+      isFork: true,
+    };
+  }
+  // Genuine third-party owner (already correct).
+  return {
+    label: `${repo.owner}/${repo.name}`,
+    href: `https://github.com/${repo.owner}/${repo.name}`,
+    isFork: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Client-side rate limit guard
 // ---------------------------------------------------------------------------
 const RATE_KEY = 'reporium_ask_timestamps';
@@ -539,6 +578,9 @@ export function StickyAskBar() {
   const [error, setError] = useState<string | null>(null);
   const [cacheHit, setCacheHit] = useState(false);
   const [routeLabel, setRouteLabel] = useState<string | null>(null);
+  // Question that produced the currently-shown answer; rendered above the
+  // answer so the user can see what they asked once the input clears.
+  const [askedQuestion, setAskedQuestion] = useState<string | null>(null);
 
   // Session state
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -701,10 +743,19 @@ export function StickyAskBar() {
     setCacheHit(false);
     setRouteLabel(null);
     setQuestion('');
+    setAskedQuestion(null);
     setPhase('idle');
     setBarState('collapsed');
     setLoading(false);
     if (phaseTimerRef.current) clearTimeout(phaseTimerRef.current);
+    inputRef.current?.focus();
+  }, []);
+
+  // Clear the input text only — does NOT end the conversation. Used by the
+  // small × inside the input field; preserves session_id and prior answer.
+  const handleClearInput = useCallback(() => {
+    setQuestion('');
+    setError(null);
     inputRef.current?.focus();
   }, []);
 
@@ -733,8 +784,11 @@ export function StickyAskBar() {
   }
 
   async function handleAsk(override?: string) {
-    const q = (override ?? question).trim();
-    if (override !== undefined) setQuestion(override);
+    // First-time use: if user clicks Ask without typing, fall back to the
+    // currently-cycling suggestion so the click does something instead of
+    // showing a "3 characters" error.
+    const rawCandidate = override ?? question;
+    const q = (rawCandidate.trim() || currentPlaceholder.trim()).trim();
     if (!q || q.length < 3) { setError('Please enter at least 3 characters.'); return; }
     if (q.length > 500) { setError('Question must be 500 characters or fewer.'); return; }
     if (INJECTION_RE.test(q)) { setError('That question contains disallowed content. Please rephrase.'); return; }
@@ -754,6 +808,10 @@ export function StickyAskBar() {
     setDone(false);
     setCacheHit(false);
     setRouteLabel(null);
+    // Move the question text out of the input and into the conversation
+    // header so the input is ready for a follow-up question immediately.
+    setAskedQuestion(q);
+    setQuestion('');
     setPhase('expanding');
     setBarState('expanded');
     recordRequest();
@@ -1123,19 +1181,39 @@ export function StickyAskBar() {
             maxLength={500}
             disabled={atMinuteLimit || atDayLimit}
             aria-label="Ask a question about the repo library"
-            className="w-full rounded-lg border border-zinc-700/60 bg-zinc-800/60 py-1.5 px-3 text-base sm:text-sm text-zinc-200 placeholder:text-zinc-500 focus:border-violet-500/50 focus:outline-none focus:ring-1 focus:ring-violet-500/30 disabled:opacity-50 transition-colors"
+            className={`w-full rounded-lg border border-zinc-700/60 bg-zinc-800/60 py-1.5 pl-3 ${question ? 'pr-8' : 'pr-3'} text-base sm:text-sm text-zinc-200 placeholder:text-zinc-500 focus:border-violet-500/50 focus:outline-none focus:ring-1 focus:ring-violet-500/30 disabled:opacity-50 transition-colors`}
           />
 
-          {/* Cycling suggestion overlay — paused during loading */}
+          {/* In-input clear-text button — clears input only, preserves the
+              active conversation/session. Distinct from the conversation
+              reset × in the bar header (which is destructive). */}
+          {question && !isLoading && (
+            <button
+              type="button"
+              onClick={handleClearInput}
+              aria-label="Clear text"
+              title="Clear text"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700/60 transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="4" y1="4" x2="12" y2="12" /><line x1="12" y1="4" x2="4" y2="12" />
+              </svg>
+            </button>
+          )}
+
+          {/* Cycling suggestion overlay — paused during loading.
+              Click sends the suggestion immediately (was: only prefilled
+              the input, leaving the user with a "3 characters" error if
+              they then hit Ask without typing). */}
           {showSuggestionOverlay && !question && !isFocused && !isLoading && !hasAnswer && (
             <button
               type="button"
               onClick={() => {
-                setQuestion(currentPlaceholder);
                 setShowSuggestionOverlay(false);
-                inputRef.current?.focus();
+                void handleAsk(currentPlaceholder);
               }}
               className="absolute inset-0 flex items-center px-3 text-sm text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer truncate text-left"
+              aria-label={`Ask: ${currentPlaceholder}`}
             >
               {currentPlaceholder}
             </button>
@@ -1213,8 +1291,10 @@ export function StickyAskBar() {
           </button>
         )}
 
-        {/* Clear / close button — when there is content */}
-        {(hasAnswer || error || question) && (
+        {/* Reset-conversation button — only when there's an answer or error
+            in flight. Typing-only clears go through the in-input × button
+            (handleClearInput) which preserves the session. */}
+        {(hasAnswer || error || askedQuestion) && (
           <button
             type="button"
             onClick={handleNewConversation}
@@ -1283,6 +1363,16 @@ export function StickyAskBar() {
             </div>
           )}
 
+          {/* The question that produced the current answer — shown above the
+              answer so the user can see what they asked once the input has
+              self-cleared for a follow-up. */}
+          {askedQuestion && (
+            <div className="pt-1">
+              <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-600 mb-1">You asked</p>
+              <p className="text-sm text-zinc-300 italic">&ldquo;{askedQuestion}&rdquo;</p>
+            </div>
+          )}
+
           {/* Rate limit warning */}
           {(nearMinuteLimit || nearDayLimit) && !atMinuteLimit && !atDayLimit && (
             <p className="text-xs text-amber-500/80">
@@ -1313,63 +1403,8 @@ export function StickyAskBar() {
             </div>
           )}
 
-          {/* ── Source section — skeletons while loading, real cards when ready ── */}
-          {(showSkeleton || sources.length > 0) && (
-            <div className="space-y-1.5">
-              <p className="text-xs text-zinc-500 font-medium uppercase tracking-wider">
-                {sources.length > 0
-                  ? `Sources · ${sources.length} repos`
-                  : 'Sources · searching…'}
-              </p>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {/* Skeleton cards — shown while no sources yet */}
-                {showSkeleton && sources.length === 0 && (
-                  Array.from({ length: SKELETON_SOURCE_COUNT }).map((_, i) => (
-                    <SourceCardSkeleton key={`skeleton-${i}`} />
-                  ))
-                )}
-                {/* Real source cards — staggered reveal as they arrive */}
-                {sources.slice(0, revealedSourceCount).map((repo, idx) => {
-                  const upstream = repo.forked_from ?? `${repo.owner}/${repo.name}`;
-                  const ghUrl = `https://github.com/${upstream}`;
-                  const score = Math.round(repo.relevance_score * 100);
-                  return (
-                    <motion.a
-                      key={`${repo.owner}/${repo.name}`}
-                      href={ghUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      initial={prefersReducedMotion ? SOURCE_CARD_ANIMATE : SOURCE_CARD_INITIAL}
-                      animate={SOURCE_CARD_ANIMATE}
-                      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.2, delay: idx * 0.05 }}
-                      className="group block rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2.5 hover:border-zinc-600 transition-colors"
-                    >
-                      <div className="flex items-start justify-between gap-2">
-                        <span className="text-xs font-mono text-zinc-300 group-hover:text-zinc-100 truncate">
-                          {upstream}
-                        </span>
-                        <span className="shrink-0 text-xs text-zinc-600">{score}%</span>
-                      </div>
-                      {repo.description && (
-                        <p className="mt-1 text-xs text-zinc-500 line-clamp-2">{repo.description}</p>
-                      )}
-                      {repo.stars != null && (
-                        <p className="mt-1 text-xs text-zinc-600">★ {repo.stars.toLocaleString()}</p>
-                      )}
-                    </motion.a>
-                  );
-                })}
-                {/* While real sources arriving, keep remaining skeleton slots */}
-                {sources.length > 0 && revealedSourceCount < sources.length && (
-                  Array.from({ length: sources.length - revealedSourceCount }).map((_, i) => (
-                    <SourceCardSkeleton key={`filling-${i}`} />
-                  ))
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* ── Answer section — skeleton until first token, then streaming ── */}
+          {/* ── Answer section — shown FIRST so the synthesized response leads,
+                 with source repos as supporting evidence below. ── */}
           {(showSkeleton || hasAnswer) && (
             <div className="space-y-2">
               {showSkeleton && !hasAnswer ? (
@@ -1417,6 +1452,67 @@ export function StickyAskBar() {
                   {tokensUsed.total > 0 ? `${tokensUsed.total} tokens` : ''}
                 </p>
               )}
+            </div>
+          )}
+
+          {/* ── Source section — supporting evidence, rendered BELOW the
+                 synthesized answer so the response leads. ── */}
+          {(showSkeleton || sources.length > 0) && (
+            <div className="space-y-1.5">
+              <p className="text-xs text-zinc-500 font-medium uppercase tracking-wider">
+                {sources.length > 0
+                  ? `Sources · ${sources.length} repos`
+                  : 'Sources · searching…'}
+              </p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {/* Skeleton cards — shown while no sources yet */}
+                {showSkeleton && sources.length === 0 && (
+                  Array.from({ length: SKELETON_SOURCE_COUNT }).map((_, i) => (
+                    <SourceCardSkeleton key={`skeleton-${i}`} />
+                  ))
+                )}
+                {/* Real source cards — staggered reveal as they arrive */}
+                {sources.slice(0, revealedSourceCount).map((repo, idx) => {
+                  const display = formatRepoDisplay(repo);
+                  const score = Math.round(repo.relevance_score * 100);
+                  return (
+                    <motion.a
+                      key={`${repo.owner}/${repo.name}`}
+                      href={display.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      initial={prefersReducedMotion ? SOURCE_CARD_ANIMATE : SOURCE_CARD_INITIAL}
+                      animate={SOURCE_CARD_ANIMATE}
+                      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.2, delay: idx * 0.05 }}
+                      className="group block rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2.5 hover:border-zinc-600 transition-colors"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="text-xs font-mono text-zinc-300 group-hover:text-zinc-100 truncate">
+                          {display.label}
+                          {display.isFork && (
+                            <span className="ml-1.5 rounded bg-zinc-800 px-1 py-0.5 text-[9px] uppercase tracking-wider text-zinc-500">
+                              fork
+                            </span>
+                          )}
+                        </span>
+                        <span className="shrink-0 text-xs text-zinc-600">{score}%</span>
+                      </div>
+                      {repo.description && (
+                        <p className="mt-1 text-xs text-zinc-500 line-clamp-2">{repo.description}</p>
+                      )}
+                      {repo.stars != null && (
+                        <p className="mt-1 text-xs text-zinc-600">★ {repo.stars.toLocaleString()}</p>
+                      )}
+                    </motion.a>
+                  );
+                })}
+                {/* While real sources arriving, keep remaining skeleton slots */}
+                {sources.length > 0 && revealedSourceCount < sources.length && (
+                  Array.from({ length: sources.length - revealedSourceCount }).map((_, i) => (
+                    <SourceCardSkeleton key={`filling-${i}`} />
+                  ))
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -99,6 +99,8 @@ interface DoneEvent {
   route?: string;
   cache_hit?: boolean;
   cache_source?: string;
+  // PR3: handle for posting thumbs feedback to /intelligence/feedback.
+  query_id?: string;
 }
 interface ErrorEvent { type: 'error'; message: string }
 type StreamEvent = SourcesEvent | TokenEvent | DoneEvent | ErrorEvent;
@@ -325,6 +327,54 @@ const ResponseFooter = memo(function ResponseFooter({
           ({tokens.input}↑ {tokens.output}↓)
         </span>
       )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// FeedbackThumbs — 👍 / 👎 toggle. Renders only when the API returned a
+// query_id (so old backend deployments simply don't show the row). Clicking
+// the active thumb deselects it.
+// ---------------------------------------------------------------------------
+const FeedbackThumbs = memo(function FeedbackThumbs({
+  value,
+  onChange,
+}: {
+  value: 'positive' | 'negative' | null;
+  onChange: (next: 'positive' | 'negative') => void;
+}) {
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label="Was this answer helpful?">
+      <button
+        type="button"
+        onClick={() => onChange('positive')}
+        aria-pressed={value === 'positive'}
+        aria-label={value === 'positive' ? 'Remove helpful rating' : 'Mark as helpful'}
+        title={value === 'positive' ? 'Click again to remove' : 'Helpful'}
+        className={
+          'rounded px-1.5 py-0.5 text-xs transition-colors ' +
+          (value === 'positive'
+            ? 'bg-emerald-900/40 text-emerald-300'
+            : 'text-zinc-600 hover:bg-zinc-800 hover:text-zinc-300')
+        }
+      >
+        👍
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('negative')}
+        aria-pressed={value === 'negative'}
+        aria-label={value === 'negative' ? 'Remove unhelpful rating' : 'Mark as unhelpful'}
+        title={value === 'negative' ? 'Click again to remove' : 'Not helpful'}
+        className={
+          'rounded px-1.5 py-0.5 text-xs transition-colors ' +
+          (value === 'negative'
+            ? 'bg-rose-900/40 text-rose-300'
+            : 'text-zinc-600 hover:bg-zinc-800 hover:text-zinc-300')
+        }
+      >
+        👎
+      </button>
     </div>
   );
 });
@@ -662,6 +712,12 @@ export function StickyAskBar() {
   // Question that produced the currently-shown answer; rendered above the
   // answer so the user can see what they asked once the input clears.
   const [askedQuestion, setAskedQuestion] = useState<string | null>(null);
+  // PR3: handle for posting thumbs feedback. Null until the streamed `done`
+  // event arrives. Old API deployments may not emit it — UI degrades by
+  // hiding the thumbs row entirely.
+  const [queryId, setQueryId] = useState<string | null>(null);
+  // Current selection: null = no choice, or "positive" / "negative".
+  const [feedback, setFeedback] = useState<'positive' | 'negative' | null>(null);
 
   // Session state
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -827,6 +883,8 @@ export function StickyAskBar() {
     setRouteLabel(null);
     setQuestion('');
     setAskedQuestion(null);
+    setQueryId(null);
+    setFeedback(null);
     setPhase('idle');
     setBarState('collapsed');
     setLoading(false);
@@ -841,6 +899,25 @@ export function StickyAskBar() {
     setError(null);
     inputRef.current?.focus();
   }, []);
+
+  // PR3: thumbs up/down toggle. Optimistic local update + best-effort POST.
+  // Clicking the active thumb deselects (sentiment: null). The endpoint is
+  // intentionally fire-and-forget — a dropped feedback click is annoying
+  // but not blocking, and we don't want a network failure to undo the
+  // user's visible selection.
+  const handleFeedback = useCallback((next: 'positive' | 'negative') => {
+    if (!queryId) return;
+    const newValue = feedback === next ? null : next;
+    setFeedback(newValue);
+    fetch(`${API_URL}/intelligence/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query_id: queryId, sentiment: newValue }),
+      // Use keepalive so the request survives page navigation if the user
+      // immediately clicks away after voting.
+      keepalive: true,
+    }).catch(() => { /* swallowed on purpose — see comment above */ });
+  }, [queryId, feedback]);
 
   const { minuteCount, dayCount } = getRateLimitState();
   const atMinuteLimit = minuteCount >= RATE_PER_MIN;
@@ -893,6 +970,8 @@ export function StickyAskBar() {
     setDone(false);
     setCacheHit(false);
     setRouteLabel(null);
+    setQueryId(null);
+    setFeedback(null);
     // Move the question text out of the input and into the conversation
     // header so the input is ready for a follow-up question immediately.
     setAskedQuestion(q);
@@ -1000,6 +1079,7 @@ export function StickyAskBar() {
             if (typeof event.latency_ms === 'number') setLatencyMs(event.latency_ms);
             if (event.cache_hit) setCacheHit(true);
             if (event.route) setRouteLabel(event.route);
+            if (event.query_id) setQueryId(event.query_id);
             setDone(true);
             setPhase('done');
             setTurnCount((n) => n + 1);
@@ -1532,14 +1612,17 @@ export function StickyAskBar() {
                 </div>
               )}
               {done && tokensUsed && (
-                <ResponseFooter
-                  model={model}
-                  latencyMs={latencyMs}
-                  tokens={tokensUsed}
-                  sourcesCount={sources.length}
-                  cacheHit={cacheHit}
-                  routeLabel={routeLabel}
-                />
+                <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+                  <ResponseFooter
+                    model={model}
+                    latencyMs={latencyMs}
+                    tokens={tokensUsed}
+                    sourcesCount={sources.length}
+                    cacheHit={cacheHit}
+                    routeLabel={routeLabel}
+                  />
+                  {queryId && <FeedbackThumbs value={feedback} onChange={handleFeedback} />}
+                </div>
               )}
             </div>
           )}

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -244,12 +244,28 @@ class ApiDataProvider implements DataProvider {
     this.fallback = new JsonDataProvider()
   }
 
+  /**
+   * Build request headers, attaching `X-App-Token` when the NEXT_PUBLIC_APP_API_TOKEN
+   * env var is inlined at build time (see next.config.js). Without this header,
+   * protected endpoints (e.g. /intelligence/portfolio-insights) silently 403 and
+   * callers fall through to the JSON fallback path.
+   */
+  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      ...(extra ?? {}),
+    }
+    const token = process.env.NEXT_PUBLIC_APP_API_TOKEN
+    if (token) headers['X-App-Token'] = token
+    return headers
+  }
+
   private async apiFetch<T>(path: string, timeoutMs = 30_000): Promise<T> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
-        headers: { 'Accept': 'application/json' },
+        headers: this.buildHeaders(),
         signal: controller.signal,
       })
       if (!res.ok) throw new Error(`API error: ${res.status}`)
@@ -265,10 +281,7 @@ class ApiDataProvider implements DataProvider {
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
         method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        },
+        headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(body),
         signal: controller.signal,
       })
@@ -468,7 +481,14 @@ class ApiDataProvider implements DataProvider {
 
   async getSimilarRepos(name: string, limit = 5): Promise<SimilarRepo[]> {
     try {
-      return await this.apiFetch<SimilarRepo[]>(`/repos/${encodeURIComponent(name)}/similar?limit=${limit}`)
+      // API exposes `/intelligence/similar/{name}` returning { source_repo, similar, total }.
+      // The legacy `/repos/{name}/similar` path no longer exists. Unwrap `.similar`
+      // to preserve the raw-array contract existing call sites rely on.
+      const data = await this.apiFetch<{ similar?: SimilarRepo[] } | SimilarRepo[]>(
+        `/intelligence/similar/${encodeURIComponent(name)}?limit=${limit}`
+      )
+      if (Array.isArray(data)) return data
+      return (data as { similar?: SimilarRepo[] }).similar ?? []
     } catch {
       return this.fallback.getSimilarRepos(name, limit)
     }
@@ -496,6 +516,32 @@ class ApiDataProvider implements DataProvider {
     } catch {
       return []
     }
+  }
+
+  /**
+   * Fetch values per-dimension in parallel, then flatten to the `{dimension, value, repo_count}`
+   * shape expected by the taxonomy explorer. Avoids the global-top-N cap of `/taxonomy/values`
+   * which lets a single high-cardinality dimension starve all others.
+   */
+  async getTaxonomyValuesByDimensions(
+    dimensions: readonly string[],
+    perDimensionLimit = 100,
+  ): Promise<{ dimension: string; value: string; repo_count?: number; count?: number }[]> {
+    const results = await Promise.all(
+      dimensions.map(async (dim) => {
+        try {
+          const values = await this.getTaxonomyValues(dim)
+          return values.slice(0, perDimensionLimit).map((v) => ({
+            dimension: dim,
+            value: v.name,
+            repo_count: v.repo_count,
+          }))
+        } catch {
+          return []
+        }
+      })
+    )
+    return results.flat()
   }
 
   async getGapTaxonomy(minRepos = 1): Promise<{ dimension: string; value: string; repo_count: number; gap_score?: number }[]> {

--- a/tests/AskPanel.test.tsx
+++ b/tests/AskPanel.test.tsx
@@ -60,8 +60,10 @@ describe('AskPanel', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     expect(await screen.findByText('Use the RAG stack.')).toBeTruthy();
-    // Component renders "owner/name" as the upstream label
-    expect(screen.getByText('perditioinc/repo-a')).toBeTruthy();
+    // perditioinc-owned forks render as just the repo name (no mirror prefix),
+    // tagged with a "fork" badge — see formatRepoDisplay()
+    expect(screen.getByText('repo-a')).toBeTruthy();
+    expect(screen.getByText('fork')).toBeTruthy();
     expect(screen.getByText('91%')).toBeTruthy();
     expect(global.fetch).toHaveBeenCalledWith(
       'https://api.example.com/intelligence/ask',

--- a/tests/TaxonomyPage.test.tsx
+++ b/tests/TaxonomyPage.test.tsx
@@ -21,31 +21,58 @@ describe('TaxonomyPage', () => {
     process.env = originalEnv;
   });
 
+  // Per-dimension seed values used by the fetch mock below.
+  const dimSeed: Record<string, { name: string; repo_count: number }> = {
+    skill_area: { name: 'Agents', repo_count: 10 },
+    industry: { name: 'Healthcare', repo_count: 7 },
+    use_case: { name: 'Code generation', repo_count: 6 },
+    modality: { name: 'Text', repo_count: 9 },
+    ai_trend: { name: 'Agentic AI', repo_count: 8 },
+    deployment_context: { name: 'Cloud', repo_count: 5 },
+    tags: { name: 'production-ready', repo_count: 4 },
+    maturity_level: { name: 'production', repo_count: 3 },
+  };
+
+  function buildFetchMock(opts: { dimHasValues: boolean; gaps: Array<Record<string, unknown>> }) {
+    return jest.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      // Per-dimension taxonomy endpoint: /taxonomy/{dim}
+      const dimMatch = url.match(/\/taxonomy\/([a-z_]+)(?:$|\?)/);
+      if (dimMatch) {
+        const dim = dimMatch[1];
+        const seed = dimSeed[dim];
+        return {
+          ok: true,
+          json: async () => ({
+            dimension: dim,
+            values: opts.dimHasValues && seed
+              ? [{ id: 1, dimension: dim, name: seed.name, repo_count: seed.repo_count }]
+              : [],
+          }),
+        };
+      }
+      if (url.includes('/gaps/taxonomy')) {
+        return { ok: true, json: async () => ({ gaps: opts.gaps }) };
+      }
+      if (url.includes('/library/full')) {
+        // getDerivedDimensionValues routes through getLibrary()
+        return {
+          ok: true,
+          json: async () => ({ repos: [], totalPages: 1, totalRepos: 0 }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  }
+
   test('renders 8 dimension cards', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          { dimension: 'skill_area', value: 'Agents', repo_count: 10 },
-          { dimension: 'industry', value: 'Healthcare', repo_count: 7 },
-          { dimension: 'use_case', value: 'Code generation', repo_count: 6 },
-          { dimension: 'modality', value: 'Text', repo_count: 9 },
-          { dimension: 'ai_trend', value: 'Agentic AI', repo_count: 8 },
-          { dimension: 'deployment_context', value: 'Cloud', repo_count: 5 },
-          { dimension: 'tags', value: 'production-ready', repo_count: 4 },
-          { dimension: 'maturity_level', value: 'production', repo_count: 3 },
-        ],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-            { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: true,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+        { dimension: 'industry', value: 'Finance', repo_count: 2, gap_score: 0.52 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);
@@ -61,20 +88,12 @@ describe('TaxonomyPage', () => {
   });
 
   test('renders gap chips with the expected labels', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          gaps: [
-            { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
-          ],
-        }),
-      }) as unknown as typeof fetch;
+    global.fetch = buildFetchMock({
+      dimHasValues: false,
+      gaps: [
+        { dimension: 'ai_trend', value: 'Long Context', repo_count: 1, gap_score: 0.81 },
+      ],
+    });
 
     const element = await TaxonomyPage();
     const html = renderToStaticMarkup(element);


### PR DESCRIPTION
## Summary
PR3/4 of the Ask UX series. Frontend half — renders a 👍 / 👎 control next to the response telemetry footer so users can flag answers as helpful or not.

**Stacked on [#266](https://github.com/perditioinc/reporium/pull/266)** (PR2 — telemetry footer). Review/merge that one first; this PR's diff narrows once PR2 lands.

Behavior:
- Renders only when the streamed `done` event includes a `query_id`, so old backend deployments simply don't show the row (forward-compatible with [reporium-api#418](https://github.com/perditioinc/reporium-api/pull/418)).
- Click the active thumb to deselect (sends `sentiment: null` — toggle-off).
- Click the opposite thumb to switch (mutual exclusivity).
- Optimistic local update + best-effort `fetch` with `keepalive: true`. A network failure does NOT undo the visible selection — we'd rather keep the user's expressed intent than restore the unflagged state.

`StickyAskBar` streaming reducer captures `query_id` from the done event into a new state slot, cleared on `handleAsk` and `handleNewConversation`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `jest tests/AskPanel.test.tsx tests/MiniAskBar.test.tsx` green
- [x] Verified end-to-end in the browser preview by monkey-patching `fetch` to inject a fake `query_id` into the streamed done event:
  - 👍 click → POST `{sentiment:"positive"}`, button pressed
  - 👍 click again → POST `{sentiment:null}`, button unpressed (toggle-off)
  - 👍 then 👎 → POST positive then negative, mutual exclusivity holds
- [ ] Re-verify after [reporium-api#418](https://github.com/perditioinc/reporium-api/pull/418) deploys to confirm a real query_id round-trips

## Notes
Targeting `main` because the upstream `dev` branch was pruned (CLAUDE.md GitFlow doc is stale until restored).

KAN-XX is a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)