### PR TITLE
KAN-XX: inline citation linking — click repo names in answers to scroll to source cards (PR7)

### DIFF
--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -8,6 +8,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { API_URL } from '@/lib/apiUrl';
+import {
+  CITATION_HREF_PREFIX,
+  handleCitationClick,
+  injectCitations,
+  sourceAnchorId,
+} from '@/lib/askCitations';
 
 // ---------------------------------------------------------------------------
 // Memoized markdown renderer — only re-parses when answer content changes.
@@ -15,14 +21,33 @@ import { API_URL } from '@/lib/apiUrl';
 // keeps output additive with the stream). Sanitized via rehype-sanitize.
 // ---------------------------------------------------------------------------
 const MARKDOWN_COMPONENTS = {
-  a: (props: React.ComponentProps<'a'>) => (
-    <a
-      {...props}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-zinc-200 underline underline-offset-2 hover:text-white"
-    />
-  ),
+  a: ({ href, ...props }: React.ComponentProps<'a'>) => {
+    // Internal citation link — same-document scroll + ring flash, no new tab.
+    if (href && href.startsWith(CITATION_HREF_PREFIX)) {
+      return (
+        <a
+          {...props}
+          href={href}
+          onClick={(e) => {
+            e.preventDefault();
+            handleCitationClick(href);
+          }}
+          className="text-violet-300 underline decoration-violet-500/40 underline-offset-2 hover:text-violet-200 hover:decoration-violet-300 cursor-pointer"
+          data-citation="1"
+        />
+      );
+    }
+    // External link — open in new tab as before.
+    return (
+      <a
+        {...props}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-zinc-200 underline underline-offset-2 hover:text-white"
+      />
+    );
+  },
   code: (props: React.ComponentProps<'code'>) => (
     <code {...props} className="rounded bg-zinc-800 px-1 py-0.5 text-xs" />
   ),
@@ -40,14 +65,21 @@ const MARKDOWN_COMPONENTS = {
   ),
 };
 
-const MarkdownAnswer = memo(function MarkdownAnswer({ text }: { text: string }) {
+const MarkdownAnswer = memo(function MarkdownAnswer({
+  text,
+  sources,
+}: {
+  text: string;
+  sources: ReadonlyArray<{ owner: string; name: string }>;
+}) {
+  const linked = useMemo(() => injectCitations(text, sources), [text, sources]);
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeSanitize]}
       components={MARKDOWN_COMPONENTS}
     >
-      {text}
+      {linked}
     </ReactMarkdown>
   );
 });
