### PR TITLE
auth-hardening: PR #1 (plan-only) — plan + prereads + rollout

### DIFF
--- a/.audit/2026-04-27/auth-hardening-plan.md
+++ b/.audit/2026-04-27/auth-hardening-plan.md
@@ -1,0 +1,255 @@
+# Auth + Boundary Hardening — Implementation Plan
+
+**Lane:** auth-hardening
+**Repos:** `reporium` (primary), `reporium-api` (config-only)
+**Author of this plan:** Cowork session 2026-04-27
+**Status:** plan-only. PR #1 of this lane is a plan-only PR carrying just this file. PR #2+ carries code.
+**Stop-condition rule:** if any step demands a contract change in `reporium-api` (new endpoint, changed shape, changed auth dep), stop and write that up as a separate JIRA before continuing in this lane.
+
+## TL;DR
+
+Reporium's frontend ships a public app token (`NEXT_PUBLIC_APP_API_TOKEN`) in the JS bundle and is deployed as a static export, so cookie/session-based gating is impossible today. The reporium-api side has a feature-flagged metrics gate (`METRICS_REQUIRE_AUTH=1`) that's currently a no-op in production, leaving `/metrics/*` and `/audit/status` browser-public.
+
+This lane removes the static-export deployment constraint, adds GitHub SSO via Auth.js with a server-side org-membership check for `perditioinc`, builds same-origin server proxies for every privileged API surface, and only after every consumer is migrated does it delete the public app token. The metrics gate is flipped *last*, after the proxy carries traffic, to avoid breaking the dashboard for everyone in a single release.
+
+Public Reporium browsing stays open. The `/audit` dashboard becomes perditioinc-only. Any signed-in GitHub user gets insights on their own public repos via a migrated route handler.
+
+## 1. Pre-read (mandatory before any code)
+
+Read in order:
+
+- `reporium/SECURITY-VERCEL-APR19.md` — prior security decisions and constraints
+- `reporium/next.config.js` — current static-export + env-bundle setup
+- `reporium/src/components/AskBar.tsx` (esp. line 122)
+- `reporium/src/components/StickyAskBar.tsx` (compare to AskBar — most informative surface today)
+- `reporium/src/components/AskPanel.tsx` (the `/ask` page)
+- `reporium/src/components/FAQPanel.tsx` (the `/faq` page)
+- `reporium/src/lib/dataProvider.ts` (esp. lines 240–263)
+- `reporium/src/server-api/repos/[username]/route.ts` — reference logic, NOT a production handler
+- `reporium-api/app/auth.py` (esp. `require_admin_key` and `require_metrics_access`)
+- `reporium-api/app/routers/platform.py` (esp. `/metrics/latest` at line 455)
+- `reporium/.audit/2026-04-25/reporium-ask-faq-design-memo.md` — already names this lane as "Phase 3" and treats it as the only correct fix to the spend-surface problem
+
+Pre-read deliverable: a `.audit/2026-04-27/auth-hardening-prereads.md` file listing what was read and any surprises (e.g., a fifth Ask surface that didn't exist on 2026-04-25, a different env var, etc.). If the pre-read turns up anything that invalidates this plan, **stop and revise the plan PR before any code work**.
+
+## 2. Key decisions, locked
+
+| Decision | Choice | Why |
+|---|---|---|
+| Hosting target | Vercel, server-capable Next.js | Sessions, cookies, route handlers, middleware all need server runtime |
+| Static export | Remove `output: 'export'` | Required for everything below |
+| `trailingSlash: true` | **Keep** unless a concrete routing/auth issue surfaces | Server-capable Next is fine with it; URL/SEO continuity matters |
+| Auth library | Auth.js (NextAuth v5+) with GitHub provider | Standard, supported, app-router native |
+| OAuth scope | `read:org` (minimum) | Sufficient for membership read; nothing larger needed |
+| Org-membership endpoint | `GET /user/memberships/orgs/perditioinc` with the **user's** OAuth token, accept where `state == "active"` | `/orgs/{org}/members/{username}` only sees public membership; most company org membership is private. The user-token endpoint sees the user's own active memberships regardless of visibility |
+| Membership cache | Boolean only, in the session JWT/DB record. **Never cache the raw OAuth token** | Token rotates; boolean is the access decision |
+| Privileged API access | Same-origin route handlers in `reporium`'s `app/api/` calling `reporium-api` with server-held secrets | The browser must never see admin or app tokens |
+| Metrics gate flip | Phased: proxy → verify → flip env → drop direct calls | Flipping the env first breaks the dashboard for everyone |
+| API contract | Frozen for this lane | If a contract change feels needed, file separate JIRA |
+| Worktree | Single owned branch off `main` per repo: `claude/feature/KAN-AUTH-hardening` | Lane discipline matches existing `.audit/` pattern |
+
+## 3. Phased rollout — 8 PRs, in order
+
+### PR #1 — plan-only (this file)
+
+- Adds `reporium/.audit/2026-04-27/auth-hardening-plan.md` (this content) and `reporium/.audit/2026-04-27/auth-hardening-prereads.md` (notes from §1).
+- No code change.
+- Reviewer can stop the lane here if the plan looks wrong; everything below assumes PR #1 is approved.
+
+### PR #2 — remove static export
+
+- `reporium/next.config.js`: delete `output: 'export'`. Keep `trailingSlash: true`. Keep the existing `env` block as-is for now (the keys are still in use; deletion comes in PR #7).
+- Move the dev-only `rewrites()` for `/api/proxy/:path*` to a real production same-origin proxy under `app/api/proxy/[...path]/route.ts`. (Even before SSO lands, the proxy path must work in prod, not just dev — that's exactly the gap that makes the static-export comment in `next.config.js` accurate today.)
+- Verify Vercel deploy: framework auto-detects Next.js, build command stays `next build`, no `next export`.
+- Verify the home, `/ask`, `/faq`, `/wiki/*`, `/graph/*` routes all still load and behave identically. Snapshot one anonymous network trace before/after to prove no functional regression.
+- **Acceptance:** Vercel deploy is green, all existing pages render, no behavior change visible to a logged-out user.
+
+### PR #3 — Auth.js GitHub provider, no UI yet
+
+- Add deps: `next-auth@^5` (or `@auth/nextjs` if Auth.js v5 is installed under that name in your monorepo).
+- New `src/lib/auth.ts` with `authOptions`: GitHub provider, scope `read:org user:email`, JWT session strategy, callbacks scaffolded but no membership check yet.
+- New env vars (Vercel: prod + preview): `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`. Document in `reporium/.env.example`.
+- Register GitHub OAuth app: callback URLs `https://reporium.com/api/auth/callback/github` (prod) and `https://reporium-*.vercel.app/api/auth/callback/github` (preview).
+- New `src/app/api/auth/[...nextauth]/route.ts` to mount the handler.
+- Add a `/sign-in` page (server component, single button) for testing.
+- **Acceptance:** a developer can sign in with GitHub at `/sign-in` and `getServerSession()` returns their `name`, `email`, `login`. Membership check not yet wired.
+
+### PR #4 — server-side perditioinc membership check + protected `/audit`
+
+- New `src/lib/github-org-check.ts`:
+  ```ts
+  // GET /user/memberships/orgs/perditioinc with user OAuth token.
+  // 200 + state==="active"  → member
+  // 200 + state==="pending" → not member yet (treat as deny)
+  // 403/404                  → not member
+  // 5xx                      → fail closed (deny + log)
+  // Returns boolean.
+  ```
+- Auth.js `jwt` callback: on first sign-in, call `isPerditioMember(token)`, store the boolean in the JWT as `isPerditioMember`. **Do not** persist the OAuth token after the check.
+- Augment session type in `src/types/next-auth.d.ts` to include `isPerditioMember: boolean` and `login: string`.
+- New `src/middleware.ts` matching `/audit/:path*`: redirect anonymous to `/sign-in?from=/audit`; respond 403 (or render an `/audit/access-denied` page) for signed-in non-members.
+- New `src/app/audit/page.tsx`: server component, calls `getServerSession()`, renders the audit dashboard for `isPerditioMember === true` only. Lift the HTML structure from the existing `reporium-suite-audit-dashboard` Cowork artifact (`C:\Users\PERDITIO\reporium-audit-2026-04-27\` for reference; do not import the artifact wholesale, it has Cowork-specific bindings).
+- Add `/audit/access-denied` page for the 403 path.
+- **Acceptance:** anon → sign-in redirect; signed-in non-member → 403; signed-in active perditioinc member → audit dashboard renders. All three states have a Playwright/Vitest test.
+
+### PR #5 — same-origin proxy for `/intelligence/ask` and metrics
+
+- New env vars (server-only — no `NEXT_PUBLIC_` prefix): `REPORIUM_API_URL`, `REPORIUM_APP_TOKEN`, `REPORIUM_ADMIN_KEY`. The first replaces today's `NEXT_PUBLIC_REPORIUM_API_URL` for server-side use; the latter two were never browser-safe.
+- New `src/app/api/intelligence/ask/route.ts`: POST forwarding handler. Reads request body, forwards to `${REPORIUM_API_URL}/intelligence/ask` with `X-App-Token: ${REPORIUM_APP_TOKEN}` server-side. Streams the SSE response back unchanged.
+- New `src/app/api/admin/metrics/[...path]/route.ts`: server handler for metrics surfaces. **Requires** `getServerSession()` to return `isPerditioMember === true`; otherwise 403. Forwards to `${REPORIUM_API_URL}/metrics/${path}` with `X-Admin-Key: ${REPORIUM_ADMIN_KEY}`.
+- Rewire callers — replace `process.env.NEXT_PUBLIC_APP_API_TOKEN` reads with same-origin fetches:
+  - `src/components/AskBar.tsx` line 122 + the fetch call site
+  - `src/components/StickyAskBar.tsx` (mirror change)
+  - `src/components/AskPanel.tsx`
+  - `src/components/FAQPanel.tsx`
+  - `src/lib/dataProvider.ts` `buildHeaders()` lines 258–263 (delete the `X-App-Token` branch — same-origin handler holds the token now)
+- The audit dashboard's metrics fetches go through `/api/admin/metrics/*`, never directly to Cloud Run.
+- **Acceptance:** every Ask surface still answers questions; the audit dashboard still renders metrics; bundle has zero references to `process.env.NEXT_PUBLIC_APP_API_TOKEN` *in functions that fire requests*. (The `next.config.js` `env` declaration is still present at this stage; deletion in PR #7.)
+
+### PR #6 — migrate `[username]/route.ts` to `app/api/`
+
+- Move `src/server-api/repos/[username]/route.ts` to `src/app/api/repos/[username]/route.ts`. Adjust imports.
+- Refactor: extract the public-repo fetch + enrichment functions to `src/lib/github-public-repos.ts` so the route handler is a thin wrapper.
+- Add a default-route convenience: `src/app/api/me/repos/route.ts` returns the signed-in user's own public repos by reading `session.login` and calling the same lib. Backs the "any signed-in GitHub user gets insights on their own public repos" feature.
+- Delete `src/server-api/` after confirming no remaining imports.
+- The 4 worktree copies (`.claude/worktrees/sad-elion/...`, `dazzling-kilby`, `thirsty-galileo`, `faq-ask-followup`) are untouched — they belong to other lanes.
+- **Acceptance:** `GET /api/repos/{login}` returns the same shape it did from `src/server-api/`; `GET /api/me/repos` returns the signed-in user's own repos; `src/server-api/` no longer exists.
+
+### PR #7 — remove `NEXT_PUBLIC_APP_API_TOKEN` from the bundle
+
+**Order matters here.** The token disappears from the bundle *only after* every consumer is gone (PRs #5 and #6).
+
+- Sweep the entire `reporium/src/` tree for `NEXT_PUBLIC_APP_API_TOKEN`. Expected hits after PRs #5–#6: zero in `src/`. If any remain, fix them before continuing.
+- Delete the line from `next.config.js:14`.
+- Add a build-time guard test: a script that runs `next build` against a temp dir and greps `out/_next/static/chunks/*.js` (or `.next/static/chunks/*.js` after server build) for both `NEXT_PUBLIC_APP_API_TOKEN` (the literal env name) and the actual production token value (loaded from a CI secret, never committed). Test fails on any match.
+- Remove the env var from Vercel project settings.
+- **Acceptance:** the bundle-grep test is green in CI; the prod bundle has zero references; the dashboard still works through the proxy.
+
+### PR #8 — operator: flip `METRICS_REQUIRE_AUTH=1` (Cloud Run env, not a code PR)
+
+This is **the last step**, not the first. The order is non-negotiable, and the gate before step 2 is a human gate, not a CI gate.
+
+**Pre-flip human gate.** A human operator (not Claude Code, not CI) must verify on the Vercel production deployment:
+- (a) Every audit dashboard metrics call goes to same-origin `/api/admin/metrics/*`.
+- (b) Zero direct browser calls to `*.run.app/metrics/*`.
+- (c) Zero direct browser calls to `*.run.app/audit/status`.
+- (d) Network trace (HAR or DevTools screenshot) capturing (a)–(c) is attached to PR #8's description.
+
+If any direct browser call to those paths is still observed, **do not proceed**. Open a new lane to track down the remaining caller, ship that fix, then re-run the gate.
+
+**After the gate passes:**
+
+1. Set `METRICS_REQUIRE_AUTH=1` on the `reporium-api` Cloud Run service:
+   `gcloud run services update reporium-api --update-env-vars METRICS_REQUIRE_AUTH=1 --region=us-central1`
+2. Wait for the next revision to come up healthy (~30–60s).
+3. Confirm anonymous browser hits to `${API}/metrics/*` return 403; same-origin proxy hits return 200 (test rows T13 and T14).
+4. Update `reporium-api/.env.example` to flag `METRICS_REQUIRE_AUTH=1` as the production default.
+
+If step 3 returns 200 for anonymous, **rollback step 1** immediately — that means there's still a direct browser caller somewhere that the human gate missed:
+`gcloud run services update reporium-api --remove-env-vars METRICS_REQUIRE_AUTH --region=us-central1`
+
+## 4. Files touched (proposed)
+
+**`reporium` (frontend):**
+
+| File | Action | Purpose |
+|---|---|---|
+| `next.config.js` | Edit | Remove `output: 'export'`; later (PR #7) drop `NEXT_PUBLIC_APP_API_TOKEN` from `env` |
+| `package.json` | Edit | Add `next-auth` |
+| `src/lib/auth.ts` | New | Auth.js config |
+| `src/lib/github-org-check.ts` | New | Server-side org membership |
+| `src/lib/github-public-repos.ts` | New | Extracted from server-api/ |
+| `src/types/next-auth.d.ts` | New | Session augmentation |
+| `src/middleware.ts` | New | Protect `/audit/*` |
+| `src/app/api/auth/[...nextauth]/route.ts` | New | Auth.js handler mount |
+| `src/app/api/intelligence/ask/route.ts` | New | Same-origin ask proxy |
+| `src/app/api/admin/metrics/[...path]/route.ts` | New | Same-origin metrics proxy (perditio-gated) |
+| `src/app/api/repos/[username]/route.ts` | New (migrated from `server-api/`) | Public-repo route |
+| `src/app/api/me/repos/route.ts` | New | Signed-in user's own repos |
+| `src/app/api/proxy/[...path]/route.ts` | New | Promote dev rewrite to prod proxy |
+| `src/app/audit/page.tsx` | New | Protected audit dashboard |
+| `src/app/audit/access-denied/page.tsx` | New | 403 view for non-members |
+| `src/app/sign-in/page.tsx` | New | Sign-in entry |
+| `src/components/AskBar.tsx` | Edit | Drop `NEXT_PUBLIC_APP_API_TOKEN` read; call `/api/intelligence/ask` |
+| `src/components/StickyAskBar.tsx` | Edit | Same |
+| `src/components/AskPanel.tsx` | Edit | Same |
+| `src/components/FAQPanel.tsx` | Edit | Same |
+| `src/lib/dataProvider.ts` | Edit | Drop `X-App-Token` branch in `buildHeaders` |
+| `src/server-api/` | Delete | After PR #6 migration |
+| `tests/auth/*.test.ts` | New | Three-state tests + bundle grep |
+| `.audit/2026-04-27/auth-hardening-plan.md` | New (PR #1) | This file |
+| `.audit/2026-04-27/auth-hardening-prereads.md` | New (PR #1) | Pre-read notes |
+| `.env.example` | Edit | Add new server-side keys; document removal of `NEXT_PUBLIC_APP_API_TOKEN` |
+
+**`reporium-api` (backend):**
+
+| File | Action | Purpose |
+|---|---|---|
+| `app/auth.py` | None | `require_metrics_access` already correct; activated via env |
+| `app/routers/platform.py` | None | Gate dependency already wired |
+| `.env.example` | Edit (PR #8) | Document `METRICS_REQUIRE_AUTH=1` as prod default |
+
+## 5. Test matrix
+
+| ID | Scenario | Expected | Lane |
+|---|---|---|---|
+| T1 | Anon hits `/audit` | 302 to `/sign-in?from=/audit` | PR #4 |
+| T2 | Signed-in non-perditioinc member hits `/audit` | 403 (or `/audit/access-denied`) | PR #4 |
+| T3 | Signed-in active perditioinc member hits `/audit` | 200, dashboard renders | PR #4 |
+| T4 | Signed-in pending perditioinc invite hits `/audit` | 403 (state ≠ active) | PR #4 |
+| T5 | Anon hits `/api/admin/metrics/latest` | 401 | PR #5 |
+| T6 | Signed-in non-member hits `/api/admin/metrics/latest` | 403 | PR #5 |
+| T7 | Signed-in member hits `/api/admin/metrics/latest` | 200, payload from API | PR #5 |
+| T8 | Anon hits `/api/intelligence/ask` POST | 200 with rate-limit (proxy enforces) | PR #5 |
+| T9 | Anon hits `/ask`, `/faq`, `/`, `/wiki/*`, `/graph/*` | 200, public Reporium browsing intact | PR #2/#5 |
+| T10 | Signed-in user hits `/api/me/repos` | 200, their own public repos | PR #6 |
+| T11 | Bundle grep for `NEXT_PUBLIC_APP_API_TOKEN` literal in `chunks/*.js` | zero matches | PR #7 |
+| T12 | Bundle grep for the actual prod token value | zero matches | PR #7 |
+| T13 | Anonymous direct call to `${API}/metrics/latest` after PR #8 | 403 | PR #8 |
+| T14 | Same-origin proxy call to `/api/admin/metrics/latest` after PR #8 | 200 | PR #8 |
+
+## 6. Rollout & rollback
+
+**Vercel side (rollout):**
+- Each PR deploys to a preview URL first.
+- Smoke-test the preview against the matching test rows above.
+- Promote to production on green CI + reviewer approval.
+
+**GCP side (rollout, PR #8 only):**
+- Set env on `reporium-api` Cloud Run service via `gcloud run services update --update-env-vars METRICS_REQUIRE_AUTH=1`.
+- Wait for next revision to come up healthy (~30–60s).
+- Run T13 + T14 within 5 min.
+
+**Rollback:**
+- PRs #2–#7: standard Git revert + Vercel re-deploy.
+- PR #8: `gcloud run services update --remove-env-vars METRICS_REQUIRE_AUTH` (or set to `0`). Re-deploys in ~30s.
+- If PRs #2 or #3 introduce session/cookie problems with `trailingSlash: true`, that's the *only* concrete trigger for removing it. Document the symptom in a follow-up `.audit/` note before changing it.
+
+## 7. What this lane does NOT do
+
+- Does not change any `reporium-api` endpoint shapes or auth deps. (`require_metrics_access` already exists; we only flip the env that activates it.)
+- Does not redesign the Ask UX. The Apr 25 design memo's Phase 1 (`<AnswerReceipt />`, `<WalletMeter />`, cache-age pill, source attestations) is a separate lane that *builds on* this one.
+- Does not unify the four Ask surfaces (`AskBar`, `StickyAskBar`, `AskPanel`, `FAQPanel`). Same comment.
+- Does not touch the knowledge-graph quality issue (60.1% invalid edges). Separate lane.
+- Does not address the 5-night Nightly Graph Build red streak. That's `reporium-ingestion` + ops.
+- Does not move the public marketing/library experience behind auth. Only `/audit/*` is gated.
+- Does not migrate any `reporium-api` endpoints to use OAuth tokens. The frontend proxy uses the existing app/admin keys server-side; that's the simplest correct fix and avoids a contract change in `reporium-api`.
+
+## 8. Open questions for the reviewer
+
+1. **Session storage:** JWT (default) or DB? JWT is simplest; DB lets you revoke tokens server-side. Default to JWT unless reviewer prefers DB.
+2. **Org-membership re-check cadence:** check on sign-in only, or on every session refresh? Default: re-check on every session refresh (~1h) — cheap (1 GitHub API call) and keeps the boolean fresh after a member is removed.
+3. **Sign-in UX:** dedicated `/sign-in` page (proposed) or hidden behind `/audit` redirect with a Toast on the public side? Default: dedicated page; clearer for the "any user can sign in" feature.
+4. **OAuth app vs GitHub App:** OAuth app proposed (simpler, smallest scope). Reviewer: is there an org-policy reason to require a GitHub App? If yes, document and we adjust PR #3.
+5. **`trailingSlash: true`:** keep unless concrete issue. Reviewer: any pre-existing canonical/SEO commitments to redirect-without-slash? If yes, change in a follow-up, not here.
+
+## 9. Provenance + cross-references
+
+- Cowork audit 2026-04-27: `C:\Users\PERDITIO\reporium-audit-2026-04-27\AUDIT.md` (P0 findings D2, D3 reference this lane as the only correct fix)
+- Apr 25 Ask/FAQ design memo: `reporium/.audit/2026-04-25/reporium-ask-faq-design-memo.md` §5 + §6 Phase 3 (treats this lane as Phase 3 of the spend-surface fix)
+- Existing security note: `reporium/SECURITY-VERCEL-APR19.md` (must be read in §1 pre-read)
+- Auth.js docs: https://authjs.dev/
+- Next.js route handlers: https://nextjs.org/docs/app/getting-started/route-handlers-and-middleware
+- GitHub OAuth scopes: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
+- GitHub user memberships endpoint: `GET /user/memberships/orgs/{org}` — https://docs.github.com/en/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user
+- Next.js static export limitations: https://nextjs.org/docs/app/building-your-application/deploying/static-exports

--- a/.audit/2026-04-27/auth-hardening-prereads.md
+++ b/.audit/2026-04-27/auth-hardening-prereads.md
@@ -1,0 +1,109 @@
+# Auth + Boundary Hardening — Pre-read Notes
+
+**Lane:** auth-hardening
+**Date:** 2026-04-27
+**Branch:** `claude/feature/KAN-AUTH-hardening` (worktree at `.claude/worktrees/auth-hardening/`, off `origin/main` @ `57901f7`)
+**Companion:** [`auth-hardening-plan.md`](auth-hardening-plan.md)
+
+This file is the §1 deliverable of the plan: a record of what was read, what was confirmed, and any surprises that should change the plan before code work starts.
+
+## 1. Files read (11 of 11)
+
+In the order the plan §1 specified:
+
+| # | File | Result |
+|---|---|---|
+| 1 | [`SECURITY-VERCEL-APR19.md`](../../SECURITY-VERCEL-APR19.md) | Read in full |
+| 2 | [`next.config.js`](../../next.config.js) | Read in full (55 lines) |
+| 3 | [`src/components/AskBar.tsx`](../../src/components/AskBar.tsx) | Read in full (434 lines) |
+| 4 | [`src/components/StickyAskBar.tsx`](../../src/components/StickyAskBar.tsx) | **Could not read in one shot** — 35,209 tokens, exceeds 25,000 reader limit. Searched via `Grep` for token references; lines 160–209 read for SSE event shape verification. Full review will need offset/limit reads in PR #5. |
+| 5 | [`src/components/AskPanel.tsx`](../../src/components/AskPanel.tsx) | Read in full (281 lines) |
+| 6 | [`src/components/FAQPanel.tsx`](../../src/components/FAQPanel.tsx) | Read in full (402 lines) |
+| 7 | [`src/lib/dataProvider.ts`](../../src/lib/dataProvider.ts) | Read in full (619 lines) |
+| 8 | [`src/server-api/repos/[username]/route.ts`](../../src/server-api/repos/[username]/route.ts) | Read in full (325 lines) |
+| 9 | `reporium-api/app/auth.py` | Read in full (219 lines) — sibling repo, outside worktree |
+| 10 | `reporium-api/app/routers/platform.py` | Read in full (841 lines) — sibling repo, outside worktree |
+| 11 | [`.audit/2026-04-25/reporium-ask-faq-design-memo.md`](../2026-04-25/reporium-ask-faq-design-memo.md) | Read in full (215 lines) |
+
+## 2. Confirmations (plan-as-written holds up)
+
+- **`next.config.js` static-export** at line 6 (`output: 'export'`) and `trailingSlash: true` at line 7 — both as plan describes. The dev-only `rewrites()` block at lines 31-41 with the comment "rewrites are ignored during `next export`" matches plan's PR #2 framing.
+- **`AskBar.tsx:122`** — `const APP_TOKEN = process.env.NEXT_PUBLIC_APP_API_TOKEN ?? '';` — exactly as cited.
+- **`dataProvider.ts:258-263`** — `buildHeaders` does read `NEXT_PUBLIC_APP_API_TOKEN` and attach `X-App-Token`. Plan citation correct.
+- **`reporium-api/app/auth.py:86-110`** — `require_metrics_access` is exactly as plan describes: feature-flagged on `METRICS_REQUIRE_AUTH=1`, no-op when unset, timing-safe `_secrets_equal`. The gate is real and ready; PR #8's env flip is all that activates it.
+- **`reporium-api/app/routers/platform.py:455`** — `/metrics/latest` IS gated by `Depends(require_metrics_access)`. **Plus** every other metrics endpoint in the file (`/audit/status:555`, `/metrics/slo:585`, `/metrics/latency:610`, `/metrics/backfill:630`, `/metrics/graph-quality:642`, `/metrics/data-quality:654`, `/metrics/prometheus:732`, `/metrics/spend:743`, `/metrics/export:774`, plus the legacy alias `/platform/metrics:546`). The catch-all proxy `/api/admin/metrics/[...path]/route.ts` proposed in plan §5 is the right shape — there are 10 gated metrics endpoints, not 1.
+- **Apr 25 design memo** explicitly names this lane as "Phase 3" (memo §6) and treats it as the only correct fix to the spend surface (memo §5.1, §7). Plan is consistent with the memo.
+- **GitFlow / branch direction.** CLAUDE.md says "Feature branches off **dev**, PRs target **dev**." That is documentation drift: `origin/dev` does not exist on the remote (`git ls-remote --heads origin` returns only `main` plus feature branches), and the 5 most-recent merged PRs (#269, #270, #271, #273, #274) all target `main`. The de-facto convention is `claude/feature/...` → `main`, which matches the plan as written. **Recommend updating CLAUDE.md in a separate housekeeping PR**, not this lane.
+
+## 3. Surprises that change PR #5 / PR #7 file scope
+
+These are not strategy-level deviations — the plan's overall approach (proxy → migrate → delete → flip) holds. They are **enumeration gaps in the plan's file list**.
+
+### 3.1 Five Ask/AI surfaces, not four
+
+Plan §5 names 4 token consumers: `AskBar`, `StickyAskBar`, `AskPanel`, `FAQPanel`. The full grep (across `src/`) finds **five**:
+
+| File:line | Surface | Endpoint |
+|---|---|---|
+| `src/components/AskBar.tsx:122,213` | inline ask widget | `/intelligence/ask/stream` |
+| `src/components/StickyAskBar.tsx:293,1245` | sticky ask dock | `/intelligence/ask/stream` |
+| `src/components/AskPanel.tsx:47` (via `dataProvider.askQuestion`) | `/ask` page | `/intelligence/ask` |
+| `src/components/FAQPanel.tsx:9,212` | `/faq` page | `/intelligence/ask` |
+| **`src/components/NLFilterBar.tsx:18,51`** | NL filter bar | **`/intelligence/nl-filter`** |
+
+`NLFilterBar.tsx` is missing from plan §5. It calls a *different* endpoint (`/intelligence/nl-filter`, not `/intelligence/ask`), so PR #5's same-origin proxy needs a second route handler: `src/app/api/intelligence/nl-filter/route.ts`. Already cross-referenced in the **April 19 security memo** (`SECURITY-VERCEL-APR19.md` lists `NLFilterBar.tsx:18` as a `NEXT_PUBLIC_APP_API_TOKEN` consumer at HIGH rotation priority); the plan inherited the gap from somewhere else, not from the security memo.
+
+### 3.2 Two token-set sites in `dataProvider.ts`, not one
+
+Plan §5 says "delete the `X-App-Token` branch" referring to `buildHeaders` at lines 258-263. There is a **second** site in the same file at line 593 inside the `askQuestion()` method that also sets `X-App-Token` from an `options.app_token` parameter. AskPanel calls into `askQuestion()` at `AskPanel.tsx:129` passing `app_token: APP_TOKEN`. So PR #5 must:
+
+1. Delete `buildHeaders` X-App-Token branch (`dataProvider.ts:263-264`).
+2. Either delete `askQuestion`'s `app_token` option entirely, **or** rewrite `askQuestion` to call same-origin `/api/intelligence/ask` rather than the upstream `${this.apiUrl}/intelligence/ask` at line 597.
+3. Update the AskPanel call site at `AskPanel.tsx:129` to stop passing `app_token`.
+
+The cleaner shape is: rewrite `askQuestion` to hit the proxy and remove the `app_token` option from its signature. That keeps the abstraction clean and avoids leaving a dead parameter behind.
+
+### 3.3 User-facing error strings literally name the env var
+
+Two surfaces have user-facing error text that includes the string `NEXT_PUBLIC_APP_API_TOKEN`:
+
+- `src/components/FAQPanel.tsx:202` — `'Ask is not configured in this environment (missing NEXT_PUBLIC_APP_API_TOKEN).'`
+- `src/components/StickyAskBar.tsx:1278` — `'Ask is not configured in this environment (missing NEXT_PUBLIC_APP_API_TOKEN). Contact the site owner.'`
+
+After PR #5 (proxy lands) and PR #7 (env var deleted), these strings will be wrong — the env var no longer exists, the proxy's failure mode is different (server-side misconfig, not browser-side). PR #5 should update them to a generic "Ask is temporarily unavailable" or similar, and PR #7's bundle-grep test should also fail on these literal mentions if they're not updated.
+
+**Recommend:** add to PR #5's file list and acceptance criteria. Add to PR #7's bundle-grep test (it will catch this for free if the test searches for the literal `NEXT_PUBLIC_APP_API_TOKEN` across all bundle chunks, including ones that contain user-visible error strings).
+
+### 3.4 `StickyAskBar.tsx` line numbers in cross-references are stale
+
+The April 19 security memo cites `StickyAskBar.tsx:174` for the `NEXT_PUBLIC_APP_API_TOKEN` read. Current line is 293; the file has grown to ~1278+ lines since the memo was written. The plan does not cite a specific line for StickyAskBar, so plan is unaffected — this note is for whoever does the actual rewrite in PR #5.
+
+The file is also large enough that the Read tool cannot ingest it whole (35k tokens > 25k limit). PR #5 will need to read/edit it in slices. This is a code-health observation, not a blocker; out of scope to refactor here.
+
+## 4. Open questions that the plan §8 already names — no new ones
+
+Plan §8 lists 5 open questions (session storage, re-check cadence, sign-in UX, OAuth-vs-GitHub-App, `trailingSlash`). The pre-read did not turn up new open questions beyond those.
+
+## 5. Recommended amendments to the plan before approval
+
+If the user wants the committed plan to match what PR #5/#7 will actually do, the following amendments to `auth-hardening-plan.md` are low-effort and should land as a 2nd commit on PR #1:
+
+1. **§1 pre-read list** — add line for `src/components/NLFilterBar.tsx`.
+2. **§3 PR #5 "Rewire callers" bullet list** — add `NLFilterBar.tsx`; add note about `dataProvider.ts:593` second token set; rewrite `askQuestion` signature to drop `app_token`.
+3. **§3 PR #5 "New env vars" / proxy list** — add `src/app/api/intelligence/nl-filter/route.ts` as a second proxy handler.
+4. **§3 PR #5 acceptance** — change "every Ask surface still answers questions" → "every Ask **and NL Filter** surface still works".
+5. **§3 PR #5 + PR #7** — add line items: update user-facing error strings at `FAQPanel.tsx:202` and `StickyAskBar.tsx:1278` so they no longer name the env var.
+6. **§4 frontend file table** — add `src/components/NLFilterBar.tsx` row (Edit) and `src/app/api/intelligence/nl-filter/route.ts` row (New).
+7. **§5 test matrix** — add a row mirroring T8 for the NL filter proxy: anon hits `/api/intelligence/nl-filter` → 200 (proxy enforces rate limit).
+
+If the user prefers to commit the verbatim plan and treat these as known PR #5 scope additions documented only in this prereads file, that is also workable — but the plan's §5 file enumeration will then be incomplete on its own terms.
+
+## 6. Pre-flight environment notes (operator checklist for later PRs)
+
+These do not affect PR #1 but are worth capturing now so they don't get forgotten:
+
+- **GitHub OAuth app registration** (PR #3): callback URLs `https://reporium.com/api/auth/callback/github` (prod) + `https://reporium-*.vercel.app/api/auth/callback/github` (preview). User account is `perditioinc` per CLAUDE.md (note: it's a *user* account, not an org — does not affect the OAuth callback but does affect the `read:org` membership endpoint scope, which still works on user-org memberships via `/user/memberships/orgs/{org}`).
+- **Vercel env vars to add** (PR #3 + PR #5): `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `REPORIUM_API_URL`, `REPORIUM_APP_TOKEN`, `REPORIUM_ADMIN_KEY`. All marked Sensitive (per `SECURITY-VERCEL-APR19.md` going-forward §1).
+- **Vercel env var to remove** (PR #7): `NEXT_PUBLIC_APP_API_TOKEN`.
+- **Cloud Run env var to set** (PR #8 — operator, not Claude Code): `METRICS_REQUIRE_AUTH=1` on `reporium-api` service via `gcloud run services update`.
+- **Worktree state**: `.claude/worktrees/auth-hardening/` was created off `origin/main`. The main `reporium` working tree remains untouched on its existing `claude/feature/KAN-272-faq-spend-surface` branch with prior-lane WIP intact.

--- a/.audit/2026-04-27/auth-hardening-rollout.md
+++ b/.audit/2026-04-27/auth-hardening-rollout.md
@@ -1,0 +1,293 @@
+# Auth + Boundary Hardening — Rollout & Runbook
+
+**Lane:** auth-hardening
+**Date:** 2026-04-27
+**Companion:** [`auth-hardening-plan.md`](auth-hardening-plan.md), [`auth-hardening-prereads.md`](auth-hardening-prereads.md)
+
+This is the operator-facing companion to the plan. The plan documents *strategy*; this file documents the concrete *steps* for each PR. Keep it open in a second tab while shipping.
+
+## PR #1 — plan-only (this PR)
+
+- **Action:** review the three files in `reporium/.audit/2026-04-27/`. Confirm the plan matches your intent, the prereads findings are acceptable (or request amendments), and the rollout below is realistic.
+- **Operator steps:** none. Approve or request changes via standard PR review.
+- **Rollback:** trivially revertable. Closes the PR; the worktree at `.claude/worktrees/auth-hardening/` can be removed via `git worktree remove .claude/worktrees/auth-hardening` from the main `reporium` checkout.
+
+## PR #2 — remove static export
+
+### Vercel project settings (one-time check before merging)
+
+Open the Vercel dashboard → `reporium` project → Settings → Build & Development Settings:
+
+- **Framework Preset:** Next.js (should already auto-detect; confirm it does)
+- **Build Command:** `next build` (or leave blank for the framework default; do NOT use `next export`)
+- **Output Directory:** leave blank (Vercel auto-uses `.next`); explicitly NOT `out`
+- **Install Command:** leave default
+
+### Vercel env vars (no change in this PR)
+
+No env-var change yet. The existing `NEXT_PUBLIC_*` vars stay in place; PR #5 adds new server-side keys.
+
+### Smoke test on the Vercel preview URL
+
+Capture a HAR file or DevTools network screenshot for these routes (each as an anonymous browser):
+
+- `/` (home)
+- `/ask`
+- `/faq`
+- `/wiki/*` (any one wiki page)
+- `/graph/*` (any one graph page)
+
+Each should return 200 and render. Compare to the same routes on production *before* merging — the goal is "no behavior change visible to a logged-out user."
+
+### Rollback
+
+`git revert` the merge commit + Vercel re-deploys the prior production build automatically. ~2-minute recovery.
+
+## PR #3 — Auth.js GitHub provider
+
+### Register a GitHub OAuth app (one-time, before merging)
+
+Go to https://github.com/settings/developers → "OAuth Apps" → "New OAuth App":
+
+- **Application name:** `Reporium`
+- **Homepage URL:** `https://reporium.com` (or your prod domain)
+- **Application description:** `Sign in to Reporium with your GitHub account.`
+- **Authorization callback URL:** `https://reporium.com/api/auth/callback/github`
+
+After saving, click "Generate a new client secret" and copy both the Client ID and the Client Secret immediately. You can't recover the secret later — only regenerate.
+
+For preview deployments, you have two options:
+- **Single OAuth app, multi-callback:** GitHub OAuth apps support multiple callbacks. Add `https://reporium-*.vercel.app/api/auth/callback/github` as a second callback (note: GitHub does support a list, separated by newlines in the dashboard).
+- **Separate "Reporium (Preview)" OAuth app:** safer for principle-of-least-privilege, but means tracking two sets of credentials.
+
+Recommend the single-app multi-callback approach unless the org-policy review pushes back.
+
+### Vercel env vars to add (Production + Preview scopes)
+
+In Vercel dashboard → reporium project → Settings → Environment Variables:
+
+| Name | Value | Scope | Sensitive? |
+|---|---|---|---|
+| `GITHUB_OAUTH_CLIENT_ID` | from GitHub OAuth app | Production + Preview | **Yes** |
+| `GITHUB_OAUTH_CLIENT_SECRET` | from GitHub OAuth app | Production + Preview | **Yes** |
+| `NEXTAUTH_URL` | `https://reporium.com` (prod) and `https://reporium-{branch}.vercel.app` (preview — Vercel can substitute via `VERCEL_URL`, see Auth.js docs) | Production + Preview | No |
+| `NEXTAUTH_SECRET` | generate with `openssl rand -base64 32` | Production + Preview | **Yes** |
+
+Mark Sensitive any time the value is a credential — per the April 19 security memo, that's enabling at-rest encryption.
+
+### Smoke test
+
+After merging, on the preview URL: visit `/sign-in`, click the GitHub button, complete OAuth, return to the app. `getServerSession()` should yield `name`, `email`, `login` for your account. **Membership check is not yet wired in this PR**; both perditioinc members and non-members will sign in successfully. That's by design — gating happens in PR #4.
+
+### Rollback
+
+Two layers:
+1. `git revert` the merge commit. Vercel re-deploys.
+2. **Do not delete the GitHub OAuth app** — you may need to re-merge later. Just revoke any session via Vercel rollback. The OAuth app is dormant if the env vars and routes are gone.
+
+## PR #4 — server-side perditioinc membership check + protected `/audit`
+
+### Vercel env vars
+
+No new env vars in this PR (the membership check uses the OAuth token from the user's own session).
+
+### Smoke test (must run on the preview URL with three accounts)
+
+| Account | URL | Expected |
+|---|---|---|
+| Anonymous (cleared cookies) | `/audit` | 302 redirect to `/sign-in?from=/audit` |
+| Signed in, *not* a perditioinc member | `/audit` | 403 (or `/audit/access-denied`) |
+| Signed in, *active* perditioinc member | `/audit` | 200, dashboard renders |
+| Signed in with a *pending* invite to perditioinc | `/audit` | 403 (state ≠ active) |
+
+The third account is the canonical "you" path — sign in with `kim.loza.dev@gmail.com` if that GitHub account has active perditioinc membership; otherwise use any account that does.
+
+The fourth account is the trickiest to test. To simulate: invite a throwaway GitHub account to perditioinc, do not have it accept, then sign in with that account. Membership endpoint returns `state: "pending"`; the gate must deny.
+
+### Rollback
+
+`git revert` + Vercel re-deploy. The middleware disappears with the revert, and `/audit` becomes anonymously accessible again. **This is a temporary regression of access control** — if the merge is rolled back, the dashboard goes wide-open until the next deploy. Mitigation: add Vercel password protection on the project for the duration of the rollback. Simple checkbox in project settings.
+
+## PR #5 — same-origin proxy for `/intelligence/ask` and metrics
+
+### Vercel env vars to add (Production + Preview)
+
+| Name | Value | Scope | Sensitive? |
+|---|---|---|---|
+| `REPORIUM_API_URL` | `https://reporium-api-573778300586.us-central1.run.app` (or current Cloud Run URL) | Production + Preview | No (it's a URL, not a secret) |
+| `REPORIUM_APP_TOKEN` | the same value currently in `NEXT_PUBLIC_APP_API_TOKEN` (do **not** rotate yet — rotate in PR #7's window) | Production + Preview | **Yes** |
+| `REPORIUM_ADMIN_KEY` | the existing reporium-api `ADMIN_API_KEY` | Production + Preview | **Yes** |
+
+Note: `REPORIUM_APP_TOKEN` and `REPORIUM_ADMIN_KEY` have **no** `NEXT_PUBLIC_` prefix. That is the entire point. Next.js will *not* inline them into the client bundle — they're available only to server-side route handlers.
+
+### Smoke test
+
+| Test | URL | Expected |
+|---|---|---|
+| T8 (anon ask) | `POST /api/intelligence/ask` from a logged-out browser | 200 with rate-limit enforced server-side |
+| T8a (anon nl-filter) | `POST /api/intelligence/nl-filter` from a logged-out browser | 200 with rate-limit enforced server-side (only present if PR #5 includes the NLFilterBar fix per prereads §3.1) |
+| T5 (anon metrics) | `GET /api/admin/metrics/latest` from a logged-out browser | 401 (no session) |
+| T6 (signed-in non-member metrics) | `GET /api/admin/metrics/latest` from a signed-in non-perditioinc browser | 403 |
+| T7 (signed-in member metrics) | `GET /api/admin/metrics/latest` from a signed-in perditioinc browser | 200 with payload |
+
+Plus regression tests:
+- Every Ask surface (AskBar, StickyAskBar, AskPanel, FAQPanel) still answers a sample question end-to-end.
+- The audit dashboard still renders metrics (it now goes through `/api/admin/metrics/*`).
+- `NLFilterBar` still applies a filter when given a natural-language query.
+
+### Rollback
+
+`git revert` + Vercel re-deploy. The route handlers disappear; the inline `NEXT_PUBLIC_APP_API_TOKEN` consumers are still in the same files so the surfaces continue to work via the old direct path. **No outage** during rollback.
+
+## PR #6 — migrate `[username]/route.ts` to `app/api/`
+
+### Smoke test
+
+| Test | URL | Expected |
+|---|---|---|
+| Existing route shape | `GET /api/repos/perditioinc` | 200 with same `LibraryData` shape as before, same `Cache-Control` headers, `X-Cache: HIT/MISS` reflects cache state |
+| New me route | `GET /api/me/repos` (signed-in user) | 200, returns the signed-in user's own public repos |
+| Anonymous me route | `GET /api/me/repos` (logged out) | 401 |
+
+Confirm `src/server-api/` directory is **deleted** after the migration — `ls reporium/src/server-api 2>/dev/null` should produce nothing.
+
+### Rollback
+
+`git revert` restores the directory. The 4 worktree copies under `.claude/worktrees/...` are unaffected (they're separate git worktrees — `git revert` only touches the current branch's tree).
+
+## PR #7 — remove `NEXT_PUBLIC_APP_API_TOKEN` from the bundle
+
+### Bundle-grep test (must run as part of CI)
+
+Add a CI job that:
+1. Runs `next build` with the production env (mock secrets are fine — what matters is whether the literal env-var name appears in the output).
+2. Greps `.next/static/chunks/*.js` for the literal string `NEXT_PUBLIC_APP_API_TOKEN`. **Must return zero matches.**
+3. Greps `.next/static/chunks/*.js` for the actual production token value (loaded as a CI secret at test time, never committed). **Must return zero matches.**
+
+A leading implementation:
+
+```bash
+# CI step (sketch — Bash; adjust for your runner)
+set -euo pipefail
+npm run build
+# Test #1: literal env-var name
+if grep -r --include='*.js' 'NEXT_PUBLIC_APP_API_TOKEN' .next/static/chunks/; then
+  echo 'FAIL: NEXT_PUBLIC_APP_API_TOKEN literal still in bundle'
+  exit 1
+fi
+# Test #2: actual prod token value (passed in via CI secret)
+if [[ -n "${PROD_APP_TOKEN_VALUE:-}" ]] && grep -r --include='*.js' --fixed-strings "${PROD_APP_TOKEN_VALUE}" .next/static/chunks/; then
+  echo 'FAIL: production app token value found in bundle'
+  exit 1
+fi
+echo 'PASS: bundle is clean'
+```
+
+### Vercel env vars to remove (after PR #7 merges)
+
+In Vercel dashboard → reporium project → Settings → Environment Variables:
+
+- **Delete** `NEXT_PUBLIC_APP_API_TOKEN` from Production and Preview scopes.
+
+Confirm the next deploy succeeds without that var (it should — PR #7 also removes the declaration from `next.config.js`).
+
+### Rollback
+
+`git revert` + re-add the Vercel env var (Production + Preview). Re-deploy. The bundle once again contains the public token, but the proxy paths from PR #5 still work — the rollback only re-introduces the *option* of using the public token directly. To force re-use of the public path, also `git revert` PR #5.
+
+## PR #8 — operator: flip `METRICS_REQUIRE_AUTH=1`
+
+**This is not a code PR.** It is a Cloud Run env-var update. Open it as a PR-shaped record (or a JIRA ticket) so there's an audit trail of when the env was flipped and who approved it.
+
+### Pre-flip human gate (mandatory — do NOT skip)
+
+Before flipping, capture and attach to the PR/JIRA description:
+
+1. **Vercel production network trace** showing every dashboard metrics call goes to same-origin `/api/admin/metrics/*`. Open prod, sign in as a perditioinc member, navigate to `/audit`, capture HAR or DevTools screenshot.
+2. **Confirm** in the same trace: zero direct browser calls to `*.run.app/metrics/*`.
+3. **Confirm** in the same trace: zero direct browser calls to `*.run.app/audit/status`.
+
+If any direct browser call to `*.run.app/metrics/*` or `*.run.app/audit/status` is observed, **do not flip**. Open a new lane to track down the remaining caller, ship that fix, then re-run this gate.
+
+### Cloud Run env-var update
+
+Once the gate passes:
+
+```bash
+# Set the gate. Wait ~30-60s for the new revision to come up healthy.
+gcloud run services update reporium-api \
+  --region=us-central1 \
+  --update-env-vars METRICS_REQUIRE_AUTH=1
+```
+
+### Post-flip verification (within 5 minutes)
+
+```bash
+# T13 — anonymous direct call must now 403
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://reporium-api-573778300586.us-central1.run.app/metrics/latest
+# Expected: 403
+
+# T14 — same-origin proxy must still 200 (use a signed-in perditioinc cookie)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -H 'Cookie: <session-cookie-from-signed-in-perditioinc-browser>' \
+  https://reporium.com/api/admin/metrics/latest
+# Expected: 200
+```
+
+### Rollback (if T13 returns 200 — gate didn't take, or there's still a public caller)
+
+```bash
+gcloud run services update reporium-api \
+  --region=us-central1 \
+  --remove-env-vars METRICS_REQUIRE_AUTH
+```
+
+Cloud Run rolls forward to a new revision (~30s). Anonymous calls to `/metrics/*` will succeed again. Do **not** retry the flip until the cause is found.
+
+### Update `reporium-api/.env.example`
+
+After the flip succeeds in production, update `reporium-api/.env.example` (separate trivial PR or amendment):
+
+```
+# Production default — required for HTTPS endpoints to be admin-key-gated.
+METRICS_REQUIRE_AUTH=1
+```
+
+## Cross-PR appendix
+
+### Summary table of env-var changes
+
+| PR | Action | Env var | Scope |
+|---|---|---|---|
+| #3 | Add | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET` | Vercel (prod + preview) |
+| #5 | Add | `REPORIUM_API_URL`, `REPORIUM_APP_TOKEN`, `REPORIUM_ADMIN_KEY` | Vercel (prod + preview) |
+| #7 | Remove | `NEXT_PUBLIC_APP_API_TOKEN` | Vercel (prod + preview) |
+| #8 | Add | `METRICS_REQUIRE_AUTH=1` | Cloud Run (`reporium-api`) |
+
+### Order of merges (non-negotiable)
+
+```
+PR #1 (plan)
+  ↓
+PR #2 (remove static export)
+  ↓
+PR #3 (Auth.js)
+  ↓
+PR #4 (membership check + /audit)
+  ↓
+PR #5 (proxies + rewire callers)        ← critical: must land before PR #7
+  ↓
+PR #6 (migrate [username]/route.ts)
+  ↓
+PR #7 (delete NEXT_PUBLIC_APP_API_TOKEN) ← critical: callers gone first
+  ↓
+PR #8 (Cloud Run env flip — operator)    ← critical: human gate before flip
+```
+
+### Where to look if something breaks mid-rollout
+
+- **`/audit` returns 500 after PR #4 merge** → check Vercel function logs for `getServerSession` errors. Most common cause: `NEXTAUTH_SECRET` missing or truncated in Vercel.
+- **Ask widget returns "Network error" after PR #5 merge** → check Vercel function logs for `/api/intelligence/ask` route handler. Most common cause: `REPORIUM_APP_TOKEN` not set in Vercel, or `REPORIUM_API_URL` missing the leading `https://`.
+- **Bundle grep test fails after PR #7 merge** → re-run `Grep -r 'NEXT_PUBLIC_APP_API_TOKEN' src/` (it should be empty); if any callers were missed in PR #5/#6, fix them in a hotfix PR before re-running PR #7.
+- **`/metrics/latest` returns 500 after PR #8 flip** → check Cloud Run logs for `Server misconfiguration` from `require_metrics_access`. Most common cause: `ADMIN_API_KEY` not actually set on Cloud Run when `METRICS_REQUIRE_AUTH=1` was flipped. Set it (`gcloud run services update reporium-api --update-env-vars ADMIN_API_KEY=<value>`) and the next revision recovers.


### PR DESCRIPTION
## Summary

PR #1 of an 8-PR auth-hardening lane. **Plan-only** — no code changes. Three documents land in `reporium/.audit/2026-04-27/`:

- **`auth-hardening-plan.md`** — 8-PR phased rollout: remove static export → add Auth.js GitHub SSO with perditioinc membership check → same-origin proxies for `/intelligence/ask` + metrics family → migrate `[username]/route.ts` → delete `NEXT_PUBLIC_APP_API_TOKEN` → operator-only Cloud Run `METRICS_REQUIRE_AUTH=1` flip.
- **`auth-hardening-prereads.md`** — required §1 deliverable. What was read, what was confirmed, four findings to decide on before approval.
- **`auth-hardening-rollout.md`** — operator runbook keyed by PR (Vercel env vars, GitHub OAuth app, Cloud Run gcloud commands, rollback per step).

## Reviewer decisions before approval

The prereads turned up four items. None are blockers; all are scope additions or doc-rot to flag:

1. **5 token consumers, not 4.** Plan §5 misses `src/components/NLFilterBar.tsx:18,51`, which calls a different endpoint (`/intelligence/nl-filter`). PR #5 needs a second proxy at `src/app/api/intelligence/nl-filter/route.ts` and a 5th rewire.
2. **Second token-set site in `dataProvider.ts:593`.** Plan §5 only names `buildHeaders:258-263`. The `askQuestion()` method also sets `X-App-Token` directly. PR #5 should rewrite `askQuestion` to call the same-origin proxy and drop the `app_token` option.
3. **User-facing error strings.** `FAQPanel.tsx:202` and `StickyAskBar.tsx:1278` literally name `NEXT_PUBLIC_APP_API_TOKEN`. PR #5/#7 should reword them.
4. **CLAUDE.md GitFlow is doc-rot.** It says \"PRs target dev,\" but `origin/dev` does not exist on the remote and the last 5 merged PRs (#269–#274) all targeted `main`. The plan saying \"off `main`\" matches reality. **Recommend** a separate housekeeping PR to update CLAUDE.md; not in scope for this lane.

**Reviewer:** please decide between
- **(A)** approve as-is, treat findings #1–#3 as PR #5/#7 scope additions documented only in the prereads, OR
- **(B)** ask for a 2nd commit on this PR that amends the plan to incorporate findings #1–#3 (low-effort: ~7 line-item edits to plan §1, §3 PR #5, §4, §5).

Both are workable. (A) is faster; (B) keeps the committed plan as a clean source-of-truth.

## Stop-condition rule

Per the plan's own §1: \"If the pre-read turns up anything that invalidates this plan, **stop and revise the plan PR before any code work**.\" The four findings are scope-of-PR-#5 amendments, not strategy invalidations. The phased rollout (proxy → migrate → delete → flip) is unchanged.

## Test plan

- [x] All 11 §1 pre-read files read (one — `StickyAskBar.tsx` — required Grep + slice reads due to file size; documented in prereads §1).
- [x] All cited line numbers verified or noted as drifted (none materially affect the plan).
- [x] `require_metrics_access` confirmed wired on all 10 metrics endpoints in `reporium-api/app/routers/platform.py`.
- [x] `origin/dev` confirmed absent; \"off main\" target matches recent merge history.
- [ ] Reviewer makes the (A)/(B) call.

## What this PR does NOT do

This PR ships zero code. PRs #2–#8 follow only after this PR is approved (per user prompt: \"Wait for plan approval before PR #2\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)