### PR TITLE
hotfix: bump staticPageGenerationTimeout to 240s (fixes /faq 404, prod build failure)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,13 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
 
+  // Per-page static-generation timeout (default 60s). Production build of
+  // SHA 71a48bb1 failed because /repo/[name]/page hit 60s on /repo/rl across
+  // all 3 retry attempts (Vercel deployment dpl_7Xrjrf8mQUdRLoPJvsj5Qbe1LPTJ
+  // build log). Bump to 240s to absorb slow upstream API responses without
+  // changing rendering strategy.
+  staticPageGenerationTimeout: 240,
+
   // Explicitly expose NEXT_PUBLIC_* vars. Sentry's process polyfill can prevent
   // the default build-time inlining of `process.env.NEXT_PUBLIC_*`, leaving
   // the literal key in the bundle (resolves to undefined at runtime). Declaring


### PR DESCRIPTION
## Live regression this fixes

- `curl -L https://reporium.com/faq` → **404** despite `src/app/faq/page.tsx` being on `main` since #273 (`71a48bb1`).
- Root cause is **not** a /faq-specific bug — `/faq` 404s because the **entire production build of `71a48bb1` failed** and Vercel is still serving the previous prod SHA `53e36aee`.

## Evidence (Vercel)

- Production deployment `dpl_7Xrjrf8mQUdRLoPJvsj5Qbe1LPTJ` (SHA `71a48bb1`, created `2026-04-26T00:31:17Z`)
- `state: "failure"` (`gh api repos/perditioinc/reporium/deployments/4486415704/statuses`)
- Final build log lines (from `mcp__vercel__get_deployment_build_logs`):
  ```
  Failed to build /repo/[name]/page: /repo/rl after 3 attempts.
  ⨯ Export encountered an error on /repo/[name]/page: /repo/rl, exiting the build.
  ⨯ Next.js build worker exited with code: 1 and signal: null
  Error: Command "npm run generate:resilient && npm run build" exited with 1
  ```
- Multiple repos hit the 60s ceiling during static export: `FlashRAG`, `Grounded-SAM-2`, `gemma-cookbook`, `FastVideo`, `rl`, `rdkit`. `/repo/rl` was the one that exhausted all 3 retries, killing the build.

## What this PR changes

One config line in `next.config.js`:

```js
staticPageGenerationTimeout: 240,
```

That's 4× the Next.js default (60s). Combined with the existing 3-attempt retry, each page now has up to ~12 minutes of effective budget before failing the build. Output strategy is unchanged (`output: 'export'` retained).

## What this PR does *not* do

- Does not change rendering strategy (still full static export of all 1,992 repo pages).
- Does not touch the `generate:resilient` wrapper (`scripts/generate-with-fallback.ts`).
- Does not address the longer-term concern that fully static-exporting a growing corpus is structurally fragile — that's a separate ADR-worthy discussion (ISR, on-demand SSR, or paginated SSG).

## Verification plan

After merge:
1. Vercel auto-builds `main`. Watch deployment status; expect `state: success`.
2. `curl -L https://reporium.com/faq` → expect HTTP 200 + FAQ content (not the 404 page).
3. Spot-check `/repo/rl/`, `/repo/Grounded-SAM-2/`, `/repo/gemma-cookbook/` → expect 200.

## Why now / why hotfix to main

Per `CLAUDE.md`: "Hotfixes can go direct to **main** when urgent." Production is currently stuck on yesterday's SHA, which means **all** post-#273 work (`/faq`, spend-surface mitigation) is invisible to users until a clean build lands on `main`. Reverting #273 wouldn't help — `71a48bb1`'s code didn't cause the timeout; the timeout is a long-standing flake that finally tipped over.

## Out of scope (file separately if needed)

- Static-export scaling concerns (ISR / on-demand pages)
- Investigation of why `/repo/rl` specifically is slow (the underlying API call may have a fixable hot path)
- Separately: `Data Quality Check` red on reporium-api `main` and `Nightly Graph Build` red 4 nights running — handled in the wave closeout note at `.audit/2026-04-26/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)