@@ -1816,7 +1848,7 @@ export function StickyAskBar() {
                   <div
                     className="rounded-lg bg-zinc-800/60 px-4 py-3 text-sm text-zinc-200 leading-relaxed"
                   >
-                    <MarkdownAnswer text={streamingAnswer} />
+                    <MarkdownAnswer text={streamingAnswer} sources={sources} />
                     {isLoading && (
                       <span className="inline-block w-0.5 h-4 ml-0.5 bg-zinc-400 align-middle animate-pulse" />
                     )}
@@ -1868,6 +1900,7 @@ export function StickyAskBar() {
                   return (
                     <motion.a
                       key={`${repo.owner}/${repo.name}`}
+                      id={sourceAnchorId(repo)}
                       href={display.href}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/src/lib/askCitations.ts
+++ b/src/lib/askCitations.ts
@@ -1,0 +1,116 @@
+/**
+ * askCitations.ts — PR7 (Ask UX inline citations)
+ *
+ * Pure-function helpers for turning bare repo-name mentions in a synthesized
+ * answer into in-document anchor links pointing at the matching source card.
+ *
+ * Lives outside StickyAskBar.tsx so unit tests can import it without dragging
+ * in react-markdown (ESM-only) and the full component dependency graph.
+ */
+
+/** Stable DOM id for a source card. owner+name disambiguates forks. */
+export function sourceAnchorId(repo: { owner: string; name: string }): string {
+  const slug = `${repo.owner}-${repo.name}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  return `ask-source-${slug}`;
+}
+
+/** Internal anchor href prefix used by injected citations. */
+export const CITATION_HREF_PREFIX = '#ask-source-';
+
+/** Repo names this short or this generic are skipped — too risky for false matches. */
+export const CITATION_NAME_MIN_LEN = 4;
+export const CITATION_NAME_BLOCKLIST: ReadonlySet<string> = new Set([
+  'node', 'next', 'tools', 'core', 'docs', 'main', 'data', 'apis',
+  'agent', 'agents', 'chat', 'demo', 'demos', 'test', 'tests', 'utils',
+]);
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Pattern matching anything we should skip when looking for repo-name mentions. */
+const SKIP_TOKEN_RE = /(```[\s\S]*?```|`[^`]*`|!?\[[^\]]*\]\([^)]*\))/g;
+
+/**
+ * Find the first word-boundary, case-insensitive occurrence of `needle` in `s`
+ * that is NOT inside a fenced code block, inline code span, or markdown link/image.
+ * Returns the match start index and the actually-matched substring (preserving
+ * the visible casing), or null if no safe occurrence exists.
+ */
+function findSafeMatch(s: string, needle: string): { start: number; text: string } | null {
+  // Build a per-character mask: 1 = skip (inside code/link), 0 = scan.
+  const skip = new Uint8Array(s.length);
+  for (const m of s.matchAll(SKIP_TOKEN_RE)) {
+    const start = m.index ?? 0;
+    for (let i = start; i < start + m[0].length; i++) skip[i] = 1;
+  }
+  const re = new RegExp(`\\b(${escapeRegExp(needle)})\\b`, 'gi');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(s)) !== null) {
+    if (!skip[m.index]) return { start: m.index, text: m[1] };
+  }
+  return null;
+}
+
+/**
+ * Pre-process the answer text to wrap repo-name mentions in markdown links.
+ *
+ * - Skips matches inside fenced code, inline code, link text, link href, and
+ *   image syntax. Re-tokenises after each injection so the next candidate
+ *   correctly skips the just-injected link.
+ * - Word-boundary, case-insensitive match; preserves the user-visible casing.
+ * - Each (owner+name) repo is linked at most once per answer to avoid
+ *   visual noise on long lists.
+ * - Longer repo names are matched first so `langchain-community` wins over
+ *   `langchain` on overlapping text.
+ */
+export function injectCitations(
+  text: string,
+  sources: ReadonlyArray<{ owner: string; name: string }>,
+): string {
+  if (!text || sources.length === 0) return text;
+
+  const candidates = sources
+    .filter((s) => s.name.length >= CITATION_NAME_MIN_LEN
+                && !CITATION_NAME_BLOCKLIST.has(s.name.toLowerCase()))
+    .slice()
+    .sort((a, b) => b.name.length - a.name.length);
+  if (candidates.length === 0) return text;
+
+  let out = text;
+  const linked = new Set<string>();
+  for (const repo of candidates) {
+    const key = `${repo.owner}/${repo.name}`.toLowerCase();
+    if (linked.has(key)) continue;
+    const match = findSafeMatch(out, repo.name);
+    if (!match) continue;
+    linked.add(key);
+    out =
+      out.slice(0, match.start) +
+      `[${match.text}](#${sourceAnchorId(repo)})` +
+      out.slice(match.start + match.text.length);
+  }
+  return out;
+}
+
+/**
+ * Click handler for in-document citation links. Scrolls the matching source
+ * card into view and applies a brief ring-flash highlight.
+ */
+export function handleCitationClick(href: string): void {
+  if (typeof document === 'undefined') return;
+  const id = href.slice(1); // drop leading '#'
+  const target = document.getElementById(id);
+  if (!target) return;
+  target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  const prevTransition = target.style.transition;
+  const prevBoxShadow = target.style.boxShadow;
+  target.style.transition = 'box-shadow 200ms ease-out';
+  target.style.boxShadow = '0 0 0 2px rgb(167 139 250 / 0.7)'; // violet-400 @70%
+  window.setTimeout(() => {
+    target.style.boxShadow = prevBoxShadow;
+    window.setTimeout(() => {
+      target.style.transition = prevTransition;
+    }, 220);
+  }, 1000);
+}

