### PR TITLE
Ask UX: citation hover preview card (PR9)

### DIFF
--- a/src/components/CitationHoverCard.tsx
+++ b/src/components/CitationHoverCard.tsx
@@ -180,9 +180,14 @@ function CitationHoverCardImpl({
   const desc = source ? describeForHover(source.description) : '';
   const label = source ? formatLabel(source) : null;
 
+  // Stable id for aria-describedby wiring. `href` already encodes the anchor
+  // id (e.g. `#ask-source-langchain`), so it makes a unique-per-citation key.
+  const tooltipId = `citation-hover-${href}`;
+
   const card =
     open && pos && source && label ? (
       <div
+        id={tooltipId}
         role="tooltip"
         // pointer-events-none so the card doesn't intercept mouseleave from
         // the wrapper — same flicker-prevention trick as PR6's portal popover.
@@ -223,7 +228,7 @@ function CitationHoverCardImpl({
         onClick={onAnchorClick}
         className={anchorClassName}
         data-citation="1"
-        aria-describedby={open && source ? `citation-hover-${href}` : undefined}
+        aria-describedby={open && source ? tooltipId : undefined}
       >
         {children}
       </a>

--- a/src/components/CitationHoverCard.tsx
+++ b/src/components/CitationHoverCard.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+/**
+ * CitationHoverCard.tsx — PR9 (Ask UX inline citation hover preview).
+ *
+ * When the user hovers (or focuses) an inline citation link rendered by the
+ * PR7 markdown renderer, this component pops a small card next to the link
+ * showing the matched repo's stars and a one-line description excerpt — so
+ * citations are useful at a glance without forcing a click+scroll trip.
+ *
+ * Same overflow-clip lesson as PR6 (jellyfish tips popover): the sticky ask
+ * bar root uses `overflow:hidden` so a positioned tooltip needs to render
+ * through a portal to `document.body` with `position:fixed`. Otherwise the
+ * card would visually clip even though it'd be in the DOM.
+ *
+ * Behavior:
+ *   - 350 ms hover/focus delay before show (avoids flashing while scanning).
+ *   - Hides immediately on mouseleave / blur.
+ *   - ESC dismisses while open.
+ *   - Suppressed during streaming (caller controls via `disabled` prop) so
+ *     the live answer animation doesn't fight a hover popover for attention.
+ *   - Click semantics on the wrapped <a> are unchanged — PR7's
+ *     handleCitationClick still scrolls + ring-flashes the source card.
+ */
+
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+
+// SSR-safe "are we hydrated yet" hook. Returns false on the server snapshot
+// (so the portal isn't emitted into the SSR string) and true on the client
+// after hydration. Avoids the lint-flagged setState-in-effect pattern.
+const subscribeNoop = () => () => {};
+function useHasMounted(): boolean {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => true,   // client snapshot
+    () => false,  // server snapshot
+  );
+}
+
+/**
+ * Minimal repo shape used by the hover card. Compatible with the SourceRepo
+ * type in StickyAskBar without importing the whole module (keeps this
+ * component free of streaming/SSE coupling).
+ */
+export interface CitationSource {
+  owner: string;
+  name: string;
+  forked_from: string | null;
+  description: string | null;
+  stars: number | null;
+}
+
+/** Format a stars count compactly: 1234 -> "1.2k", 1500000 -> "1.5M". */
+function formatStars(n: number | null | undefined): string | null {
+  if (n == null || !Number.isFinite(n) || n <= 0) return null;
+  if (n < 1000) return String(n);
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1_000_000) return `${Math.round(n / 1000)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+/**
+ * Trim a description to a one-liner. Prefers the first sentence; falls back
+ * to a hard char cap with an ellipsis. Keeps the card compact and scannable.
+ */
+export function describeForHover(description: string | null | undefined, maxLen = 140): string {
+  if (!description) return '';
+  const trimmed = description.trim();
+  if (!trimmed) return '';
+  // Prefer first sentence if it's short enough.
+  const sentenceEnd = trimmed.search(/[.!?](\s|$)/);
+  if (sentenceEnd > 0 && sentenceEnd <= maxLen) {
+    return trimmed.slice(0, sentenceEnd + 1);
+  }
+  if (trimmed.length <= maxLen) return trimmed;
+  return trimmed.slice(0, maxLen).trimEnd() + '…';
+}
+
+/**
+ * Display label for a forked repo: prefer `upstream-owner/name`, else just
+ * `name` with a "fork" hint. Mirrors the formatRepoDisplay logic so the
+ * hover card and the underlying source card show the same identity.
+ */
+function formatLabel(repo: CitationSource): { primary: string; isFork: boolean } {
+  if (repo.forked_from) {
+    // forked_from is "upstream-owner/name" in our schema
+    return { primary: repo.forked_from, isFork: true };
+  }
+  return { primary: `${repo.owner}/${repo.name}`, isFork: false };
+}
+
+const SHOW_DELAY_MS = 350;
+
+interface CitationHoverCardProps {
+  href: string;
+  /** Underlying anchor render — typically the PR7 violet citation link. */
+  children: React.ReactNode;
+  /** The matched source for `href`, or null if no preview is available. */
+  source: CitationSource | null;
+  /** When true, suppresses the hover card (e.g. during answer streaming). */
+  disabled?: boolean;
+  /** Click handler for the wrapped anchor (PR7 scroll + flash). */
+  onAnchorClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  /** Class string for the underlying anchor (PR7 violet styling). */
+  anchorClassName?: string;
+}
+
+/**
+ * Wraps a citation `<a>` and renders a portalled hover card next to it on
+ * pointer/focus. If `source` is null (anchor map miss) or `disabled` is set,
+ * behaves exactly like a bare anchor.
+ */
+function CitationHoverCardImpl({
+  href,
+  children,
+  source,
+  disabled,
+  onAnchorClick,
+  anchorClassName,
+}: CitationHoverCardProps) {
+  const wrapperRef = useRef<HTMLSpanElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const showTimerRef = useRef<number | null>(null);
+  const mounted = useHasMounted();
+
+  const clearShowTimer = useCallback(() => {
+    if (showTimerRef.current != null) {
+      window.clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleShow = useCallback(() => {
+    if (disabled || !source) return;
+    clearShowTimer();
+    showTimerRef.current = window.setTimeout(() => setOpen(true), SHOW_DELAY_MS);
+  }, [disabled, source, clearShowTimer]);
+
+  const hide = useCallback(() => {
+    clearShowTimer();
+    setOpen(false);
+  }, [clearShowTimer]);
+
+  // Anchor the card just above the wrapper. Recomputed on visible / scroll
+  // / resize so the popover tracks during page motion.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const w = wrapperRef.current;
+    if (!w) return;
+    const recompute = () => {
+      const r = w.getBoundingClientRect();
+      setPos({ top: r.top, left: r.left + r.width / 2 });
+    };
+    recompute();
+    window.addEventListener('scroll', recompute, true);
+    window.addEventListener('resize', recompute);
+    return () => {
+      window.removeEventListener('scroll', recompute, true);
+      window.removeEventListener('resize', recompute);
+    };
+  }, [open]);
+
+  // Global ESC dismiss while open (matches PR6 jellyfish-popover pattern).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') hide();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, hide]);
+
+  // Cleanup pending show timer on unmount so a citation that scrolls offscreen
+  // mid-delay doesn't flash up later.
+  useEffect(() => () => clearShowTimer(), [clearShowTimer]);
+
+  const stars = source ? formatStars(source.stars) : null;
+  const desc = source ? describeForHover(source.description) : '';
+  const label = source ? formatLabel(source) : null;
+
+  const card =
+    open && pos && source && label ? (
+      <div
+        role="tooltip"
+        // pointer-events-none so the card doesn't intercept mouseleave from
+        // the wrapper — same flicker-prevention trick as PR6's portal popover.
+        className="pointer-events-none fixed z-[60] w-[280px] -translate-x-1/2 -translate-y-full rounded-lg border border-zinc-700 bg-zinc-900/95 px-3 py-2 text-xs text-zinc-200 shadow-xl backdrop-blur"
+        style={{ top: pos.top - 8, left: pos.left }}
+        data-testid="citation-hover-card"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate font-medium text-zinc-100">{label.primary}</span>
+          {stars && (
+            <span className="shrink-0 tabular-nums text-amber-300">★ {stars}</span>
+          )}
+        </div>
+        {label.isFork && (
+          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-zinc-500">
+            mirrored fork
+          </div>
+        )}
+        {desc && <div className="mt-1 line-clamp-3 leading-snug text-zinc-300">{desc}</div>}
+        <div className="mt-1.5 text-[10px] uppercase tracking-wide text-violet-400/70">
+          click to view source
+        </div>
+      </div>
+    ) : null;
+
+  return (
+    <span
+      ref={wrapperRef}
+      // inline-block-ish wrapper so it inherits flow but can host a hover hit area.
+      className="inline"
+      onMouseEnter={scheduleShow}
+      onMouseLeave={hide}
+      onFocus={scheduleShow}
+      onBlur={hide}
+    >
+      <a
+        href={href}
+        onClick={onAnchorClick}
+        className={anchorClassName}
+        data-citation="1"
+        aria-describedby={open && source ? `citation-hover-${href}` : undefined}
+      >
+        {children}
+      </a>
+      {mounted && card && createPortal(card, document.body)}
+    </span>
+  );
+}
+
+export const CitationHoverCard = memo(CitationHoverCardImpl);

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -10,74 +10,107 @@ import rehypeSanitize from 'rehype-sanitize';
 import { API_URL } from '@/lib/apiUrl';
 import {
   CITATION_HREF_PREFIX,
+  buildSourceAnchorMap,
+  findSourceByCitationHref,
   handleCitationClick,
   injectCitations,
   sourceAnchorId,
 } from '@/lib/askCitations';
+import { CitationHoverCard, type CitationSource } from '@/components/CitationHoverCard';
 
 // ---------------------------------------------------------------------------
 // Memoized markdown renderer — only re-parses when answer content changes.
 // Streaming appends trigger re-parse, which is acceptable (parse is fast and
 // keeps output additive with the stream). Sanitized via rehype-sanitize.
+//
+// PR9: the `a` override consults a precomputed anchor map so citation links
+// can render the floating CitationHoverCard preview. The map is keyed by the
+// stable `sourceAnchorId(repo)` so two forks of the same name resolve to
+// distinct sources. The `hoverDisabled` flag suppresses the popover during
+// active streaming (the live answer animation should win over hover affordance).
 // ---------------------------------------------------------------------------
-const MARKDOWN_COMPONENTS = {
-  a: ({ href, ...props }: React.ComponentProps<'a'>) => {
-    // Internal citation link — same-document scroll + ring flash, no new tab.
-    if (href && href.startsWith(CITATION_HREF_PREFIX)) {
+function buildMarkdownComponents(
+  anchorMap: ReadonlyMap<string, CitationSource>,
+  hoverDisabled: boolean,
+) {
+  const citationAnchorClass =
+    'text-violet-300 underline decoration-violet-500/40 underline-offset-2 hover:text-violet-200 hover:decoration-violet-300 cursor-pointer';
+  return {
+    a: ({ href, children, ...props }: React.ComponentProps<'a'>) => {
+      // Internal citation link — same-document scroll + ring flash, no new tab.
+      if (href && href.startsWith(CITATION_HREF_PREFIX)) {
+        const onAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+          e.preventDefault();
+          handleCitationClick(href);
+        };
+        const source = findSourceByCitationHref(href, anchorMap);
+        // PR9: source may be null on a transient stream miss (link emitted
+        // before the matching source is on the map). Fall back to a bare
+        // anchor — still scrolls + flashes once the card is rendered.
+        return (
+          <CitationHoverCard
+            href={href}
+            source={source}
+            disabled={hoverDisabled}
+            onAnchorClick={onAnchorClick}
+            anchorClassName={citationAnchorClass}
+          >
+            {children}
+          </CitationHoverCard>
+        );
+      }
+      // External link — open in new tab as before.
       return (
         <a
           {...props}
           href={href}
-          onClick={(e) => {
-            e.preventDefault();
-            handleCitationClick(href);
-          }}
-          className="text-violet-300 underline decoration-violet-500/40 underline-offset-2 hover:text-violet-200 hover:decoration-violet-300 cursor-pointer"
-          data-citation="1"
-        />
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-200 underline underline-offset-2 hover:text-white"
+        >
+          {children}
+        </a>
       );
-    }
-    // External link — open in new tab as before.
-    return (
-      <a
-        {...props}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-zinc-200 underline underline-offset-2 hover:text-white"
-      />
-    );
-  },
-  code: (props: React.ComponentProps<'code'>) => (
-    <code {...props} className="rounded bg-zinc-800 px-1 py-0.5 text-xs" />
-  ),
-  pre: (props: React.ComponentProps<'pre'>) => (
-    <pre {...props} className="rounded-lg bg-zinc-900 p-3 overflow-x-auto my-2 text-xs" />
-  ),
-  ul: (props: React.ComponentProps<'ul'>) => (
-    <ul {...props} className="list-disc pl-5 space-y-1 my-2" />
-  ),
-  ol: (props: React.ComponentProps<'ol'>) => (
-    <ol {...props} className="list-decimal pl-5 space-y-1 my-2" />
-  ),
-  p: (props: React.ComponentProps<'p'>) => (
-    <p {...props} className="my-2 first:mt-0 last:mb-0" />
-  ),
-};
+    },
+    code: (props: React.ComponentProps<'code'>) => (
+      <code {...props} className="rounded bg-zinc-800 px-1 py-0.5 text-xs" />
+    ),
+    pre: (props: React.ComponentProps<'pre'>) => (
+      <pre {...props} className="rounded-lg bg-zinc-900 p-3 overflow-x-auto my-2 text-xs" />
+    ),
+    ul: (props: React.ComponentProps<'ul'>) => (
+      <ul {...props} className="list-disc pl-5 space-y-1 my-2" />
+    ),
+    ol: (props: React.ComponentProps<'ol'>) => (
+      <ol {...props} className="list-decimal pl-5 space-y-1 my-2" />
+    ),
+    p: (props: React.ComponentProps<'p'>) => (
+      <p {...props} className="my-2 first:mt-0 last:mb-0" />
+    ),
+  };
+}
 
 const MarkdownAnswer = memo(function MarkdownAnswer({
   text,
   sources,
+  hoverDisabled,
 }: {
   text: string;
-  sources: ReadonlyArray<{ owner: string; name: string }>;
+  sources: ReadonlyArray<CitationSource>;
+  /** When true, suppresses the citation hover card (e.g. during streaming). */
+  hoverDisabled: boolean;
 }) {
   const linked = useMemo(() => injectCitations(text, sources), [text, sources]);
+  const anchorMap = useMemo(() => buildSourceAnchorMap(sources), [sources]);
+  const components = useMemo(
+    () => buildMarkdownComponents(anchorMap, hoverDisabled),
+    [anchorMap, hoverDisabled],
+  );
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeSanitize]}
-      components={MARKDOWN_COMPONENTS}
+      components={components}
     >
       {linked}
     </ReactMarkdown>
@@ -1848,7 +1881,11 @@ export function StickyAskBar() {
                   <div
                     className="rounded-lg bg-zinc-800/60 px-4 py-3 text-sm text-zinc-200 leading-relaxed"
                   >
-                    <MarkdownAnswer text={streamingAnswer} sources={sources} />
+                    <MarkdownAnswer
+                      text={streamingAnswer}
+                      sources={sources}
+                      hoverDisabled={isLoading}
+                    />
                     {isLoading && (
                       <span className="inline-block w-0.5 h-4 ml-0.5 bg-zinc-400 align-middle animate-pulse" />
                     )}

--- a/src/lib/askCitations.ts
+++ b/src/lib/askCitations.ts
@@ -94,6 +94,38 @@ export function injectCitations(
 }
 
 /**
+ * PR9: O(1) lookup map from citation anchor id to its source repo. Used by
+ * the citation hover preview to render a small floating card with stars +
+ * description on hover, without re-scanning the source list per hover.
+ *
+ * Key shape: the result of `sourceAnchorId(repo)`. Two forks of the same
+ * name produce two distinct keys, so the map is fork-safe.
+ */
+export function buildSourceAnchorMap<T extends { owner: string; name: string }>(
+  sources: ReadonlyArray<T>,
+): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const s of sources) {
+    map.set(sourceAnchorId(s), s);
+  }
+  return map;
+}
+
+/**
+ * PR9: extract the source for a citation `href` such as
+ * `#ask-source-langchain-ai-langchain` from a precomputed anchor map.
+ * Returns null on any non-citation href or unknown anchor.
+ */
+export function findSourceByCitationHref<T extends { owner: string; name: string }>(
+  href: string | undefined | null,
+  anchorMap: ReadonlyMap<string, T>,
+): T | null {
+  if (!href || !href.startsWith(CITATION_HREF_PREFIX)) return null;
+  const id = href.slice(1); // drop leading '#'
+  return anchorMap.get(id) ?? null;
+}
+
+/**
  * Click handler for in-document citation links. Scrolls the matching source
  * card into view and applies a brief ring-flash highlight.
  */

--- a/tests/unit/askCitationsHover.test.ts
+++ b/tests/unit/askCitationsHover.test.ts
@@ -1,0 +1,144 @@
+/**
+ * PR9 — citation hover preview helpers (pure logic only).
+ *
+ * `buildSourceAnchorMap` + `findSourceByCitationHref` together replace the
+ * O(n) per-hover scan over the source list with an O(1) anchor-id lookup.
+ * Two forks of the same name must remain distinguishable (different owners
+ * yield different anchor ids), so the map is fork-safe.
+ *
+ * `describeForHover` and `formatStars` (re-exported via the component file)
+ * trim repo data into a one-line preview the floating card can render
+ * without overflowing.
+ */
+import {
+  buildSourceAnchorMap,
+  findSourceByCitationHref,
+  sourceAnchorId,
+  CITATION_HREF_PREFIX,
+} from '@/lib/askCitations';
+import { describeForHover } from '@/components/CitationHoverCard';
+
+interface TestRepo {
+  owner: string;
+  name: string;
+  stars?: number | null;
+  description?: string | null;
+}
+
+describe('buildSourceAnchorMap', () => {
+  it('builds an empty map for an empty source list', () => {
+    expect(buildSourceAnchorMap<TestRepo>([])).toEqual(new Map());
+  });
+
+  it('keys each source by its sourceAnchorId', () => {
+    const sources: TestRepo[] = [
+      { owner: 'langchain-ai', name: 'langchain' },
+      { owner: 'jerryjliu', name: 'llama_index' },
+    ];
+    const map = buildSourceAnchorMap(sources);
+    expect(map.size).toBe(2);
+    expect(map.get(sourceAnchorId(sources[0]))).toBe(sources[0]);
+    expect(map.get(sourceAnchorId(sources[1]))).toBe(sources[1]);
+  });
+
+  it('fork-safe: forks of the same name with different owners get distinct keys', () => {
+    const upstream: TestRepo = { owner: 'pytorch', name: 'pytorch' };
+    const fork: TestRepo = { owner: 'perditioinc', name: 'pytorch' };
+    const map = buildSourceAnchorMap([upstream, fork]);
+    expect(map.size).toBe(2);
+    expect(sourceAnchorId(upstream)).not.toBe(sourceAnchorId(fork));
+    expect(map.get(sourceAnchorId(upstream))).toBe(upstream);
+    expect(map.get(sourceAnchorId(fork))).toBe(fork);
+  });
+
+  it('on duplicate ids the last write wins (defensive — should not occur in practice)', () => {
+    // Two repos with identical owner+name yield identical anchor ids;
+    // realistically the API dedupes upstream, but the map should not throw.
+    const a: TestRepo = { owner: 'foo', name: 'bar' };
+    const b: TestRepo = { owner: 'foo', name: 'bar' };
+    const map = buildSourceAnchorMap([a, b]);
+    expect(map.size).toBe(1);
+    expect(map.get(sourceAnchorId(a))).toBe(b);
+  });
+});
+
+describe('findSourceByCitationHref', () => {
+  const sources: TestRepo[] = [
+    { owner: 'langchain-ai', name: 'langchain' },
+    { owner: 'jerryjliu', name: 'llama_index' },
+  ];
+  const map = buildSourceAnchorMap(sources);
+
+  it('returns the source for a matching citation href', () => {
+    const href = `#${sourceAnchorId(sources[0])}`;
+    expect(findSourceByCitationHref(href, map)).toBe(sources[0]);
+  });
+
+  it('returns null for null/undefined hrefs', () => {
+    expect(findSourceByCitationHref(null, map)).toBeNull();
+    expect(findSourceByCitationHref(undefined, map)).toBeNull();
+    expect(findSourceByCitationHref('', map)).toBeNull();
+  });
+
+  it('returns null for non-citation hrefs (external links, fragments)', () => {
+    expect(findSourceByCitationHref('https://github.com/foo/bar', map)).toBeNull();
+    expect(findSourceByCitationHref('#unrelated-anchor', map)).toBeNull();
+    expect(findSourceByCitationHref('mailto:x@y.z', map)).toBeNull();
+  });
+
+  it('returns null for citation-prefix hrefs that do not match any anchor', () => {
+    const href = `${CITATION_HREF_PREFIX}does-not-exist`;
+    expect(findSourceByCitationHref(href, map)).toBeNull();
+  });
+
+  it('uses the precomputed map (no scan over sources)', () => {
+    // Guard: the function reads from the passed-in map only. A map built
+    // from an empty list must not match anything even if the href looks valid.
+    const empty = buildSourceAnchorMap<TestRepo>([]);
+    const href = `#${sourceAnchorId(sources[0])}`;
+    expect(findSourceByCitationHref(href, empty)).toBeNull();
+  });
+});
+
+describe('describeForHover', () => {
+  it('returns empty string for null/undefined/blank inputs', () => {
+    expect(describeForHover(null)).toBe('');
+    expect(describeForHover(undefined)).toBe('');
+    expect(describeForHover('')).toBe('');
+    expect(describeForHover('   ')).toBe('');
+  });
+
+  it('prefers the first sentence when it fits inside the cap', () => {
+    const desc = 'A retrieval framework. With many features and integrations.';
+    expect(describeForHover(desc, 140)).toBe('A retrieval framework.');
+  });
+
+  it('handles ! and ? as sentence terminators', () => {
+    expect(describeForHover('Wow! Amazing tool.')).toBe('Wow!');
+    expect(describeForHover('What is RAG? It stands for retrieval augmented generation.')).toBe('What is RAG?');
+  });
+
+  it('returns the trimmed description when shorter than the cap and has no sentence end', () => {
+    expect(describeForHover('short tagline')).toBe('short tagline');
+  });
+
+  it('truncates with an ellipsis when no sentence end is found and length exceeds the cap', () => {
+    const long = 'a'.repeat(200);
+    const out = describeForHover(long, 50);
+    expect(out.endsWith('…')).toBe(true);
+    // Cap is on the pre-ellipsis content, so total length is cap + 1.
+    expect(out.length).toBeLessThanOrEqual(51);
+  });
+
+  it('falls back to the cap when the first sentence itself exceeds maxLen', () => {
+    // First sentence is 200 chars but cap is 50 — must not return that whole sentence.
+    const huge = 'x'.repeat(200) + '. short next.';
+    const out = describeForHover(huge, 50);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(51);
+  });
+
+  it('trims leading/trailing whitespace before processing', () => {
+    expect(describeForHover('  hello world.  ')).toBe('hello world.');
+  });
+});


### PR DESCRIPTION
## Summary

- Hovering an inline citation link (PR7) now pops a small floating card next to the link with the matched repo's identity, ★ stars, and a one-line description excerpt — citations become useful at a glance without forcing a click + scroll trip.
- Click semantics are unchanged: PR7's \`handleCitationClick\` still scrolls and ring-flashes the source card.
- Suppressed during streaming (\`hoverDisabled\` while \`isLoading\`) so the live answer animation owns the visual focus.

## Implementation

- **\`src/components/CitationHoverCard.tsx\`** (new, ~200 lines) — wraps the citation \`<a>\`, owns the 350 ms hover timer, position recompute on scroll/resize, ESC dismiss, mouseleave hide, focus accessibility. Reuses the PR6 portal-with-\`position:fixed\` lesson so the sticky bar's \`overflow:hidden\` doesn't clip it. SSR-safe via \`useSyncExternalStore\` (no setState-in-effect).
- **\`src/lib/askCitations.ts\`** — adds \`buildSourceAnchorMap\` + \`findSourceByCitationHref\` for O(1) anchor-id → source lookup (fork-safe: two forks of the same name resolve to distinct keys).
- **\`src/components/StickyAskBar.tsx\`** — \`MARKDOWN_COMPONENTS\` converted from a static const into a memoized factory \`buildMarkdownComponents(anchorMap, hoverDisabled)\` so the \`a\` override has the per-render anchor map and streaming flag in scope. \`MarkdownAnswer\` accepts the new \`hoverDisabled\` prop.

## Test plan

- [x] tsc clean
- [x] eslint clean (CitationHoverCard, StickyAskBar, askCitations)
- [x] 16 new unit tests (\`tests/unit/askCitationsHover.test.ts\`) covering helper purity, fork-safe keying, null/external href handling, \`describeForHover\` sentence preference + char-cap fallback
- [x] Full Jest suite: 30 suites / 257 tests / 0 regressions
- [ ] Vercel preview: hover renders card with correct repo + stars; mouseleave hides; click still scrolls + ring-flashes; doesn't appear while streaming
- [ ] Production smoke after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)