### PR TITLE
feat(faq): /faq + client spend-surface mitigation (KAN-272, supersedes #272)

### DIFF
--- a/.audit/2026-04-24/faq-spend-surface-jira.md
+++ b/.audit/2026-04-24/faq-spend-surface-jira.md
@@ -1,0 +1,107 @@
+# JIRA draft — KAN-272 (FAQ spend-surface mitigation)
+
+> **Status:** draft. JIRA CLI not available in this environment; create in
+> perditio.atlassian.net by hand or via `gh`-paired automation.
+
+## Summary
+
+`feat(faq): client-side spend-surface mitigation for /faq` — fold a small
+client-side budget gate and 1h answer cache into PR #272 before merging the
+new public FAQ page that calls `/intelligence/ask` with the public
+`NEXT_PUBLIC_APP_API_TOKEN`.
+
+## Type
+Improvement (rides on top of feature PR #272).
+
+## Component
+`reporium` (frontend) — files touched: `src/components/FAQPanel.tsx` only.
+
+## Background
+
+PR #272 ([github.com/perditioinc/reporium#272](https://github.com/perditioinc/reporium/pull/272))
+adds a public `/faq` page with 16 cards. Every card expand fires
+`POST /intelligence/ask` from the browser using the public app token. The PR
+is CI-green and product-useful, but it strictly *expands* the browser-side
+Ask spend surface — `AskBar` enforces a 10/min · 100/day client wallet, and
+FAQ today bypasses it entirely.
+
+The real fix is server-side: hold the token on the server and gate
+`/intelligence/ask` calls behind a session cookie + per-IP quota. That's a
+joint reporium-api + reporium frontend lane, not in scope here. This ticket
+is the *small client mitigation* that ships with #272 and buys time.
+
+## Problem
+1. FAQ cards do not consume the shared `reporium_ask_timestamps` budget,
+   so a user who opens 16 cards plus uses the Ask bar can fire 26+
+   `/intelligence/ask` calls before any client guard kicks in.
+2. FAQ questions are *hardcoded literals* — there is no reason a refresh
+   should refetch any of them. There is no client cache.
+3. A bot or curious tab that scripts `details.open = true` on all 16 cards
+   will burn 16 tokens of LLM cost per page-load with no friction.
+
+## Fix (this ticket)
+
+Local to `src/components/FAQPanel.tsx` only:
+
+- Read the same `reporium_ask_timestamps` localStorage wallet that
+  `AskBar.tsx` writes. Before firing a `/intelligence/ask` request, refuse
+  if `minute >= 10` or `day >= 100` and surface a friendly message
+  ("you've hit Reporium's per-minute Ask budget — try again in a moment").
+- After a successful response, append `Date.now()` to the wallet (mirrors
+  `AskBar.recordRequest`).
+- Cache successful answers in `localStorage['reporium_faq_answer_cache']`
+  keyed by question text, with a 1h TTL. On expand, check cache first and
+  short-circuit the fetch if a fresh entry exists.
+- Both helpers degrade silently when localStorage is unavailable
+  (private browsing, etc.) — the FAQ remains usable, just unmetered/uncached.
+
+## Out of scope (filed elsewhere)
+
+- **Real spend containment** (server-side proxy, session cookie, per-IP
+  quota): KAN-LATER-2 in the design memo. This is the only correct
+  long-term fix.
+- **UX visibility surfaces** (budget meter, grounding badge, cache-age
+  pill, unified error voice): owned by Lane Claude Design
+  ([reporium-ask-faq-design-memo.md](reporium-ask-faq-design-memo.md))
+  Phase 1.
+
+## Acceptance criteria
+
+- [x] On `/faq`, opening a card with `localStorage['reporium_ask_timestamps']`
+      already at 10 entries within the past minute results in **zero**
+      network calls to `/intelligence/ask` and a visible friendly message.
+- [x] Opening a card the *first* time fires one fetch and writes one entry
+      to `reporium_faq_answer_cache`.
+- [x] Closing and reopening that card does not refetch (handled by existing
+      `state.status === 'ready'` guard inside the same component instance).
+- [x] Reloading `/faq` and opening the same card serves the answer from
+      cache with **zero** new fetches and **zero** new wallet entries.
+- [x] Same TTL behavior as the AskBar wallet — entries older than 24h are
+      pruned on the next write.
+- [x] No new dependencies; no API change; no edits outside FAQPanel.tsx.
+
+## Verification (already done in lane)
+
+Manual verification against `next dev` against /faq, with `window.fetch`
+hooked to count `/intelligence/ask` calls:
+
+| Scenario                                    | Fetches | Notes |
+| ------------------------------------------- | ------- | ----- |
+| Cap at 10/min, then open card               | 0       | budget-gate message renders |
+| Reset, open card                            | 1       | cache + wallet write |
+| Reload `/faq`, open same card               | 0       | cache hit on cold mount |
+
+## Risk
+
+Low. Single file, ~80 LOC additive. Falls back to current behavior if
+localStorage is unavailable. Cannot regress the rest of the Ask surface
+because it only reads the wallet (does not change AskBar's writer).
+
+## Notes
+
+- Does *not* defend against an attacker who reads the bundled token. That
+  is the architecture lane (KAN-LATER-2).
+- The design lane's [reporium-ask-faq-design-memo.md](reporium-ask-faq-design-memo.md)
+  Phase 1 surfaces (budget meter, grounding badge) build on the wallet
+  this ticket starts paying into. Don't rip the wallet out when those
+  ship — extend it.

--- a/.audit/2026-04-24/pr-272-faq-decision.md
+++ b/.audit/2026-04-24/pr-272-faq-decision.md
@@ -1,0 +1,151 @@
+# PR #272 — Decision: merge with mitigation
+
+**Date:** 2026-04-24
+**Lane:** `claude/feature/KAN-272-faq-spend-surface-v2` off `main`
+**Reviewer:** Claude Opus 4.7 (spend-surface lane)
+**Subject:** [PR #272 — feat(faq): add /faq page rendering every curated Ask suggestion](https://github.com/perditioinc/reporium/pull/272)
+
+## TL;DR
+
+**Merge with the small mitigation in this lane.** Do not wait for the
+server-side proxy. The proxy is the right long-term fix and is *not* in
+scope here, but #272 is product-useful as-is and the local mitigation
+removes the worst of the new client-side burn risk in ~80 lines.
+
+## What #272 does
+
+- New public `/faq` page with 16 hardcoded curated questions across 5
+  sections, each pinned to a deterministic smart-route in `reporium-api`.
+- Each card lazy-fetches `POST /intelligence/ask` on first expand using
+  `NEXT_PUBLIC_APP_API_TOKEN` (the same public token the AskBar already
+  exposes).
+- Adds a `/faq` link to the sticky nav.
+- Files: `src/app/faq/page.tsx` (40 LOC), `src/components/FAQPanel.tsx`
+  (296 LOC), `src/components/StickyNavBar.tsx` (+8 LOC).
+
+CI is green. The PR is honest about smart-route grounding and the answers
+are useful product surface — it's the right Phase-2 build for the trust
+story (`/ai-native` slide 2 + 4).
+
+## What #272 makes worse
+
+- **Spend surface widens.** AskBar enforces a `reporium_ask_timestamps`
+  client wallet (10/min · 100/day) before allowing `/intelligence/ask`.
+  FAQ bypasses it — its own `fetchAnswer` writes nothing to that wallet
+  and reads nothing from it. So a user who used the AskBar 8 times in the
+  last minute can still expand 16 FAQ cards on top of that with no
+  client-side push-back, and a bot can script `details.open = true`
+  across all 16 cards in one tick.
+- **No cache, despite hardcoded inputs.** FAQ questions are literals.
+  Refresh refetches all of them. There is no reason a returning visitor
+  should reburn the LLM-summary cards (Comparisons section) when nothing
+  in the input changed and the answer was good 30 minutes ago.
+- **The token-in-bundle problem is unchanged.** That's true of the whole
+  Ask surface today — #272 doesn't make it worse, it just adds another
+  call site.
+
+## Why not "wait for server-side proxy"
+
+- The proxy is a real piece of work — new server route, session cookie,
+  per-IP quota plumbing, then deletion of `NEXT_PUBLIC_APP_API_TOKEN`
+  from the client bundle and migration of all four Ask call sites
+  (AskBar, StickyAskBar, AskPanel, FAQPanel). That's a separate joint
+  lane (frontend + reporium-api), described as Phase 3 / KAN-LATER-2 in
+  [reporium-ask-faq-design-memo.md](reporium-ask-faq-design-memo.md).
+- Holding #272 hostage to it costs us a useful product surface for an
+  unknown number of weeks. The local mitigation in this lane closes the
+  worst *new* burn vector #272 introduces (multi-card expansion bypassing
+  the wallet) without pretending to fix the architectural one.
+- The mitigation is forward-compatible: when the proxy ships, the
+  client-side wallet becomes redundant, not in the way. Pull it out at
+  that time.
+
+## Why not "merge as-is"
+
+The two delta costs above are cheap to remove and high-leverage:
+- One curious user reading top-to-bottom is the worst case path today
+  and could fire 16 LLM calls with no client friction at all.
+- Refresh-on-FAQ refires 16 calls. Trivial cache eliminates that.
+
+These are *new* spend vectors specific to #272. We're already on the
+hook for AskBar's existing spend surface; this lane keeps #272 from
+*widening* it.
+
+## The mitigation (this lane's diff)
+
+Local to `src/components/FAQPanel.tsx`. ~80 additive lines. No new files,
+no API change, no other call sites touched.
+
+1. **Shared budget wallet.** Add `readBudget()` and `recordAsk()` helpers
+   that read/write the same `reporium_ask_timestamps` localStorage key
+   `AskBar.tsx` uses. Same constants (`RATE_PER_MIN = 10`,
+   `RATE_PER_DAY = 100`).
+2. **Pre-flight gate inside `load()`.** Before firing `fetchAnswer`,
+   check the wallet. If `minute >= 10` or `day >= 100`, set state to
+   `error` with a friendly message; do not fetch.
+3. **Record on success.** After a `'ready'` response, append `Date.now()`
+   to the wallet — same pruning policy as AskBar.
+4. **1h answer cache.** Add `readCache(question)` / `writeCache(...)`
+   against `reporium_faq_answer_cache` keyed by question text. On
+   expand, check the cache first; on hit, render directly with zero
+   network call. On any successful fetch, write the cache. Cache TTL is
+   1 hour; entries older than that are pruned on the next write.
+5. **Degrade silently on localStorage failure.** Both helpers `try/catch`
+   and fall through to "no wallet, no cache" — `/faq` remains usable in
+   private browsing.
+
+That is the entire mitigation. No UI surfaces (no budget meter, no
+"served from cache" pill — those belong to the design lane's Phase 1,
+which builds on the wallet this lane starts paying into).
+
+## Verified locally (next dev against /faq)
+
+`window.fetch` was hooked to count `/intelligence/ask` calls.
+
+| Scenario                                    | Fetches | Wallet ticks |
+| ------------------------------------------- | ------- | ------------ |
+| Wallet pre-loaded with 10 timestamps; open card | 0   | 0 (gated)    |
+| Reset, open one card fresh                  | 1       | 1            |
+| Reload `/faq`, open the same card           | 0       | 0 (cache)    |
+
+Friendly gated message rendered as expected:
+`"You've hit Reporium's per-minute Ask budget (10/min). Try again in a moment."`
+
+## Note on future Ask architecture
+
+This lane does **not** replace, defer, or compete with the server-side
+proxy. The proxy is the only thing that actually closes the spend
+surface; no UI patch can. The mitigation here is a 1h speed-bump that
+keeps the *new* `/faq` surface from doubling the existing burn risk
+while the proxy is scoped.
+
+When the proxy ships:
+- `NEXT_PUBLIC_APP_API_TOKEN` is deleted from the bundle.
+- All four Ask call sites switch to same-origin `/api/ask`.
+- Per-IP / per-session quotas move to the server.
+- The client wallet becomes legacy. Remove it then, in the same lane that
+  ships the proxy. Do not rip it out before — losing the wallet would
+  un-pace honest users for no architectural gain.
+
+## Recommendation
+
+**Merge with mitigation.** The PR target is `main`; this lane carries
+the cherry-picked PR #272 commit plus the mitigation commit on a single
+branch (`claude/feature/KAN-272-faq-spend-surface-v2`) so the diff
+reviewer sees the full delta against `main` in one PR. The original
+`claude/feature/faq-page` PR can be closed in favor of this one, or the
+mitigation commit can be folded into PR #272 directly — either is fine,
+but the merged result must include the mitigation.
+
+## Stop-conditions check
+
+- ✅ Owned scope respected: only `FAQPanel.tsx` was *modified*.
+  `page.tsx` and `StickyNavBar.tsx` are unchanged from #272.
+- ✅ No edits outside owned files (`.audit/2026-04-24/*` is the lane's
+  decision documentation, not a code change).
+- ✅ No merge, no deploy.
+- ✅ Honest about backend: server-side proxy is the real fix and is out
+  of scope for this lane.
+- ✅ No collision with the sibling design lane — that lane authored
+  `.audit/2026-04-24/reporium-ask-faq-design-{memo,jira}.md`; this lane
+  only adds `pr-272-faq-decision.md` and `faq-spend-surface-jira.md`.

--- a/.audit/2026-04-25/faq-spend-surface-jira.md
+++ b/.audit/2026-04-25/faq-spend-surface-jira.md
@@ -12,7 +12,10 @@ The mitigation was authored on 2026-04-24 against `main @ 8224e3a` and
 PR #272 head `63c33e4`. Today's lane re-runs the validation:
 
 - `git fetch --all --prune` clean.
-- `origin/main` HEAD: `8224e3a` (no change since 2026-04-24).
+- `origin/main` HEAD: `53e36ae` (advanced from `8224e3a` via
+  `chore: refresh library data 2026-04-25` — touches only `DIGEST.md`,
+  `public/data/library.json`, `public/data/trends.json`; outside owned
+  scope; no rebase conflict risk for `FAQPanel.tsx`).
 - PR #272 (`claude/feature/faq-page`): HEAD `63c33e4`, `mergeStateStatus`
   `CLEAN`, `mergeable` `MERGEABLE`, no new pushes since the v1 commit.
 - AskBar wallet contract (the assumption the mitigation relies on)

--- a/.audit/2026-04-25/faq-spend-surface-jira.md
+++ b/.audit/2026-04-25/faq-spend-surface-jira.md
@@ -1,0 +1,151 @@
+# JIRA draft — KAN-272 (FAQ spend-surface mitigation, 2026-04-25 re-validation)
+
+> **Status:** draft. JIRA CLI not available in this environment; create in
+> perditio.atlassian.net by hand. This file is the canonical lane record
+> for 2026-04-25; the substantive design and decision rationale live in
+> [`../2026-04-24/pr-272-faq-decision.md`](../2026-04-24/pr-272-faq-decision.md)
+> and [`../2026-04-24/faq-spend-surface-jira.md`](../2026-04-24/faq-spend-surface-jira.md).
+
+## Re-validation pass — 2026-04-25
+
+The mitigation was authored on 2026-04-24 against `main @ 8224e3a` and
+PR #272 head `63c33e4`. Today's lane re-runs the validation:
+
+- `git fetch --all --prune` clean.
+- `origin/main` HEAD: `8224e3a` (no change since 2026-04-24).
+- PR #272 (`claude/feature/faq-page`): HEAD `63c33e4`, `mergeStateStatus`
+  `CLEAN`, `mergeable` `MERGEABLE`, no new pushes since the v1 commit.
+- AskBar wallet contract (the assumption the mitigation relies on)
+  re-checked at `src/components/AskBar.tsx`:
+  - line 67: `const RATE_KEY = 'reporium_ask_timestamps'`
+  - line 68: `const RATE_PER_MIN = 10`
+  - line 69: `const RATE_PER_DAY = 100`
+  Identical to 2026-04-24.
+- `npx tsc --noEmit` on lane HEAD: **exit 0**.
+- `npx eslint src/components/FAQPanel.tsx`: clean.
+- No other open PR or local branch touches the owned scope
+  (`src/app/faq/page.tsx`, `src/components/FAQPanel.tsx`,
+  `src/components/StickyNavBar.tsx`); only `claude/feature/faq-page`
+  itself does. No cross-lane collision.
+
+Recommendation unchanged: **merge with mitigation.** No re-scope.
+
+## Summary
+
+`feat(faq): client-side spend-surface mitigation for /faq` — fold a small
+client-side budget gate and 1h answer cache into PR #272 before merging
+the new public FAQ page that calls `/intelligence/ask` with the public
+`NEXT_PUBLIC_APP_API_TOKEN`.
+
+## Type
+Improvement (rides on top of feature PR #272).
+
+## Component
+`reporium` (frontend) — files touched: `src/components/FAQPanel.tsx` only.
+
+## Background
+
+PR #272 ([github.com/perditioinc/reporium#272](https://github.com/perditioinc/reporium/pull/272))
+adds a public `/faq` page with 16 cards. Every card expand fires
+`POST /intelligence/ask` from the browser using the public app token. The PR
+is CI-green and product-useful, but it strictly *expands* the browser-side
+Ask spend surface — `AskBar` enforces a 10/min · 100/day client wallet, and
+FAQ today bypasses it entirely.
+
+The real fix is server-side: hold the token on the server and gate
+`/intelligence/ask` calls behind a session cookie + per-IP quota. That's a
+joint reporium-api + reporium frontend lane, not in scope here. This ticket
+is the *small client mitigation* that ships with #272 and buys time.
+
+## Problem
+
+1. FAQ cards do not consume the shared `reporium_ask_timestamps` budget,
+   so a user who opens 16 cards plus uses the Ask bar can fire 26+
+   `/intelligence/ask` calls before any client guard kicks in.
+2. FAQ questions are *hardcoded literals* — there is no reason a refresh
+   should refetch any of them. There is no client cache.
+3. A bot or curious tab that scripts `details.open = true` on all 16 cards
+   will burn 16 tokens of LLM cost per page-load with no friction.
+
+## Fix (this ticket)
+
+Local to `src/components/FAQPanel.tsx` only:
+
+- Read the same `reporium_ask_timestamps` localStorage wallet that
+  `AskBar.tsx` writes. Before firing a `/intelligence/ask` request, refuse
+  if `minute >= 10` or `day >= 100` and surface a friendly message
+  ("you've hit Reporium's per-minute Ask budget — try again in a moment").
+- After a successful response, append `Date.now()` to the wallet (mirrors
+  `AskBar.recordRequest`).
+- Cache successful answers in `localStorage['reporium_faq_answer_cache']`
+  keyed by question text, with a 1h TTL. On expand, check cache first and
+  short-circuit the fetch if a fresh entry exists.
+- Both helpers degrade silently when localStorage is unavailable
+  (private browsing, etc.) — the FAQ remains usable, just unmetered/uncached.
+
+## Out of scope (filed elsewhere)
+
+- **Real spend containment** (server-side proxy, session cookie, per-IP
+  quota): KAN-LATER-2 in the design memo. This is the only correct
+  long-term fix. **Stop-condition note:** the lane prompt asks whether
+  the only correct mitigation requires backend/auth work outside this
+  repo. Yes — the *complete* fix does. This lane ships the *partial,
+  honest, in-scope* client mitigation explicitly to avoid blocking the
+  product surface on a multi-repo lane.
+- **UX visibility surfaces** (budget meter, grounding badge, cache-age
+  pill, unified error voice): owned by Lane Claude Design (`reporium-ask-faq-design-memo.md`)
+  Phase 1.
+
+## Acceptance criteria
+
+- [x] On `/faq`, opening a card with `localStorage['reporium_ask_timestamps']`
+      already at 10 entries within the past minute results in **zero**
+      network calls to `/intelligence/ask` and a visible friendly message.
+- [x] Opening a card the *first* time fires one fetch and writes one entry
+      to `reporium_faq_answer_cache`.
+- [x] Closing and reopening that card does not refetch (handled by existing
+      `state.status === 'ready'` guard inside the same component instance).
+- [x] Reloading `/faq` and opening the same card serves the answer from
+      cache with **zero** new fetches and **zero** new wallet entries.
+- [x] Same TTL behavior as the AskBar wallet — entries older than 24h are
+      pruned on the next write.
+- [x] No new dependencies; no API change; no edits outside `FAQPanel.tsx`.
+
+## Verification (carried over from 2026-04-24, re-checked today)
+
+Manual verification against `next dev` against /faq, with `window.fetch`
+hooked to count `/intelligence/ask` calls (recorded 2026-04-24, contract
+unchanged today):
+
+| Scenario                                    | Fetches | Notes |
+| ------------------------------------------- | ------- | ----- |
+| Cap at 10/min, then open card               | 0       | budget-gate message renders |
+| Reset, open card                            | 1       | cache + wallet write |
+| Reload `/faq`, open same card               | 0       | cache hit on cold mount |
+
+2026-04-25 static checks on lane HEAD:
+
+| Check                                            | Result |
+| ------------------------------------------------ | ------ |
+| `npx tsc --noEmit`                               | exit 0 |
+| `npx eslint src/components/FAQPanel.tsx`         | clean  |
+| AskBar wallet constants match (`RATE_KEY`, 10, 100) | yes |
+| PR #272 still `MERGEABLE` / `CLEAN`              | yes    |
+
+## Risk
+
+Low. Single file, ~80 LOC additive. Falls back to current behavior if
+localStorage is unavailable. Cannot regress the rest of the Ask surface
+because it only reads the wallet (does not change AskBar's writer).
+
+## Notes
+
+- Does *not* defend against an attacker who reads the bundled token. That
+  is the architecture lane (KAN-LATER-2 / future Ask architecture).
+- The design lane's `reporium-ask-faq-design-memo.md` Phase 1 surfaces
+  (budget meter, grounding badge) build on the wallet this ticket starts
+  paying into. Don't rip the wallet out when those ship — extend it.
+- Today's lane did not re-run the live `next dev` verification — the
+  contract surfaces it depends on (AskBar wallet keys + constants, PR
+  diff) are byte-identical to 2026-04-24. If the maintainer wants a
+  fresh manual pass before merge, the steps are in the table above.

--- a/.audit/2026-04-25/frontend-merge-gate-jira.md
+++ b/.audit/2026-04-25/frontend-merge-gate-jira.md
@@ -1,0 +1,67 @@
+# Frontend Merge Gate — FAQ Lane (KAN-272)
+
+**Date:** 2026-04-25
+**Lane:** Frontend merge gate for `/faq` + spend-surface mitigation
+**Workspace:** `C:\DEV\PERDITIO_PLATFORM\reporium`
+**Owned scope:** `src/app/faq/page.tsx`, `src/components/FAQPanel.tsx`, `src/components/StickyNavBar.tsx`, `.audit/2026-04-25/`
+
+---
+
+## Live state (re-verified via `gh` + `git fetch` at 2026-04-25 ~03:15 PDT)
+
+| Field | PR #273 (real lane) | PR #272 (superseded) |
+|---|---|---|
+| Title | feat(faq): /faq + client spend-surface mitigation (KAN-272, supersedes #272) | feat(faq): add /faq page rendering every curated Ask suggestion |
+| Branch | `claude/feature/KAN-272-faq-spend-surface` | `claude/feature/faq-page` |
+| HEAD | `6d595a1` | `63c33e4` |
+| Base | `main` | `main` |
+| State | OPEN, MERGEABLE, **CLEAN** | OPEN, MERGEABLE, CLEAN |
+| Checks | lint-and-build ✅ (6m14s, run 24928235148), security ✅ (25s), Vercel ✅ SUCCESS (10:08:16Z), Vercel Preview Comments ✅ | lint-and-build ✅, security ✅, Vercel ✅, Vercel Preview Comments ✅ |
+| Commits ahead of main | 5 | 1 |
+| Files changed | 8 (3 src + 5 audit notes) | 3 (all src, in owned scope) |
+| Local branch == remote HEAD | yes (6d595a1 == 6d595a1) | n/a (gate lane only) |
+
+`origin/main` is at `53e36ae`. Merge base of #273 is `8224e3a`. No conflicts. Vercel preview flipped UNSTABLE → CLEAN since the earlier dispatch revalidation; no code changes between then and now.
+
+## Spend-surface mitigation — present and local to owned scope
+
+Verified in `src/components/FAQPanel.tsx`:
+
+- **Lazy fetch** (`FAQCard.load`, line 241) — `/intelligence/ask` fires only on user `onToggle` open, not on mount. 16 cards → 0 fetches at first paint.
+- **Shared client budget** with AskBar (lines 14–16) — `RATE_KEY = 'reporium_ask_timestamps'`, `RATE_PER_MIN=10`, `RATE_PER_DAY=100`. FAQ expansions and `/ask` submissions draw from one wallet.
+- **Per-question 1h cache** (lines 19–20, 57–85) — repeat opens on the same question in a session do not re-hit the API; TTL pruned on write.
+- **Budget-exhausted UI states** (lines 250–264) — minute/day caps short-circuit before any fetch, with explicit copy and a Retry button.
+- **Honest scope comment** (lines 11–13) — explicitly notes server-side proxy is required to stop a determined attacker (Phase 3 follow-up). This is the only remaining gap and it is backend architecture, not a frontend blocker.
+
+`StickyNavBar.tsx` change is the FAQ entry in `NAV_LINKS` (line 71) and the inline `faq` icon (lines 53–59). Pure additive nav surface.
+
+`src/app/faq/page.tsx` is the WikiNavBar shell + `<FAQPanel />`. No data-fetching at the page boundary.
+
+## Check status — fully green
+
+PR #273 is now `mergeStateStatus = CLEAN`. All gates green:
+
+- `lint-and-build` PASS (6m14s) on run 24928235148
+- `security` PASS (25s) on the same run
+- `Vercel` SUCCESS (preview deploy completed 10:08:16Z)
+- `Vercel Preview Comments` PASS
+
+No transient state remaining. No human wait required.
+
+## Decision
+
+### PR #273 — **MERGE NOW**
+
+Mitigation is real, local to the owned scope, and matches the design memo committed to this branch. The remaining concern (server-side proxy / signed-token gateway to defeat localStorage clearing) is explicitly out-of-scope per the gate's stop conditions — it is backend architecture and does not invalidate the present client-side mitigation. All checks green; ready for merge button. Do not deploy from this lane (process rule 9).
+
+### PR #272 — **SUPERSEDED**
+
+Close as superseded by #273 with no merge. #272 carries the `/faq` page without the spend-surface mitigation; #273 contains the same `/faq` page **plus** the lazy-fetch + shared-budget + cache work. Merging #272 would ship the unmitigated surface that #273 was created to fix. Recommended close comment: *"Superseded by #273 which adds the KAN-272 client spend-surface mitigation on top of this branch's `/faq` page. Closing without merge — all changes here are subsumed by #273."*
+
+## No tiny patch required
+
+Reviewed every line of the three owned files. No nits worth blocking on; comments are accurate; no dead code; no `console.log`; sanitizer (`rehype-sanitize`) is wired on the markdown render; `noopener noreferrer` is present on every external link.
+
+## Stop condition acknowledgement
+
+Per gate rules 9 and 10: not merging, not deploying, not broadening into Ask UX work. Server-side proxy / signed-token rate-limiting noted as Phase 3 follow-up in the existing design memo (`.audit/2026-04-25/reporium-ask-faq-design-memo.md`) and tracked under KAN-272 — not blocking #273.

--- a/.audit/2026-04-25/reporium-ask-faq-design-jira.md
+++ b/.audit/2026-04-25/reporium-ask-faq-design-jira.md
@@ -1,0 +1,129 @@
+# JIRA draft — Reporium Ask / FAQ design lane (sibling of KAN-272)
+
+> **Status:** draft. JIRA CLI is not available in this environment; create
+> in perditio.atlassian.net by hand (or via `gh`-paired automation when the
+> Atlassian MCP is connected).
+> **Companion docs:**
+> [`reporium-ask-faq-design-memo.md`](reporium-ask-faq-design-memo.md) (the substantive memo) and
+> [`faq-spend-surface-jira.md`](faq-spend-surface-jira.md) (KAN-272 mitigation re-validation).
+
+## Summary
+
+`design(ask): trust + pacing UX for the Reporium Ask / FAQ surface` — a
+phased design plan that improves answer trust cues, makes the client wallet
+visible, and adds friction *only where wallet pressure is high*, without
+pretending to fix the public-token spend surface that only a server-side
+proxy can close.
+
+## Type
+Spike → Improvement (the spike is this memo; the implementation is a
+follow-on ticket per phase).
+
+## Component
+`reporium` (frontend). Phase 3 also touches `reporium-api`, but that is
+filed separately under KAN-LATER-2 / Ask architecture.
+
+## Background
+
+Sibling lane to KAN-272 (FAQ spend-surface mitigation). KAN-272 added a
+shared client wallet + 1h answer cache to `/faq` so PR #272 can ship without
+widening the burn surface. That is the right *partial* fix and is already
+on the lane branch (commits `7ab8e64`, `285747d`).
+
+What KAN-272 explicitly didn't do — and what this ticket scopes — is the
+UX work that surrounds the wallet:
+
+1. The wallet is invisible until a user hits the cap. They should see it
+   counting down.
+2. Cache hits are silent, so a 58-minute-old answer looks identical to a
+   fresh one. That undermines the whole "trust foundation" story.
+3. The four Ask call sites (AskBar, StickyAskBar, AskPanel, FAQPanel)
+   don't share a visual language — the floating dock has more grounding
+   cues than the page named "Ask."
+4. Open-all-cards is still the worst-case path on `/faq`. The wallet
+   bounds *total* burn but doesn't bound *concurrent* burn.
+
+The substantive design and rationale live in
+[`reporium-ask-faq-design-memo.md`](reporium-ask-faq-design-memo.md). This
+ticket exists so that memo gets reviewed, sized, and converted into
+implementation tickets.
+
+## Scope (this ticket)
+
+**Spike deliverable: review and triage the design memo, file the
+implementation tickets.** No production code change is owned by this
+ticket; the memo itself is the deliverable.
+
+The memo proposes three phases:
+
+- **Phase 1 (Now)**: ~8 additive UI items (wallet meter, answer receipt,
+  cache-age pill, source attestation, conversation indicator on `/ask`,
+  empty-state coaching, 70%-wallet confirm). All renderable from data the
+  server already returns. Each will get its own KAN ticket on approval.
+- **Phase 2 (Next)**: concurrent-open throttle, shared answer cache for
+  AskBar/AskPanel, replace `<details>` with `<button>`, lift the streaming
+  + phase-state machine from StickyAskBar into AskPanel. Cross-component,
+  still frontend-owned. One or two tickets.
+- **Phase 3 (Later)**: server-side proxy holding the App API token,
+  per-IP / per-session quota, deletion of `NEXT_PUBLIC_APP_API_TOKEN`,
+  migration of all four Ask call sites to same-origin fetch. Joint
+  reporium-api + reporium frontend lane. **This is the only correct fix
+  for the spend surface.** Track under KAN-LATER-2.
+
+## Out of scope
+
+- **Phase 3 itself.** This ticket scopes the design memo and the Phase 1
+  + Phase 2 implementation tickets. Phase 3 is its own joint lane.
+- **Server cost cap.** A daily dollar cap on `/intelligence/ask` is a
+  backend observability concern. Filed separately.
+- **Anti-abuse ML / bot detection.** Out of scope for the design lane and
+  not on the proposed roadmap.
+
+## Acceptance criteria
+
+- [x] Memo lands in `.audit/2026-04-25/reporium-ask-faq-design-memo.md`
+      with five sections required by the lane prompt: UX principles,
+      groundedness/trust cues, spend-mitigation ideas, Now/Next/Later
+      plan, and validation against current code.
+- [x] Memo names the public-token problem honestly as backend/auth work
+      (lane rule 11) and does not pretend a UI tweak solves it.
+- [x] Every Phase-1 recommendation cites the file and line range it
+      depends on, against the actual code on lane HEAD.
+- [x] Each phase carries a rough LOC and risk estimate so a reviewer can
+      size implementation tickets without re-reading the code.
+- [ ] Reviewer approves the memo (or sends comments back). On approval,
+      author files individual KAN tickets per Phase-1 item.
+- [ ] Phase-1 implementation lands on a *separate* branch
+      (`claude/feature/KAN-XXX-ask-trust-ui`), not on this lane's branch.
+
+## Verification (lane stop-conditions)
+
+| Check | Result |
+| --- | --- |
+| `origin/main` HEAD fetched and noted (`53e36ae`) | yes |
+| Existing 04-25 design notes inspected before authoring | yes |
+| Owned file set respected (`.audit/2026-04-25/*` only) | yes |
+| Branch is `claude/feature/KAN-272-faq-spend-surface` off `main` | yes |
+| No production code changed by this lane | yes |
+| Token-in-bundle named as Phase 3 / backend lane | yes |
+
+## Risk
+
+Spike-level — none. The ticket produces documentation. Risk lives in the
+implementation tickets that follow.
+
+## Notes
+
+- The lane branch already carries the KAN-272 mitigation. **Do not** roll
+  this design lane into KAN-272's PR — it muddies the merge review for a
+  spend-surface fix that is small, scoped, and ready.
+- Phase 1 implementation will need the wallet helper extracted out of
+  AskBar/StickyAskBar/FAQPanel into `src/lib/askWallet.ts`. That refactor
+  is byte-identical behavior; it is the natural first PR if the maintainer
+  wants something landed before the full Phase 1 batch.
+- The Figma marketing site at
+  `C:\DEV\PERDITIO_PLATFORM\figma-make-perditio-website-claude` was
+  inspected as read-only design reference (per lane prompt) — it does
+  not contain a literal Ask/FAQ component. Visual direction in the memo
+  is consistent with the existing in-tree Reporium UI (Tailwind on
+  zinc-900 surfaces), not the marketing site's palette.

--- a/.audit/2026-04-25/reporium-ask-faq-design-memo.md
+++ b/.audit/2026-04-25/reporium-ask-faq-design-memo.md
@@ -1,0 +1,214 @@
+# Reporium Ask / FAQ — Design Memo (KAN-272 sibling lane)
+
+**Date:** 2026-04-25
+**Lane:** Claude Design — safer Reporium Ask / FAQ UX
+**Branch:** `claude/feature/KAN-272-faq-spend-surface` (existing, off `main`)
+**Status:** design-only (no production code change in this lane)
+**Companion docs:**
+- [`pr-272-faq-decision.md`](../2026-04-24/pr-272-faq-decision.md) — merge-with-mitigation rationale
+- [`faq-spend-surface-jira.md`](faq-spend-surface-jira.md) — KAN-272 mitigation re-validation
+- [`reporium-ask-faq-design-jira.md`](reporium-ask-faq-design-jira.md) — this lane's JIRA draft
+
+## TL;DR
+
+PR [#272](https://github.com/perditioinc/reporium/pull/272) is product-useful and should ship with the in-tree mitigation already on this branch (`7ab8e64`, `285747d`). The remaining gap is **UX, not architecture**: the Ask surface today does not *show* the user what it knows, what it cost, or what budget they have left, and that gap is what makes the spend-surface complaint feel sharper than it actually is.
+
+This memo proposes a small set of trust-and-pacing surfaces that ride on top of the wallet KAN-272 already pays into, plus an honest carve-out for the only thing a UI tweak cannot fix: the public token in the bundle. That part is a backend lane (Phase 3 below); calling it a UI problem would be dishonest.
+
+> **Stop-condition check (per lane prompt rule 11):** the *complete* fix to the spend surface — closing the public-token attack — is server-side, not UI. This memo makes that explicit and only proposes UI work that compounds correctly with the future server proxy. No UI change is offered as a substitute for it.
+
+## 1. Current state — verified against `main` and this branch
+
+Files inspected today (`origin/main` HEAD `53e36ae`, lane HEAD `285747d`):
+
+| File | Role | Wallet? | Cache? | Trust cues today |
+| --- | --- | --- | --- | --- |
+| `src/components/AskBar.tsx` | Embedded ask widget (e.g. /repos) | yes (writes) | no | "x remaining this minute" warning at <2; injection regex; sources cards w/ % match; 500-char cap |
+| `src/components/StickyAskBar.tsx` | Floating dock-style ask | yes (writes) | no (server cache via `cache_hit`) | phase state machine (`warming` cold-start hint); thumbs feedback (`query_id`); model/latency/tokens footer; cache/route badges; injection regex |
+| `src/components/AskPanel.tsx` (`/ask`) | Full-page ask | no (delegates to provider) | no | basic source cards, no model/latency footer, no thumbs, no streaming |
+| `src/components/FAQPanel.tsx` (`/faq`) | 16-card curated FAQ | yes (reads + writes, KAN-272) | yes (1h, KAN-272) | friendly gated message on cap; markdown w/ rehype-sanitize; source pill list; "Open in Ask" deep link |
+
+Findings:
+- **Three Ask surfaces, three different visual languages.** AskBar is compact and warns near the cap; StickyAskBar is the most informative (phase, footer, thumbs, route badge); `/ask` (AskPanel) is the least — no phase machine, no model footer, no thumbs. The user sees more trust cues from a sidebar widget than from the page named "Ask."
+- **Wallet is invisible.** Three of four call sites write to `reporium_ask_timestamps`, but the only surface that ever *names* it is FAQPanel's gated error and AskBar's "x remaining" sub-2-warning. There is no positive "you have 9 questions left this minute" affordance — the user discovers the budget by hitting it.
+- **Cache is invisible.** FAQPanel serves the 1h cache silently (good for spend, bad for trust): a user reloading `/faq` and getting an instant card has no idea whether the answer is fresh or 58 minutes stale. StickyAskBar surfaces server-side `cache_hit` as a `⚡ cached` badge; FAQPanel does not surface its own client cache the same way.
+- **Grounding is implied, not asserted.** Source cards render under the answer, but the answer text itself does not say "answered from N sources, smart-route X" up-top. For a "trust foundation" product, the trust cue should lead, not trail.
+- **Token-in-bundle is real but out of UI scope.** `NEXT_PUBLIC_APP_API_TOKEN` is exposed in every Ask surface bundle. No UI affordance can fix this; only the server proxy in Phase 3 can.
+
+## 2. UX principles for the Ask / FAQ surface
+
+These are the rules I want every Phase-1 and Phase-2 change to satisfy. They're sized so a reviewer can apply them in one pass.
+
+1. **Show the receipt.** Every answer surface should make grounding, model, latency, and cost visible *by default*, not behind a "details" expand. StickyAskBar's `ResponseFooter` is the right shape — promote it everywhere.
+2. **Wallet is a positive number, not an error.** "9 / 10 questions left this minute · 87 / 100 today" should sit quietly under the input at all times. The user should never be surprised by the cap; they should *see* it crossing 0.
+3. **Cache is named, not silent.** A served-from-cache answer should say so, with the age. Cached freshness is a feature; hiding it is not.
+4. **Friction is the cheapest spend defense.** Every multi-card surface (today: only `/faq`, but tomorrow: any Ask "explore" page) should require an *explicit* expand per card. No "expand all," no `?open=*` URL, no scripts that script `details.open = true` getting a free pass.
+5. **One voice on errors.** The four call sites currently produce four worded variants of "rate limit." Pick one. (Suggestion: the FAQPanel phrasing.)
+6. **Be honest about the bundled token.** The product surface doesn't have to mention it, but the docs and the design memo do. UI should not pretend to fix it.
+7. **Conversation is opt-in, visible, and reset-able.** AskBar's "Continuing conversation (3 turns)" / "New conversation" pattern is the right model — extend it to `/ask`. A user who can't see they're in a conversation can't trust the answer is about *their* question.
+
+## 3. Groundedness / trust cues (Phase 1 — additive, in-scope)
+
+For each cue, I'll name the surface(s), the data already available, and the LOC-shape so the reviewer can sanity-check effort.
+
+### 3.1 Grounding ribbon (above answer, all surfaces)
+A one-line ribbon that names *how* the answer was produced — not just what it is.
+
+```
+✓ Grounded · 8 repos searched · smart-route: leaderboard · Haiku 4.5 · 1.4s · 412 tokens
+```
+
+Components:
+- **`✓ Grounded`** badge — green when `sources.length > 0`, amber when `sources.length === 0` ("ungrounded — model used general knowledge"). FAQ cards that hit the curated smart-route always have sources, so they're always green; `/ask` queries that fall through to the LLM-only path get amber and a hover tooltip explaining what that means.
+- **Source count + smart-route** — already on `done.route` for StickyAskBar. AskPanel doesn't read it; should.
+- **Model · latency · tokens** — already in `ResponseFooter`. Lift to a shared `<AnswerReceipt />` and use everywhere.
+
+### 3.2 Wallet meter (under input, all surfaces with input)
+Replace the current "x remaining" warning that only fires near the cap with a permanent, calm meter:
+
+```
+○○○○○○○○● ●  9 / 10 questions left this minute    87 / 100 today
+```
+
+- Two filled dots = used (1 minute) and 13 used (day).
+- Filled becomes amber when `>=8/10` minute or `>=80/100` day; red at cap.
+- Tooltip explains: "Per-tab, resets every minute / 24h. Shared with FAQ."
+- LOC: ~40-line component, single `useEffect` polling the wallet every 1s. (The wallet is already in localStorage; readBudget() exists in FAQPanel and `getRateLimitState()` exists in AskBar/StickyAskBar — extract once.)
+
+### 3.3 Cache-age pill (FAQPanel + future cached surfaces)
+Where the answer was served from local cache, render a small pill *inside* the answer block:
+
+```
+⚡ cached · 12 min ago · refresh
+```
+
+- "refresh" is a button that *bypasses* the cache for that one card (still consumes wallet — bypassing is a deliberate cost). This is the user's escape hatch when an answer feels stale.
+- Reuses StickyAskBar's `⚡` cached badge styling for visual consistency.
+- LOC: ~25 lines in FAQPanel; mirror the API in AskBar when cache lands there in Phase 2.
+
+### 3.4 Source-attestation row (under answer)
+Today, sources render as bare pills. Add micro-attestations directly on each:
+
+```
+[★ 71k  langchain-ai/langchain   used: license, stars]
+```
+
+- Tags the *fields the answer cited* from each source. (Server already returns `integration_tags` per source; smart-router already knows which fields it pulled. Surface that.)
+- Why: a user reading "LangChain has 71k stars" needs to *see* that the system is reading the same row they would read on GitHub. This is the cheapest "no-hallucination" affordance available.
+- LOC: ~20 lines in the source pill renderer (FAQPanel + AskBar + StickyAskBar already share a similar structure; consolidate).
+
+### 3.5 Sticky-bar conversation indicator on `/ask`
+The full Ask page (`AskPanel.tsx`) is the only surface without conversation continuity UI. AskBar has it (`turnCount`, `New conversation` button). Lift the same component to AskPanel. LOC: ~10 lines plus a hook.
+
+### 3.6 Empty-state coaching
+First-load on `/ask` with no `?q=` is currently a blank input. Replace with three example prompts (cribbed from `/faq` Library Stats section — they're guaranteed grounded). One click prefills the input — does not auto-submit (per principle 4: friction is the spend defense).
+
+## 4. Ways to reduce spammy / accidental spend (Phase 1 — UI-only)
+
+Each item below is bounded to UI, in-scope for this lane, and forward-compatible with the Phase 3 server proxy.
+
+### 4.1 Per-card click confirmation when wallet >= 70%
+When a `/faq` card is opened with `minute >= 7` or `day >= 70`, the *first* click expands the card but does not fetch — instead, render:
+
+```
+You've used 7 of 10 minute requests. Open this answer? [Yes, fetch]  [Just close]
+```
+
+This is friction *only when needed*. Below 70%, opens fetch immediately as today.
+
+### 4.2 Refuse all-cards expansion
+Today, `details` elements are stateless to the page — a user can scroll-and-tap-everything. Add a `useFAQOpenCounter()` hook that throttles concurrent opens to **3 active fetches per 10 seconds** at the page level. Beyond that, additional opens render the gated message immediately and don't decrement the wallet. The wallet still bounds total cost; this bounds a synchronized burst.
+
+### 4.3 Defeat-the-script prompts
+Replace `<details>` `onToggle` with a `<button>`-driven open. `<details open>` set via dev-tools or URL hash today fetches; an explicit click handler doesn't. Roughly the same DOM, different control surface, immune to programmatic open. (Only worth doing if 4.1/4.2 land — they cover the same ground for honest users.)
+
+### 4.4 Cap concurrent in-flights per surface
+Across all four Ask surfaces, hold a shared `AbortController` registry keyed by surface. New ask cancels the previous in-flight *on the same surface*. Already true for StickyAskBar (`abortRef`); extend to AskBar and FAQPanel. Stops the user from triple-clicking Submit and burning three answers they'll never read.
+
+### 4.5 Cache extension to AskBar / AskPanel
+FAQPanel's 1h cache is keyed on the literal question. Lift the same helper to a shared `lib/askAnswerCache.ts` and apply on AskBar / AskPanel — but with a tighter TTL (15 min) since user-written queries drift in intent and a stale answer is more confusing than a fresh fetch. Cache hit always renders `cache-age pill` from §3.3.
+
+### 4.6 Diff cache and wallet — never both write on a hit
+Audit acceptance criterion: a wallet write should happen *only* when a real `fetch()` occurred. KAN-272 already gets this right on FAQPanel; lift the same shape into the shared cache helper so AskBar/AskPanel inherit it.
+
+## 5. What this lane explicitly does NOT solve
+
+Said plainly so a future reviewer doesn't mistake the design memo for a security memo:
+
+1. **Public app token in the JS bundle.** `NEXT_PUBLIC_APP_API_TOKEN` is readable by anyone who opens DevTools. No UI affordance closes this. The proxy in §6 Phase 3 is the only fix.
+2. **Server-side rate limiting.** The server enforces 429 and the client has a friendly message for it, but the *primary* defense should be server-side per-IP / per-session quota. Phase 3.
+3. **Cost cap.** A daily *dollar* cap on `/intelligence/ask` (separate from per-user rate) is a backend concern. Out of scope here; track in a separate observability ticket.
+4. **Anti-abuse ML.** Detecting "this is a scraping bot vs. a curious user" is its own lane. Not even on this roadmap.
+
+## 6. Phased plan — Now / Next / Later
+
+### Phase 1 — Now (this lane, UI-only, no backend dependency)
+*Goal: improve trust + UX without widening surface area. All compounds correctly with Phase 3.*
+
+| Item | File(s) | Rough LOC | Owner | Risk |
+| --- | --- | --- | --- | --- |
+| Extract shared wallet helper (`lib/askWallet.ts`) | new file + 3 call sites | ~80 | design lane | Low — pure refactor, byte-identical behavior |
+| `<AnswerReceipt />` component | new file + 4 call sites | ~120 | design lane | Low — additive |
+| `<WalletMeter />` component | new file + 3 call sites | ~80 | design lane | Low — additive |
+| Cache-age pill in FAQPanel | FAQPanel.tsx | ~25 | design lane | Low |
+| Source attestation row | shared SourceList | ~40 | design lane | Low |
+| Conversation indicator on AskPanel | AskPanel.tsx | ~30 | design lane | Low |
+| Empty-state example prompts on `/ask` | AskPanel.tsx | ~25 | design lane | Low |
+| 70%-wallet confirm-before-fetch on `/faq` | FAQPanel.tsx | ~30 | design lane | Low |
+
+**This lane today does not implement Phase 1.** It produces this memo. Implementation gets its own follow-up branch (`claude/feature/KAN-XXX-ask-trust-ui`) once a JIRA is filed against this memo. See §7 for why.
+
+### Phase 2 — Next (1–2 weeks; cross-component but still frontend-owned)
+*Goal: tighten anti-burst behavior and unify the Ask surfaces around one component family.*
+
+- Concurrent-open throttle for `/faq` (4.2). Two-line hook in FAQPanel.
+- Shared `lib/askAnswerCache.ts` with 15-min TTL applied to AskBar/AskPanel (4.5).
+- Replace `<details>` with `<button>` toggles for FAQ (4.3) — only worth doing if §4.2 lands.
+- Migrate `AskPanel.tsx` to use the StickyAskBar streaming + phase-state machine. Today `/ask` is the *worst* of the three surfaces; aligning it lifts the floor.
+- Unified error voice: pick FAQPanel's phrasing as canonical and propagate.
+
+### Phase 3 — Later (joint reporium-api + reporium frontend; right thing)
+*Goal: actually close the spend surface. The only correct fix.*
+
+1. Add same-origin `/api/ask` route in `reporium` that proxies `/intelligence/ask` server-side, holding the App API token as a Vercel env-only secret (never `NEXT_PUBLIC_*`).
+2. Move per-IP / per-session quota enforcement to that proxy (or to `reporium-api` directly with a session cookie set by the proxy).
+3. Delete `NEXT_PUBLIC_APP_API_TOKEN` from the build. Migrate all four Ask call sites to same-origin fetch.
+4. Decommission the `reporium_ask_timestamps` localStorage wallet at the *same* PR — it becomes legacy. Don't pull it earlier or honest users lose pacing.
+5. Drop the `<WalletMeter />` UI in favor of a server-fed "questions remaining today" header, reusing the same component contract.
+
+This is real work — separate JIRA, joint lane, multi-PR. The trigger for starting it is "we see actual abuse traffic" or "we want to public-launch `/faq`". Not before. KAN-272 mitigation buys time; it does not eliminate the need.
+
+## 7. Why this lane delivers a memo, not a patch
+
+Per lane rule 3: implement only if "one small, high-confidence frontend mitigation fits cleanly." On inspection:
+
+- **The smallest cohesive Phase-1 win is `<WalletMeter />`** — but it depends on extracting `lib/askWallet.ts` first to avoid duplicating the helper for the *fourth* time. That extraction touches AskBar, StickyAskBar, FAQPanel, and a new `lib` file — four files, ~150 LOC delta. That is past the "one small, high-confidence" bar in this prompt.
+- **The KAN-272 mitigation is already in this branch** (commits `7ab8e64`, `285747d`). The next thing to add is not a patch but a JIRA so the design memo gets reviewed, sized, and assigned. Shipping a half-Phase-1 here would muddy that review.
+- **Rule 9: one lane, one branch, one PR, one owned file set.** The owned file set today is `.audit/2026-04-25/*`. Anything more is a separate lane.
+
+If the maintainer wants the smallest concrete patch, the right cut is "extract `lib/askWallet.ts`" only — pure refactor, no behavior change. I can ship that as a follow-up if asked, but it should be its own branch and PR ([`claude/refactor/ask-wallet-helper`](https://github.com/perditioinc/reporium/compare/main...claude/refactor/ask-wallet-helper) — does not exist yet).
+
+## 8. Validation — recommendations were checked against current code
+
+Each Phase-1 recommendation was verified against the actual files on this lane HEAD (`285747d`):
+
+| Recommendation | Where it lands | Code dependency |
+| --- | --- | --- |
+| Wallet meter | new component + AskBar L159-163, StickyAskBar L224-236, FAQPanel L28-41 | All three already compute `{minute, day}`; meter is a render-only consumer |
+| Answer receipt | promote StickyAskBar L355-403 `ResponseFooter` to shared | Server sends `model`, `latency_ms`, `tokens`, `route`, `cache_hit` on `done` event; AskPanel currently *ignores* these |
+| Cache-age pill | FAQPanel L57-85 (cache helpers) + state shape | `CachedAnswer.at` already stored; just needs render |
+| Source attestation | FAQPanel L327-353, AskBar L370-411, StickyAskBar source list | `integration_tags` already returned per source; not displayed |
+| Conversation indicator on `/ask` | AskPanel L91-103, lift AskBar L296-308 component | AskPanel reads `session_id` from localStorage but doesn't track `turnCount` |
+| 70%-wallet confirm | FAQPanel L241-276 `load()` | Trivial check before `setState({status:'loading'})` |
+
+All five trust cues are *renderable from data the server already returns* — no API change required for Phase 1. Phase 2 cache extension also no-API-change. Phase 3 is the only API-change phase.
+
+## 9. Stop-conditions check (per lane rules)
+
+- ✅ Rule 1: fetched `origin/main` (HEAD `53e36ae`).
+- ✅ Rule 2: existing FAQ/Ask design notes inspected — none in `.audit/2026-04-25/` before today other than the spend-surface JIRA, which references *this* memo as the design-lane deliverable.
+- ✅ Rule 3: JIRA-first acknowledged; companion JIRA draft authored as `reporium-ask-faq-design-jira.md` (rule 4 fallback).
+- ✅ Rule 5/6: branch `claude/feature/KAN-272-faq-spend-surface` is off `main`; no new branch created.
+- ✅ Rule 7/8/9: PR target would be `main`; one lane, one branch, one owned file set (this memo + its JIRA).
+- ✅ Rule 10: no merge, no deploy.
+- ✅ Rule 11: token-in-bundle is named as backend/auth architecture work in §5 and §6 Phase 3 — not pretended away as a UI tweak.

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+import { WikiNavBar } from '@/components/WikiNavBar';
+import { FAQPanel } from '@/components/FAQPanel';
+
+export const metadata: Metadata = {
+  title: 'Reporium FAQ — Suggested questions, grounded answers',
+  description:
+    'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base. Grounded in indexed repos, no hallucinations.',
+  openGraph: {
+    title: 'Reporium FAQ — Suggested questions, grounded answers',
+    description:
+      'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base.',
+    url: 'https://www.reporium.com/faq',
+  },
+  twitter: {
+    title: 'Reporium FAQ — Suggested questions, grounded answers',
+    description:
+      'Every suggested question the Ask bar offers, answered live by the Reporium knowledge base.',
+  },
+};
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <WikiNavBar title="FAQ" />
+
+      <main className="mx-auto max-w-4xl px-6 py-10 space-y-8">
+        <header>
+          <h1 className="text-2xl font-bold text-zinc-100 sm:text-3xl">FAQ</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            Every question the Ask bar suggests, answered live against the Reporium
+            knowledge base. Open a card to see the grounded answer and its source repos.
+          </p>
+        </header>
+
+        <FAQPanel />
+      </main>
+    </div>
+  );
+}

--- a/src/components/FAQPanel.tsx
+++ b/src/components/FAQPanel.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import { API_URL } from '@/lib/apiUrl';
+
+const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
+
+// Grouped so the page reads as a tour of Reporium's capabilities. Every entry
+// is pinned to a deterministic smart-route match in reporium-api so the answer
+// is always grounded — no generic "not enough information" early-exit. Keep in
+// sync with `_CURATED_SUGGESTIONS` in `reporium-api/app/routers/intelligence.py`.
+interface FAQSection {
+  title: string;
+  blurb: string;
+  questions: string[];
+}
+
+const FAQ_SECTIONS: readonly FAQSection[] = [
+  {
+    title: 'Library stats',
+    blurb: 'Instant SQL counts over the indexed library. Zero token cost.',
+    questions: [
+      'How many repos are tracked?',
+      'What categories are available?',
+      'How many Python repos are there?',
+    ],
+  },
+  {
+    title: 'Leaderboards',
+    blurb: 'Ranked repos by stars, forks, activity, or recency.',
+    questions: [
+      'What are the most forked repos?',
+      'What are the most starred repos?',
+      'What are the most active repos?',
+      'What are the newest repos?',
+    ],
+  },
+  {
+    title: 'Topic-narrowed picks',
+    blurb: 'Leaderboards filtered to a specific AI-dev category.',
+    questions: [
+      'Show me RAG tools with the most stars',
+      'Show me agent tools with the most stars',
+      'Show me inference tools with the most stars',
+      'Show me evaluation tools with the most stars',
+    ],
+  },
+  {
+    title: 'Tag search',
+    blurb: 'Find every repo tagged with a given capability.',
+    questions: [
+      'Which repos support MCP?',
+      'Which repos use pgvector?',
+    ],
+  },
+  {
+    title: 'Comparisons',
+    blurb: 'Side-by-side metadata for two repos — license, category, stars, activity.',
+    questions: [
+      'Compare LangChain and LlamaIndex',
+      "What's the difference between vLLM and TGI?",
+      'Compare CrewAI and AutoGen',
+    ],
+  },
+];
+
+interface SourceRepo {
+  name: string;
+  owner: string;
+  forked_from: string | null;
+  description: string | null;
+  stars: number | null;
+  relevance_score: number;
+  problem_solved: string | null;
+  integration_tags: string[];
+}
+
+interface AnswerState {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  answer?: string;
+  sources?: SourceRepo[];
+  error?: string;
+}
+
+const MARKDOWN_COMPONENTS = {
+  a: (props: React.ComponentProps<'a'>) => (
+    <a
+      {...props}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-zinc-200 underline underline-offset-2 hover:text-white"
+    />
+  ),
+  code: (props: React.ComponentProps<'code'>) => (
+    <code {...props} className="rounded bg-zinc-800 px-1 py-0.5 text-xs" />
+  ),
+  pre: (props: React.ComponentProps<'pre'>) => (
+    <pre {...props} className="rounded-lg bg-zinc-900 p-3 overflow-x-auto my-2 text-xs" />
+  ),
+  ul: (props: React.ComponentProps<'ul'>) => (
+    <ul {...props} className="list-disc pl-5 space-y-1 my-2" />
+  ),
+  ol: (props: React.ComponentProps<'ol'>) => (
+    <ol {...props} className="list-decimal pl-5 space-y-1 my-2" />
+  ),
+  p: (props: React.ComponentProps<'p'>) => (
+    <p {...props} className="my-2 first:mt-0 last:mb-0" />
+  ),
+};
+
+function formatRepoLink(src: SourceRepo) {
+  if (src.forked_from) {
+    return { label: src.forked_from, href: `https://github.com/${src.forked_from}` };
+  }
+  const slug = `${src.owner}/${src.name}`;
+  return { label: slug, href: `https://github.com/${slug}` };
+}
+
+async function fetchAnswer(question: string, signal: AbortSignal): Promise<AnswerState> {
+  if (!APP_TOKEN) {
+    return {
+      status: 'error',
+      error: 'Ask is not configured in this environment (missing NEXT_PUBLIC_APP_API_TOKEN).',
+    };
+  }
+  try {
+    const res = await fetch(`${API_URL}/intelligence/ask`, {
+      method: 'POST',
+      signal,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-App-Token': APP_TOKEN,
+      },
+      body: JSON.stringify({ question, top_k: 8 }),
+    });
+    if (res.status === 429) {
+      return { status: 'error', error: 'Rate limit exceeded. Try refreshing in a minute.' };
+    }
+    if (!res.ok) {
+      return { status: 'error', error: `Server error (${res.status}).` };
+    }
+    const body = (await res.json()) as { answer: string; sources: SourceRepo[] };
+    return { status: 'ready', answer: body.answer, sources: body.sources ?? [] };
+  } catch (err) {
+    if ((err as DOMException)?.name === 'AbortError') {
+      return { status: 'idle' };
+    }
+    return { status: 'error', error: 'Network error — please refresh to retry.' };
+  }
+}
+
+/**
+ * FAQ card — lazily fetches the answer the first time the details element opens.
+ * Keeps the initial page weightless (one fetch per user-initiated expansion)
+ * instead of firing 16 requests on mount.
+ */
+function FAQCard({ question }: { question: string }) {
+  const [state, setState] = useState<AnswerState>({ status: 'idle' });
+  const controllerRef = useRef<AbortController | null>(null);
+
+  function load() {
+    if (state.status === 'loading' || state.status === 'ready') return;
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setState({ status: 'loading' });
+    void fetchAnswer(question, controller.signal).then(setState);
+  }
+
+  useEffect(() => () => controllerRef.current?.abort(), []);
+
+  return (
+    <details
+      className="group rounded-lg border border-zinc-800 bg-zinc-900/60 open:bg-zinc-900 transition-colors"
+      onToggle={(e) => {
+        if ((e.currentTarget as HTMLDetailsElement).open) load();
+      }}
+    >
+      <summary className="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-zinc-100">{question}</span>
+        <span
+          aria-hidden
+          className="text-zinc-500 group-open:rotate-180 transition-transform text-xs shrink-0"
+        >
+          ▾
+        </span>
+      </summary>
+      <div className="px-4 pb-4 pt-1 border-t border-zinc-800/60">
+        {state.status === 'idle' && (
+          <p className="text-xs text-zinc-500 py-2">Click to load the answer.</p>
+        )}
+        {state.status === 'loading' && <FAQSkeleton />}
+        {state.status === 'error' && (
+          <div className="py-2">
+            <p className="text-xs text-red-400">{state.error}</p>
+            <button
+              type="button"
+              onClick={() => {
+                setState({ status: 'idle' });
+                load();
+              }}
+              className="mt-2 rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {state.status === 'ready' && (
+          <div className="space-y-3">
+            <div className="prose prose-invert prose-sm max-w-none text-sm text-zinc-200">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+                components={MARKDOWN_COMPONENTS}
+              >
+                {state.answer ?? ''}
+              </ReactMarkdown>
+            </div>
+            {state.sources && state.sources.length > 0 && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-zinc-500 mb-1.5">
+                  Sources
+                </p>
+                <ul className="flex flex-wrap gap-1.5">
+                  {state.sources.slice(0, 8).map((src) => {
+                    const link = formatRepoLink(src);
+                    return (
+                      <li key={`${src.owner}/${src.name}`}>
+                        <a
+                          href={link.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors"
+                        >
+                          {link.label}
+                          {typeof src.stars === 'number' && (
+                            <span className="text-zinc-500">★ {src.stars.toLocaleString()}</span>
+                          )}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+            <a
+              href={`/ask?q=${encodeURIComponent(question)}`}
+              className="inline-block text-[11px] text-zinc-500 hover:text-zinc-300 underline underline-offset-2"
+            >
+              Open in Ask →
+            </a>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function FAQSkeleton() {
+  return (
+    <div className="space-y-2 py-2" aria-hidden>
+      <div className="h-3 w-3/4 rounded bg-zinc-800 animate-pulse" />
+      <div className="h-3 w-5/6 rounded bg-zinc-800 animate-pulse" />
+      <div className="h-3 w-2/3 rounded bg-zinc-800 animate-pulse" />
+    </div>
+  );
+}
+
+export function FAQPanel() {
+  const total = useMemo(
+    () => FAQ_SECTIONS.reduce((acc, s) => acc + s.questions.length, 0),
+    [],
+  );
+  return (
+    <div className="space-y-10">
+      <p className="text-xs text-zinc-500">
+        {total} questions · answers come directly from <code className="bg-zinc-800 px-1 rounded">/intelligence/ask</code>,
+        the same endpoint that powers the Ask bar.
+      </p>
+      {FAQ_SECTIONS.map((section) => (
+        <section key={section.title}>
+          <h2 className="text-lg font-semibold text-zinc-200">{section.title}</h2>
+          <p className="mt-1 text-xs text-zinc-500">{section.blurb}</p>
+          <div className="mt-4 space-y-2">
+            {section.questions.map((q) => (
+              <FAQCard key={q} question={q} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/FAQPanel.tsx
+++ b/src/components/FAQPanel.tsx
@@ -8,6 +8,82 @@ import { API_URL } from '@/lib/apiUrl';
 
 const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';
 
+// Shares AskBar's client-side budget key so /faq expands and /ask submissions
+// draw from one wallet (10/min, 100/day). Does not stop a determined attacker
+// — that requires a server-side proxy (see KAN-272 design memo, Phase 3).
+const RATE_KEY = 'reporium_ask_timestamps';
+const RATE_PER_MIN = 10;
+const RATE_PER_DAY = 100;
+
+// FAQ questions are hardcoded literals, so cache hits are high and safe.
+const CACHE_KEY = 'reporium_faq_answer_cache';
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+interface CachedAnswer {
+  at: number;
+  answer: string;
+  sources: SourceRepo[];
+}
+
+function readBudget(): { minute: number; day: number } {
+  if (typeof window === 'undefined') return { minute: 0, day: 0 };
+  try {
+    const raw = localStorage.getItem(RATE_KEY);
+    const ts: number[] = raw ? JSON.parse(raw) : [];
+    const now = Date.now();
+    return {
+      minute: ts.filter((t) => t > now - 60_000).length,
+      day: ts.filter((t) => t > now - 86_400_000).length,
+    };
+  } catch {
+    return { minute: 0, day: 0 };
+  }
+}
+
+function recordAsk() {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(RATE_KEY);
+    const ts: number[] = raw ? JSON.parse(raw) : [];
+    const now = Date.now();
+    const pruned = ts.filter((t) => t > now - 86_400_000);
+    pruned.push(now);
+    localStorage.setItem(RATE_KEY, JSON.stringify(pruned));
+  } catch {
+    // localStorage unavailable — degrade gracefully (no counter, no cache)
+  }
+}
+
+function readCache(question: string): CachedAnswer | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    const map: Record<string, CachedAnswer> = raw ? JSON.parse(raw) : {};
+    const hit = map[question];
+    if (!hit || Date.now() - hit.at > CACHE_TTL_MS) return null;
+    return hit;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(question: string, answer: string, sources: SourceRepo[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    const map: Record<string, CachedAnswer> = raw ? JSON.parse(raw) : {};
+    const fresh: Record<string, CachedAnswer> = {};
+    const now = Date.now();
+    for (const [k, v] of Object.entries(map)) {
+      if (now - v.at <= CACHE_TTL_MS) fresh[k] = v;
+    }
+    fresh[question] = { at: now, answer, sources };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(fresh));
+  } catch {
+    // ignore — cache is best-effort
+  }
+}
+
 // Grouped so the page reads as a tour of Reporium's capabilities. Every entry
 // is pinned to a deterministic smart-route match in reporium-api so the answer
 // is always grounded — no generic "not enough information" early-exit. Keep in
@@ -164,10 +240,39 @@ function FAQCard({ question }: { question: string }) {
 
   function load() {
     if (state.status === 'loading' || state.status === 'ready') return;
+
+    const cached = readCache(question);
+    if (cached) {
+      setState({ status: 'ready', answer: cached.answer, sources: cached.sources });
+      return;
+    }
+
+    const { minute, day } = readBudget();
+    if (minute >= RATE_PER_MIN) {
+      setState({
+        status: 'error',
+        error: "You've hit Reporium's per-minute Ask budget (10/min). Try again in a moment.",
+      });
+      return;
+    }
+    if (day >= RATE_PER_DAY) {
+      setState({
+        status: 'error',
+        error: "Today's Ask budget is used up (100/day). Try again tomorrow.",
+      });
+      return;
+    }
+
     const controller = new AbortController();
     controllerRef.current = controller;
     setState({ status: 'loading' });
-    void fetchAnswer(question, controller.signal).then(setState);
+    void fetchAnswer(question, controller.signal).then((next) => {
+      if (next.status === 'ready') {
+        recordAsk();
+        writeCache(question, next.answer ?? '', next.sources ?? []);
+      }
+      setState(next);
+    });
   }
 
   useEffect(() => () => controllerRef.current?.abort(), []);

--- a/src/components/StickyNavBar.tsx
+++ b/src/components/StickyNavBar.tsx
@@ -50,6 +50,13 @@ const NavIcon = {
       <circle cx="12" cy="12" r="3" />
     </svg>
   ),
+  faq: (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
 } as const;
 
 const NAV_LINKS = [
@@ -61,6 +68,7 @@ const NAV_LINKS = [
   { href: '/trends',       label: 'Trends',       icon: NavIcon.trends       },
   { href: '/architecture', label: 'Architecture', icon: NavIcon.architecture },
   { href: '/ai-native',    label: 'AI-Native',    icon: NavIcon.aiNative     },
+  { href: '/faq',          label: 'FAQ',          icon: NavIcon.faq          },
 ];
 
 interface StickyNavBarProps {


### PR DESCRIPTION
## Decision

**Merge with mitigation** (this PR). Supersedes #272.

PR [#272](https://github.com/perditioinc/reporium/pull/272) is CI-green and product-useful but bypasses AskBar's existing client wallet (`reporium_ask_timestamps`, 10/min · 100/day) and has no cache despite hardcoded curated questions. This branch carries #272's commit verbatim plus an ~80-LOC mitigation local to `src/components/FAQPanel.tsx`.

The complete fix — moving `NEXT_PUBLIC_APP_API_TOKEN` to a server-side proxy with session cookie + per-IP quota — requires `reporium-api` work and is **out of scope** for this lane. It is filed as `KAN-LATER-2` in the 2026-04-24 design memo. We are not blocking the FAQ surface on it.

## What this PR contains

1. **PR #272 verbatim** (commit `3f8718d`):
   - `src/app/faq/page.tsx` (40 LOC, new)
   - `src/components/FAQPanel.tsx` (296 LOC, new)
   - `src/components/StickyNavBar.tsx` (+8 LOC, FAQ nav entry)

2. **Spend-surface mitigation** (commit `7ab8e64`, local to `FAQPanel.tsx`):
   - `readBudget()` / `recordAsk()` share AskBar's `reporium_ask_timestamps` localStorage key (same constants: `RATE_PER_MIN = 10`, `RATE_PER_DAY = 100`).
   - `load()` pre-flights the wallet; over-cap renders a friendly error message instead of fetching.
   - `readCache()` / `writeCache()` store successful answers in `reporium_faq_answer_cache`, keyed by question text, 1h TTL.
   - Both helpers degrade silently on `localStorage` failure (private browsing, quota).

3. **Audit / decision record** under `.audit/`:
   - `.audit/2026-04-24/pr-272-faq-decision.md` — full decision memo.
   - `.audit/2026-04-24/faq-spend-surface-jira.md` — JIRA draft.
   - `.audit/2026-04-25/faq-spend-surface-jira.md` — re-validation pass.

## Why merge with mitigation, not as-is

- `/faq` exposes 16 cards. Without the wallet, a user who already used AskBar 8x in the last minute can still expand 16 FAQ cards on top, and a bot can `details.open = true` all 16 in one tick.
- FAQ questions are hardcoded literals — refresh re-burning all 16 has no upside. A 1h cache eliminates that.
- Both vectors are *new* with #272. Mitigating them keeps #272 from widening the existing AskBar burn surface.

## Why merge with mitigation, not "wait for server-side proxy"

- The proxy is the right long-term fix and the only one that closes the spend surface (token-in-bundle).
- It is a multi-repo lane (reporium + reporium-api). Holding `/faq` hostage to it costs us a useful product surface for an unknown number of weeks.
- The mitigation is forward-compatible: when the proxy ships, delete the client wallet + cache in the same lane that ships the proxy.

## Verification

Local manual pass on 2026-04-24 (recorded in audit doc), with `window.fetch` instrumented:

| Scenario                                      | Fetches | Wallet ticks |
| --------------------------------------------- | ------- | ------------ |
| Wallet pre-loaded with 10 timestamps; open card | 0     | 0 (gated)    |
| Reset, open one card fresh                    | 1       | 1            |
| Reload `/faq`, open the same card             | 0       | 0 (cache)    |

Static checks on lane HEAD (2026-04-25):
- `npx tsc --noEmit` → exit 0
- `npx eslint src/components/FAQPanel.tsx` → clean

## Test plan

- [ ] Vercel preview: `/faq` renders, sticky nav shows FAQ link.
- [ ] Open 3-4 cards across sections; confirm grounded answers + source chips.
- [ ] Reload `/faq`, re-open the same card → no new network call (cache hit).
- [ ] Open DevTools, set `localStorage.reporium_ask_timestamps = JSON.stringify(Array(10).fill(Date.now()))`, then expand a fresh card → friendly per-minute message, **zero** `/intelligence/ask` calls.
- [ ] `/ask` (existing AskBar surface) still respects the same wallet — no regression.

## Disposition of #272

Close in favor of this branch, OR cherry-pick commit `7ab8e64` onto `claude/feature/faq-page` and merge that. Either is fine; the merged result must include the mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)