--- a/tests/unit/injectCitations.test.ts
+++ b/tests/unit/injectCitations.test.ts
@@ -1,0 +1,130 @@
+/**
+ * injectCitations.test.ts — PR7 (Ask UX inline citations).
+ *
+ * Pure-function tests for the markdown text pre-processor that turns
+ * bare repo-name mentions into in-document anchor links pointing at
+ * the matching source card.
+ */
+
+import { injectCitations } from '@/lib/askCitations';
+
+const REPOS = {
+  langchain: { owner: 'langchain-ai', name: 'langchain' },
+  langgraph: { owner: 'langchain-ai', name: 'langgraph' },
+  langchainCommunity: { owner: 'langchain-ai', name: 'langchain-community' },
+  haystack: { owner: 'deepset-ai', name: 'haystack' },
+  // forks of the same name living under different owners (collision case)
+  langchainFork: { owner: 'perditioinc', name: 'langchain' },
+};
+
+describe('injectCitations', () => {
+  it('returns input unchanged when sources is empty', () => {
+    expect(injectCitations('hello langchain world', [])).toBe('hello langchain world');
+  });
+
+  it('returns input unchanged when text is empty', () => {
+    expect(injectCitations('', [REPOS.langchain])).toBe('');
+  });
+
+  it('wraps a bare repo-name mention in a markdown link to its anchor', () => {
+    const out = injectCitations('Try langchain for this.', [REPOS.langchain]);
+    expect(out).toBe('Try [langchain](#ask-source-langchain-ai-langchain) for this.');
+  });
+
+  it('preserves the visible casing of the matched word', () => {
+    const out = injectCitations('Use LangChain here.', [REPOS.langchain]);
+    expect(out).toBe('Use [LangChain](#ask-source-langchain-ai-langchain) here.');
+  });
+
+  it('only links the first occurrence of a given repo to avoid noise', () => {
+    const out = injectCitations(
+      'langchain is great. langchain again. and langchain once more.',
+      [REPOS.langchain],
+    );
+    // first only
+    expect(out).toBe(
+      '[langchain](#ask-source-langchain-ai-langchain) is great. langchain again. and langchain once more.',
+    );
+  });
+
+  it('prefers the longer match when one repo name is a prefix of another', () => {
+    const out = injectCitations(
+      'Compare langchain-community against langchain itself.',
+      [REPOS.langchain, REPOS.langchainCommunity],
+    );
+    // longer name wins on the first slot, then plain "langchain" gets linked second
+    expect(out).toBe(
+      'Compare [langchain-community](#ask-source-langchain-ai-langchain-community) against [langchain](#ask-source-langchain-ai-langchain) itself.',
+    );
+  });
+
+  it('skips matches inside a fenced code block', () => {
+    const input = 'See code:\n```\npip install langchain\n```\nthen ask about langchain.';
+    const out = injectCitations(input, [REPOS.langchain]);
+    // the fenced block is untouched; only the prose mention is linked
+    expect(out).toContain('```\npip install langchain\n```');
+    expect(out).toContain('then ask about [langchain](#ask-source-langchain-ai-langchain).');
+  });
+
+  it('skips matches inside inline code', () => {
+    const out = injectCitations('Run `langchain init` then try langchain.', [REPOS.langchain]);
+    expect(out).toBe('Run `langchain init` then try [langchain](#ask-source-langchain-ai-langchain).');
+  });
+
+  it('skips matches that already appear inside a markdown link', () => {
+    const input = 'See [langchain](https://example.com) and also langchain again.';
+    const out = injectCitations(input, [REPOS.langchain]);
+    // the existing link is preserved; the prose mention is linked
+    expect(out).toBe(
+      'See [langchain](https://example.com) and also [langchain](#ask-source-langchain-ai-langchain) again.',
+    );
+  });
+
+  it('skips repo names that are too short', () => {
+    const out = injectCitations('use foo for this', [{ owner: 'a', name: 'foo' }]);
+    expect(out).toBe('use foo for this'); // 3 chars < min
+  });
+
+  it('skips generic repo names from the blocklist', () => {
+    const out = injectCitations('open the docs and the agent', [
+      { owner: 'a', name: 'docs' },
+      { owner: 'b', name: 'agent' },
+    ]);
+    expect(out).toBe('open the docs and the agent');
+  });
+
+  it('respects word boundaries (no partial matches)', () => {
+    // "langchainjs" should not match "langchain"
+    const out = injectCitations('Try langchainjs and others.', [REPOS.langchain]);
+    expect(out).toBe('Try langchainjs and others.');
+  });
+
+  it('handles multiple distinct repos in one paragraph', () => {
+    const out = injectCitations(
+      'For RAG, langchain and haystack are both popular.',
+      [REPOS.langchain, REPOS.haystack],
+    );
+    expect(out).toBe(
+      'For RAG, [langchain](#ask-source-langchain-ai-langchain) and [haystack](#ask-source-deepset-ai-haystack) are both popular.',
+    );
+  });
+
+  it('uses owner+name in the anchor so forks of the same name are addressable', () => {
+    // Two repos both named "langchain" (one upstream, one perditio-mirrored fork)
+    // should produce different anchors. Sorted by name length, the first match
+    // in source-order wins. In practice these don't appear together in one
+    // sources block (the API returns one canonical repo per name), but the
+    // anchor scheme must remain owner-disambiguated.
+    const linkUpstream = injectCitations('Use langchain here.', [REPOS.langchain]);
+    expect(linkUpstream).toContain('#ask-source-langchain-ai-langchain');
+    const linkFork = injectCitations('Use langchain here.', [REPOS.langchainFork]);
+    expect(linkFork).toContain('#ask-source-perditioinc-langchain');
+  });
+
+  it('does not double-link inside an injected link on subsequent passes', () => {
+    // Run the function twice; second pass should be a no-op for already-linked text.
+    const once = injectCitations('Try langchain here.', [REPOS.langchain]);
+    const twice = injectCitations(once, [REPOS.langchain]);
+    expect(twice).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a one-click trip from claim to evidence in the ask UI: when the synthesized answer mentions a repo by name in the prose, that name becomes a violet link. Clicking it smooth-scrolls the matching source card into view and pulses it with a brief ring highlight, so the user can immediately verify the LLM's reference.

Reinforces the broader trust thesis (provenance / verifiability / freshness / agreement). The chips already let users follow up; the new citations let them check.

## Changes

- **`src/lib/askCitations.ts`** (new) — pure helpers: `sourceAnchorId()`, `injectCitations()`, `handleCitationClick()`. `injectCitations()` pre-processes the streamed answer text, wrapping bare repo-name mentions in markdown links pointing at `#ask-source-…` anchors. Word-boundary, case-insensitive, longest-name-first; one link per repo per answer. Skips matches inside fenced code, inline code, existing markdown links, and image syntax. Re-tokenises after each injection so downstream substitutions correctly skip the just-injected link text. Names < 4 chars or in a small generic-words blocklist (`node`, `docs`, `core`, `agent`, …) are skipped to avoid false positives.
- **`StickyAskBar.tsx`** — `MarkdownAnswer` now takes `sources` and runs `injectCitations()` inside a `useMemo` before passing to `ReactMarkdown`. The `a` component override intercepts `#ask-source-…` clicks for in-document scroll + flash. Each source card carries `id={sourceAnchorId(repo)}` as the scroll target.
- **`tests/unit/injectCitations.test.ts`** (new) — 15 cases.

## Why client-side, not a synthesis-prompt change

- Backend coupling-free: works on every existing answer with no API change.
- Robust: doesn't depend on the LLM remembering to emit `[name](#anchor)` syntax.
- Doesn't conflict with the parallel session's reasoning/thinking work.
- Pure helpers are unit-testable; no LLM-in-the-loop testing needed.

## Test plan

- [x] `npx jest` — 241/241 passing (15 new cases for `injectCitations`)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [ ] Vercel preview: ask a question whose answer mentions multiple sources; verify the matching repo names render as violet links
- [ ] Click a citation → matching source card scrolls into view and gets a brief violet ring
- [ ] Names already inside markdown links (e.g. `[langchain](https://...)`) stay intact
- [ ] Code spans with repo names (e.g. `` `pip install langchain` ``) stay intact
- [ ] No false positives on generic words like `docs`, `core`, `agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)