### PR TITLE
feat(faq): add /faq page rendering every curated Ask suggestion

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { FAQPanel } from '@/components/FAQPanel';
+
+export const metadata: Metadata = {
+  title: 'Reporium FAQ — Suggested questions, grounded answers',
+  description:
+    'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base. Grounded in indexed repos, no hallucinations.',
+  openGraph: {
+    title: 'Reporium FAQ — Suggested questions, grounded answers',
+    description:
+      'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base.',
+    url: 'https://www.reporium.com/faq',
+  },
+  twitter: {
+    title: 'Reporium FAQ — Suggested questions, grounded answers',
+    description:
+      'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base.',
+  },
+};
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title="FAQ" />
+
+      <main className="mx-auto max-w-4xl px-6 py-10 space-y-8">
+        <header>
+          <h1 className="text-2xl font-bold text-zinc-100 sm:text-3xl">FAQ</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            Every question the Ask bar suggests, answered live against the Reporium
+            knowledge base. Open a card to see the grounded answer and its source repos.
+          </p>
+        </header>
+
+        <FAQPanel />
+      </main>
+    </div>
+  );
+}

--- a/src/components/FAQPanel.tsx
+++ b/src/components/FAQPanel.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import { API_URL } from '@/lib/apiUrl';
+
+const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
+
+// Grouped so the page reads as a tour of Reporium's capabilities. Every entry
+// is pinned to a deterministic smart-route match in reporium-api so the answer
+// is always grounded — no generic "not enough information" early-exit. Keep in
+// sync with `_CURATED_SUGGESTIONS` in `reporium-api/app/routers/intelligence.py`.
+interface FAQSection {
+  title: string;
+  blurb: string;
+  questions: string[];
+}
+
+const FAQ_SECTIONS: readonly FAQSection[] = [
+  {
+    title: 'Library stats',
+    blurb: 'Instant SQL counts over the indexed library. Zero token cost.',
+    questions: [
+      'How many repos are tracked?',
+      'What categories are available?',
+      'How many Python repos are there?',
+    ],
+  },
+  {
+    title: 'Leaderboards',
+    blurb: 'Ranked repos by stars, forks, activity, or recency.',
+    questions: [
+      'What are the most forked repos?',
+      'What are the most starred repos?',
+      'What are the most active repos?',
+      'What are the newest repos?',
+    ],
+  },
+  {
+    title: 'Topic-narrowed picks',
+    blurb: 'Leaderboards filtered to a specific AI-dev category.',
+    questions: [
+      'Show me RAG tools with the most stars',
+      'Show me agent tools with the most stars',
+      'Show me inference tools with the most stars',
+      'Show me evaluation tools with the most stars',
+    ],
+  },
+  {
+    title: 'Tag search',
+    blurb: 'Find every repo tagged with a given capability.',
+    questions: [
+      'Which repos support MCP?',
+      'Which repos use pgvector?',
+    ],
+  },
+  {
+    title: 'Comparisons',
+    blurb: 'Side-by-side metadata for two repos — license, category, stars, activity.',
+    questions: [
+      'Compare LangChain and LlamaIndex',
+      "What's the difference between vLLM and TGI?",
+      'Compare CrewAI and AutoGen',
+    ],
+  },
+];
+
+interface SourceRepo {
+  name: string;
+  owner: string;
+  forked_from: string | null;
+  description: string | null;
+  stars: number | null;
+  relevance_score: number;
+  problem_solved: string | null;
+  integration_tags: string[];
+}
+
+interface AnswerState {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  answer?: string;
+  sources?: SourceRepo[];
+  error?: string;
+}
+
+const MARKDOWN_COMPONENTS = {
+  a: (props: React.ComponentProps<'a'>) => (
+    <a
+      {...props}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-zinc-200 underline underline-offset-2 hover:text-white"
+    />
+  ),
+  code: (props: React.ComponentProps<'code'>) => (
+    <code {...props} className="rounded bg-zinc-800 px-1 py-0.5 text-xs" />
+  ),
+  pre: (props: React.ComponentProps<'pre'>) => (
+    <pre {...props} className="rounded-lg bg-zinc-900 p-3 overflow-x-auto my-2 text-xs" />
+  ),
+  ul: (props: React.ComponentProps<'ul'>) => (
+    <ul {...props} className="list-disc pl-5 space-y-1 my-2" />
+  ),
+  ol: (props: React.ComponentProps<'ol'>) => (
+    <ol {...props} className="list-decimal pl-5 space-y-1 my-2" />
+  ),
+  p: (props: React.ComponentProps<'p'>) => (
+    <p {...props} className="my-2 first:mt-0 last:mb-0" />
+  ),
+};
+
+function formatRepoLink(src: SourceRepo) {
+  if (src.forked_from) {
+    return { label: src.forked_from, href: `https://github.com/${src.forked_from}` };
+  }
+  const slug = `${src.owner}/${src.name}`;
+  return { label: slug, href: `https://github.com/${slug}` };
+}
+
+async function fetchAnswer(question: string, signal: AbortSignal): Promise<AnswerState> {
+  if (!APP_TOKEN) {
+    return {
+      status: 'error',
+      error: 'Ask is not configured in this environment (missing NEXT_PUBLIC_APP_API_TOKEN).',
+    };
+  }
+  try {
+    const res = await fetch(`${API_URL}/intelligence/ask`, {
+      method: 'POST',
+      signal,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-App-Token': APP_TOKEN,
+      },
+      body: JSON.stringify({ question, top_k: 8 }),
+    });
+    if (res.status === 429) {
+      return { status: 'error', error: 'Rate limit exceeded. Try refreshing in a minute.' };
+    }
+    if (!res.ok) {
+      return { status: 'error', error: `Server error (${res.status}).` };
+    }
+    const body = (await res.json()) as { answer: string; sources: SourceRepo[] };
+    return { status: 'ready', answer: body.answer, sources: body.sources ?? [] };
+  } catch (err) {
+    if ((err as DOMException)?.name === 'AbortError') {
+      return { status: 'idle' };
+    }
+    return { status: 'error', error: 'Network error — please refresh to retry.' };
+  }
+}
+
+/**
+ * FAQ card — lazily fetches the answer the first time the details element opens.
+ * Keeps the initial page weightless (one fetch per user-initiated expansion)
+ * instead of firing 16 requests on mount.
+ */
+function FAQCard({ question }: { question: string }) {
+  const [state, setState] = useState<AnswerState>({ status: 'idle' });
+  const controllerRef = useRef<AbortController | null>(null);
+
+  function load() {
+    if (state.status === 'loading' || state.status === 'ready') return;
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setState({ status: 'loading' });
+    void fetchAnswer(question, controller.signal).then(setState);
+  }
+
+  useEffect(() => () => controllerRef.current?.abort(), []);
+
+  return (
+    <details
+      className="group rounded-lg border border-zinc-800 bg-zinc-900/60 open:bg-zinc-900 transition-colors"
+      onToggle={(e) => {
+        if ((e.currentTarget as HTMLDetailsElement).open) load();
+      }}
+    >
+      <summary className="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-zinc-100">{question}</span>
+        <span
+          aria-hidden
+          className="text-zinc-500 group-open:rotate-180 transition-transform text-xs shrink-0"
+        >
+          ▾
+        </span>
+      </summary>
+      <div className="px-4 pb-4 pt-1 border-t border-zinc-800/60">
+        {state.status === 'idle' && (
+          <p className="text-xs text-zinc-500 py-2">Click to load the answer.</p>
+        )}
+        {state.status === 'loading' && <FAQSkeleton />}
+        {state.status === 'error' && (
+          <div className="py-2">
+            <p className="text-xs text-red-400">{state.error}</p>
+            <button
+              type="button"
+              onClick={() => {
+                setState({ status: 'idle' });
+                load();
+              }}
+              className="mt-2 rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {state.status === 'ready' && (
+          <div className="space-y-3">
+            <div className="prose prose-invert prose-sm max-w-none text-sm text-zinc-200">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+                components={MARKDOWN_COMPONENTS}
+              >
+                {state.answer ?? ''}
+              </ReactMarkdown>
+            </div>
+            {state.sources && state.sources.length > 0 && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-zinc-500 mb-1.5">
+                  Sources
+                </p>
+                <ul className="flex flex-wrap gap-1.5">
+                  {state.sources.slice(0, 8).map((src) => {
+                    const link = formatRepoLink(src);
+                    return (
+                      <li key={`${src.owner}/${src.name}`}>
+                        <a
+                          href={link.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors"
+                        >
+                          {link.label}
+                          {typeof src.stars === 'number' && (
+                            <span className="text-zinc-500">★ {src.stars.toLocaleString()}</span>
+                          )}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+            <a
+              href={`/ask?q=${encodeURIComponent(question)}`}
+              className="inline-block text-[11px] text-zinc-500 hover:text-zinc-300 underline underline-offset-2"
+            >
+              Open in Ask →
+            </a>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function FAQSkeleton() {
+  return (
+    <div className="space-y-2 py-2" aria-hidden>
+      <div className="h-3 w-3/4 rounded bg-zinc-800 animate-pulse" />
+      <div className="h-3 w-5/6 rounded bg-zinc-800 animate-pulse" />
+      <div className="h-3 w-2/3 rounded bg-zinc-800 animate-pulse" />
+    </div>
+  );
+}
+
+export function FAQPanel() {
+  const total = useMemo(
+    () => FAQ_SECTIONS.reduce((acc, s) => acc + s.questions.length, 0),
+    [],
+  );
+  return (
+    <div className="space-y-10">
+      <p className="text-xs text-zinc-500">
+        {total} questions · answers come directly from <code className="bg-zinc-800 px-1 rounded">/intelligence/ask</code>,
+        the same endpoint that powers the Ask bar.
+      </p>
+      {FAQ_SECTIONS.map((section) => (
+        <section key={section.title}>
+          <h2 className="text-lg font-semibold text-zinc-200">{section.title}</h2>
+          <p className="mt-1 text-xs text-zinc-500">{section.blurb}</p>
+          <div className="mt-4 space-y-2">
+            {section.questions.map((q) => (
+              <FAQCard key={q} question={q} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/StickyNavBar.tsx
+++ b/src/components/StickyNavBar.tsx
@@ -50,6 +50,13 @@ const NavIcon = {
       <circle cx="12" cy="12" r="3" />
     </svg>
   ),
+  faq: (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
 } as const;
 
 const NAV_LINKS = [
@@ -61,6 +68,7 @@ const NAV_LINKS = [
   { href: '/trends',       label: 'Trends',       icon: NavIcon.trends       },
   { href: '/architecture', label: 'Architecture', icon: NavIcon.architecture },
   { href: '/ai-native',    label: 'AI-Native',    icon: NavIcon.aiNative     },
+  { href: '/faq',          label: 'FAQ',          icon: NavIcon.faq          },
 ];
 
 interface StickyNavBarProps {


### PR DESCRIPTION
## Summary
- New `/faq` page with 16 questions grouped into 5 sections — every one pinned to a deterministic smart-route match in `reporium-api`, so answers are always grounded (no "not enough information" early-exits)
- Lazy-fetch on expand: each card fires one `/intelligence/ask` request the first time it's opened (not 16 at mount)
- Markdown answers via `ReactMarkdown` + `rehype-sanitize`; source repo chips with star counts
- FAQ entry added to `StickyNavBar`

## Companion PRs (reporium-api)
- #431 (merged) — `list-categories` regex fix + smart-route follow-up suggestions
- #433 (pending) — `newest`/`oldest` SQL column fix (was a 500)

## Verification
Tested against live API in `next dev`:
- 15/16 curated questions return grounded answers in under ~2s
- 1 remaining (newest-repos) fixed in #433 — deploy in flight

## Test plan
- [ ] Vercel preview: visit `/faq`, open 3-4 cards across different sections, confirm grounded answers with source chips
- [ ] Confirm `/faq` appears in sticky nav
- [ ] Click "Open in Ask →" link opens `/ask?q=...` with the question prefilled
- [ ] After #433 deploys: "What are the newest repos?" returns a list instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)