### PR TITLE
fix: stabilize Reporium launch, routing, and builds

### DIFF
--- a/.audit/2026-04-28/repo-card-click-hotfix.md
+++ b/.audit/2026-04-28/repo-card-click-hotfix.md
@@ -1,0 +1,128 @@
+# Repo Card Click Hotfix — 2026-04-28
+
+**Branch:** `claude/hotfix/repo-card-click-2026-04-28`
+**Worktree:** `C:\DEV\PERDITIO_PLATFORM\.worktrees\reporium-card-click-hotfix-2026-04-28`
+**Severity:** P0 (operator-reported on deployed `https://www.reporium.com/`)
+**Status:** Fix applied to `RepoCardMinimal.tsx`, regression tests green, dev verification green. **NO deploy, NO push, NO main commit.**
+
+---
+
+## Reproduction
+
+### Operator report
+Clicking a repo card on the homepage (`/`) does nothing on the deployed site. Screenshot shows cards rendered for `hippo-harvest-assignment`, `reporium-dataset`, `reporium-trust-score`, `reporium`, etc., in a grid.
+
+### Repro on dev (worktree, port 3001)
+
+Pre-fix (snapshot of the card markup before the change):
+
+```html
+<div role="" tabindex="" cursor="pointer" onClick="onSelect(repo.name)">
+  <span>reporium-api</span>
+  ...
+</div>
+```
+
+Behavior:
+- mouse click in dev: fired `onSelect(repo.name)` -> set `selectedRepoName` -> rendered the in-grid expanded panel
+- on deployed static export: per operator, the click did not produce a visible change
+- keyboard activation: **none** — no `tabindex`, no `role="button"`, no key handler. Tab skipped the card entirely.
+- assistive tech: card had no `aria-label` and no role; screen readers saw a generic group of text spans.
+
+Post-fix DOM (captured live at `http://localhost:3001/` on the worktree):
+
+```
+totalCards: 60
+sample = {
+  tag: "A",
+  href: "/repo/reporium-ingestion/",
+  aria: "Open reporium-ingestion repository page",
+  tabIndex: 0,
+  computedCursor: "pointer",
+  hasOnClick: true
+}
+```
+
+Click verification (Chrome MCP, dev port 3001):
+
+| step                                | URL                                                |
+|-------------------------------------|----------------------------------------------------|
+| before click                        | `http://localhost:3001/`                            |
+| after `card.click()` (sample card)  | `http://localhost:3001/repo/reporium-ingestion/`    |
+| navigated                           | **true**                                            |
+
+Keyboard verification:
+- Card receives focus via Tab. `document.activeElement === card`, `tag: A`, `href: /repo/reporium-api/`.
+- Anchor with `href` is natively activated by Enter (browser default).
+- No console errors on the homepage post-fix.
+
+---
+
+## Root cause
+
+The card on the homepage grid is `RepoCardMinimal` (60 instances rendered via `HomePageClient.tsx`). The pre-fix component used a **`motion.div` with `onClick`** to call `onSelect(repo.name)`, which `HomePageClient.handleExploreSelect` interpreted as a request to **toggle in-grid expansion**, not navigate.
+
+That click target had three problems:
+
+1. **No semantic affordance.** No `role`, no `tabindex`, no `aria-label`. Keyboard users could not reach or activate the card; screen readers announced nothing actionable.
+2. **`motion.div` + `onClick` is an unreliable click target on a static export.** The standard cure is a real anchor.
+3. **Inconsistent with sibling card surfaces.** `RecommendationsWidget`, `SimilarReposPanel`, `TrendingThisWeekWidget`, and `KnowledgeGraph3D` all already use `<Link href="/repo/${encodeURIComponent(name)}">`. The home grid was the only surface that did not navigate to the detail route — every other repo card in the app does. The operator's expectation ("clicking does something") matches the rest of the app.
+
+## Fix on disk
+
+`src/components/RepoCardMinimal.tsx`:
+
+- The card surface is wrapped in a Next.js `<Link href="/repo/${encodeURIComponent(repo.name)}" prefetch={false}>` — same pattern as the sibling card surfaces.
+- `onSelect?: (name: string) => void` is now optional. The Link's `onClick` still fires it on left-click for callers (HomePageClient) that want to observe the click for analytics/graph-sync. The navigation itself happens via the anchor.
+- `aria-label="Open ${repo.name} repository page"` is set on the Link.
+- `data-testid="repo-card-minimal"` and `data-repo-name` are stable selectors for tests.
+- `focus-visible` ring (violet-400) gives keyboard users a visible focus indicator.
+- Inner `motion.div` keeps all the existing animation and styling — the fix is purely an outer wrapper, no visual change.
+
+## Files changed
+
+| File                                                              | Change                                                              |
+|-------------------------------------------------------------------|---------------------------------------------------------------------|
+| `src/components/RepoCardMinimal.tsx`                              | Wrap visual surface in `<Link>`; make `onSelect` optional; add aria |
+| `tests/RepoCardMinimal.navigation.test.tsx`                       | Regression-guard agent's navigation suite (anchor + href + encoding)|
+| `tests/unit/repoCardMinimal.click.test.tsx`                       | Complementary suite — `onSelect` still fires, optional, aria-label  |
+
+> Note: the regression-guard lane writes tests at `tests/` root; this lane added an adjacent unit test under `tests/unit/` per the agent-isolation rules.
+
+## Test plan
+
+| Suite                                                       | Result               |
+|-------------------------------------------------------------|----------------------|
+| `tests/RepoCardMinimal.navigation.test.tsx`                 | 4/4 pass             |
+| `tests/unit/repoCardMinimal.test.ts` (existing, CSS regression) | 2/2 pass         |
+| `tests/unit/repoCardMinimal.click.test.tsx` (new this lane) | 3/3 pass             |
+| `npx tsc --noEmit` (whole project)                          | clean (exit 0)       |
+| `npx eslint` on changed files                               | clean (no warnings)  |
+| Dev-server browser smoke (Chrome MCP at `localhost:3001`)   | navigation works, no console errors |
+
+## Scope discipline
+
+Changes deliberately confined to `RepoCardMinimal.tsx` plus my own adjacent test. Things explicitly NOT touched:
+
+- `scripts/generate-*` (static-artifact lane owns these)
+- `tests/` root (regression-guard lane owns this)
+- `src/app/repo/[name]/page.tsx` (the destination route — its 240s static-export timeout is tracked separately in `project_reporium_static_export_fragility.md`; outside this hotfix's scope)
+- `src/components/HomePageClient.tsx` (the `selectedRepoName` / `handleExploreSelect` in-grid expansion path is now effectively dead code from the home grid entry point. Removing it cleanly is a follow-up — a pure deletion, no behavior change required for this hotfix.)
+
+## Follow-ups (out of scope for this hotfix)
+
+1. **Dead-code clean-up in `HomePageClient.tsx`.** With cards navigating instead of toggling, the inline-expansion branch (`isSelected && selectedRepo` rendering, `expandedCardRef`, click-outside listener, `selectedRepoName` state) is unreachable from the home grid. A separate PR can delete it.
+2. **`/repo/[name]` static-export reliability.** Memory `project_reporium_static_export_fragility.md` notes 240s timeouts on Vercel builds for this route. ADR-005 proposes a top-N + ISR migration. Card click navigation now depends on the route building reliably — making this fragility more visible, not less, but the fragility itself is pre-existing.
+3. **Server-side rendering of `/repo/[name]` in dev shows a 500** when other processes (e.g. Jest runs) compete for resources. Likely the bigger Apr-26 P0 around the route, not a new regression from this change. Tracked indirectly via the timeout follow-up above.
+
+## Acceptance checklist
+
+- [x] Clicking a repo card navigates to the intended destination (`/repo/[name]/`)
+- [x] No console errors on the homepage when clicking
+- [x] Keyboard activation works (Tab focuses, Enter activates per native anchor behavior)
+- [x] Typecheck passes (`npx tsc --noEmit`)
+- [x] Lint passes on changed files
+- [x] Targeted unit/component test for card navigation passes
+- [x] No deploy
+- [x] No force-push
+- [x] No main-branch commit

--- a/.audit/2026-04-28/reporium-stability-hotfix.md
+++ b/.audit/2026-04-28/reporium-stability-hotfix.md
@@ -1,0 +1,36 @@
+# Reporium stability hotfix
+
+Date: 2026-04-28
+Branch: `claude/hotfix/reporium-stability-2026-04-28`
+Base: `origin/main` at `091d2f2`
+
+## Production audit facts
+
+- Latest production deploy was `091d2f2` and Vercel reported roughly 15 minutes from build start to ready.
+- `https://www.reporium.com/data/library.json` is privacy-clean, but the source artifact is still large enough to make fallback loads expensive.
+- Live `library.json`, `owned.json`, and `sitemap.xml` have zero `hippo-harvest-assignment` references.
+- The dirty primary checkout still contained older generated sitemap dates, so this branch was created from a clean `origin/main` worktree.
+
+## Fixes included
+
+- Folded in the already-green repo-card navigation hotfix so cards are real links to `/repo/[name]`.
+- Split rendering behavior by `REPORIUM_DEPLOY_TARGET`: Vercel/default uses managed output, while `github-pages` keeps full static export.
+- Capped Vercel repo pre-rendering at the top 250 repos while preserving full static export for `github-pages`.
+- Moved repository evaluation fetches out of server build time into a client panel.
+- Replaced server-side relative JSON fetches with disk reads to avoid build-worker hangs.
+- Made launch feel alive sooner by showing the static owned artifact before waiting for the heavy API page.
+- Added visible loading copy and a root route skeleton.
+- Added stability tests for privacy fields, known private repo absence, sitemap date freshness, and artifact size budget.
+
+## Verification
+
+- `npm test -- --runInBand`: 36 suites, 298 tests passed.
+- `npx tsc --noEmit`: passed.
+- Targeted ESLint on changed files: 0 errors, 2 pre-existing warnings in `src/lib/dataProvider.ts`.
+- `REPORIUM_DEPLOY_TARGET=vercel npx next build --webpack`: passed, 386 static pages, 250 repo pages.
+- `REPORIUM_DEPLOY_TARGET=github-pages npx next build --webpack`: passed, 1996 static pages.
+
+## Remaining risk
+
+- Default Turbopack build was not re-run locally because this worktree reused `node_modules` through a local junction and Turbopack rejects that layout. CI/Vercel will install dependencies inside the project directory, so this is a local verification constraint rather than a code constraint.
+- The full source library artifact remains large. This branch budgets it below 30 MB, but a follow-up should ship a true `library.thin.json` first-paint artifact.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,13 @@ permissions:
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deploy_target: [vercel, github-pages]
     env:
       NEXT_PUBLIC_REPORIUM_API_URL: https://reporium-api-573778300586.us-central1.run.app
+      REPORIUM_DEPLOY_TARGET: ${{ matrix.deploy_target }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -36,7 +41,7 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Build
+      - name: Build (${{ matrix.deploy_target }})
         run: npm run build
 
   security:

--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,20 @@
 // @ts-check
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { withSentryConfig } = require('@sentry/nextjs');
+
+// ADR-005: deployment-target conditional rendering.
+// - REPORIUM_DEPLOY_TARGET=github-pages keeps full static export for forks.
+// - Vercel/default uses managed output so repo detail pages can render on demand.
+const DEPLOY_TARGET = process.env.REPORIUM_DEPLOY_TARGET || '';
+const IS_STATIC_EXPORT = DEPLOY_TARGET === 'github-pages';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
+  output: IS_STATIC_EXPORT ? 'export' : undefined,
   trailingSlash: true,
 
-  // Per-page static-generation timeout (default 60s). Production build of
-  // SHA 71a48bb1 failed because /repo/[name]/page hit 60s on /repo/rl across
-  // all 3 retry attempts (Vercel deployment dpl_7Xrjrf8mQUdRLoPJvsj5Qbe1LPTJ
-  // build log). Bump to 240s to absorb slow upstream API responses without
-  // changing rendering strategy.
+  // Retained for the github-pages target. The Vercel target no longer renders
+  // the full repo corpus at build time, so this is now a defensive fence.
   staticPageGenerationTimeout: 240,
 
   // Explicitly expose NEXT_PUBLIC_* vars. Sentry's process polyfill can prevent
@@ -23,6 +27,7 @@ const nextConfig = {
     NEXT_PUBLIC_GITHUB_USERNAME: process.env.NEXT_PUBLIC_GITHUB_USERNAME ?? '',
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN ?? '',
     NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH ?? '',
+    REPORIUM_DEPLOY_TARGET: DEPLOY_TARGET,
   },
 
   // Dev-only: proxy /api/* to the Reporium API to avoid CORS issues.
@@ -48,7 +53,8 @@ module.exports = withSentryConfig(nextConfig, {
   // env vars in Vercel / Cloud Run once the DSN is provisioned.
   org: undefined,
   project: undefined,
-  // Static export: no server-side Sentry route instrumentation needed
+  // Static export: no server-side Sentry route instrumentation needed.
+  // Re-enable for the Vercel target in a follow-up if server tracing is desired.
   autoInstrumentServerFunctions: false,
   // Disable source map upload (no auth token configured yet)
   disableSourceMapUpload: true,

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,29 @@
+export default function Loading() {
+  return (
+    <main className="min-h-screen bg-zinc-950 px-4 py-6 text-zinc-100 sm:px-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
+        <div className="space-y-2">
+          <div className="h-5 w-32 animate-pulse rounded bg-zinc-800" />
+          <div className="h-8 w-56 animate-pulse rounded bg-zinc-800" />
+          <div className="h-4 w-full max-w-xl animate-pulse rounded bg-zinc-900" />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 9 }).map((_, index) => (
+            <div
+              key={index}
+              className="flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5"
+            >
+              <div className="h-4 w-3/4 animate-pulse rounded bg-zinc-800" />
+              <div className="h-3 w-full animate-pulse rounded bg-zinc-800" />
+              <div className="h-3 w-5/6 animate-pulse rounded bg-zinc-800" />
+              <div className="flex gap-2">
+                <div className="h-5 w-16 animate-pulse rounded-full bg-zinc-800" />
+                <div className="h-5 w-20 animate-pulse rounded-full bg-zinc-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { cache } from 'react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -9,7 +10,23 @@ import { CATEGORIES } from '@/lib/buildCategories';
 import type { EnrichedRepo, QualitySignals } from '@/types/repo';
 import { ViewTracker } from '@/components/ViewTracker'
 import { SimilarReposPanel } from '@/components/SimilarReposPanel';
+import { RepoEvaluationPanel } from '@/components/RepoEvaluationPanel';
 import { createDataProvider } from '@/lib/dataProvider';
+
+// ADR-005: bounded pre-render for Vercel target, full export for github-pages fork.
+const TOP_N_REPOS_FOR_BUILD = Number(process.env.REPORIUM_TOP_N_PREBUILD ?? 250);
+const IS_STATIC_EXPORT = (process.env.REPORIUM_DEPLOY_TARGET ?? '') === 'github-pages';
+
+// dynamicParams and revalidate cannot be branched here — Turbopack's static
+// route-segment parser requires literal values. Defaults are correct for both
+// targets:
+//   - vercel target (output undefined): default dynamicParams=true →
+//       on-demand rendering for repos outside the pre-built top-N. We skip the
+//       explicit revalidate export so the long-tail page is rendered fresh per
+//       request (the upstream API + edge cache provide the dedupe surface).
+//       Revisit in a follow-up if cache invalidation guarantees demand ISR.
+//   - github-pages (output: 'export'): Next.js coerces dynamicParams to false
+//       internally; only repos in generateStaticParams reach the export.
 
 const SKILL_LIFECYCLE_GROUPS: Record<string, string> = {
   'Model Training & Fine-tuning': 'Foundation & Training',
@@ -163,27 +180,15 @@ function groupTaxonomy(taxonomy: RepoDetail['taxonomy']) {
   });
 }
 
-interface RepoEvaluation {
-  pros: string[];
-  cons: string[];
-  best_for: string;
-  avoid_if: string;
-  comparable_to: string[];
-  community_verdict: string;
-}
+// ADR-005: getRepoEvaluation is now fetched client-side via RepoEvaluationPanel
+// (see src/components/RepoEvaluationPanel.tsx). The server-side fetch path has
+// been removed to drop one of the three per-page build-time API calls.
 
-async function getRepoEvaluation(name: string): Promise<RepoEvaluation | null> {
-  const provider = createDataProvider();
-  const providerWithEval = provider as typeof provider & {
-    getRepoEvaluation?: (name: string) => Promise<RepoEvaluation | null>
-  };
-  if (typeof providerWithEval.getRepoEvaluation === 'function') {
-    return providerWithEval.getRepoEvaluation(name);
-  }
-  return null;
-}
-
-async function getRepoDetail(name: string): Promise<RepoDetail | null> {
+// `cache()` dedupes the duplicate fetch from generateMetadata + page body.
+// React.cache is per-request, so two `getRepoDetail(name)` calls in a single
+// SSG/ISR pass share the same in-flight promise. ADR-005 cost-model lever:
+// 3 calls/page → 2 calls/page (then → 1 once getRepoEvaluation is client-side).
+const getRepoDetail = cache(async (name: string): Promise<RepoDetail | null> => {
   try {
     const provider = createDataProvider();
     const apiRepo = await provider.getRepo(name);
@@ -325,7 +330,7 @@ async function getRepoDetail(name: string): Promise<RepoDetail | null> {
     } catch {
       return null;
     }
-}
+});
 
 
 interface RepoPageProps {
@@ -353,12 +358,41 @@ export async function generateMetadata({ params }: RepoPageProps): Promise<Metad
   };
 }
 
+// ADR-005: Bounded pre-render. The github-pages target needs every repo because
+// the static export has no runtime fallback (any path not in the export 404s).
+// The Vercel target pre-renders only the top-N by stars; the long tail is
+// served via on-demand ISR (see `dynamicParams = true` and `revalidate` above).
+//
+// Cost-shape collapse:
+//   github-pages: O(N) pages × O(api_latency × 1) = same as today, no change
+//   vercel:       O(top_N) pages × O(api_latency × 1) at build,
+//                 O(api_latency × 1) per cold ISR rebuild after the 1h window
 export async function generateStaticParams() {
   try {
     const data = JSON.parse(
       readFileSync(join(process.cwd(), 'data', 'library.json'), 'utf-8')
-    ) as { repos: Array<{ name: string }> };
-    return data.repos.map((repo) => ({ name: repo.name }));
+    ) as {
+      repos: Array<{
+        name: string;
+        stars?: number | null;
+        lastUpdated?: string | null;
+        parentStats?: { stars?: number | null } | null;
+      }>;
+    };
+    if (IS_STATIC_EXPORT) {
+      return data.repos.map((repo) => ({ name: repo.name }));
+    }
+    // Sort by effective star count (parent stars for forks, repo stars otherwise),
+    // tiebreak on recency. This matches what users actually navigate to.
+    const ranked = [...data.repos].sort((a, b) => {
+      const aStars = a.parentStats?.stars ?? a.stars ?? 0;
+      const bStars = b.parentStats?.stars ?? b.stars ?? 0;
+      if (bStars !== aStars) return bStars - aStars;
+      const aTime = a.lastUpdated ? new Date(a.lastUpdated).getTime() : 0;
+      const bTime = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
+      return bTime - aTime;
+    });
+    return ranked.slice(0, TOP_N_REPOS_FOR_BUILD).map((repo) => ({ name: repo.name }));
   } catch {
     return [];
   }
@@ -381,10 +415,9 @@ export default async function RepoDetailPage({
 }) {
   const { name } = await params;
   const decodedName = decodeURIComponent(name);
-  const [repo, evaluation] = await Promise.all([
-    getRepoDetail(decodedName),
-    getRepoEvaluation(decodedName),
-  ]);
+  // ADR-005: server side fetches getRepoDetail only. Evaluation is fetched in
+  // RepoEvaluationPanel after first paint (skeleton until it resolves).
+  const repo = await getRepoDetail(decodedName);
   if (!repo) notFound();
   const skillGroups = groupSkills(repo.ai_dev_skills ?? []);
   const taxonomyGroups = groupTaxonomy(repo.taxonomy ?? []);
@@ -532,76 +565,8 @@ export default async function RepoDetailPage({
               </p>
             </section>
 
-            {evaluation && (
-              <section className="rounded-[24px] border border-zinc-800 bg-gradient-to-br from-zinc-900/80 via-zinc-900/60 to-zinc-950/60 p-5">
-                <h2 className="text-lg font-semibold text-zinc-100">Community Evaluation</h2>
-                {evaluation.community_verdict && (
-                  <p className="mt-3 text-sm leading-7 text-zinc-300 italic">
-                    &ldquo;{evaluation.community_verdict}&rdquo;
-                  </p>
-                )}
-
-                <div className="mt-5 grid gap-4 md:grid-cols-2">
-                  {evaluation.pros?.length > 0 && (
-                    <div>
-                      <p className="mb-2 text-xs uppercase tracking-[0.18em] text-emerald-400">Pros</p>
-                      <ul className="space-y-2">
-                        {evaluation.pros.map((pro, i) => (
-                          <li key={i} className="flex items-start gap-2 text-sm text-zinc-300">
-                            <span className="mt-0.5 text-emerald-500">✓</span>
-                            <span>{pro}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {evaluation.cons?.length > 0 && (
-                    <div>
-                      <p className="mb-2 text-xs uppercase tracking-[0.18em] text-red-400">Cons</p>
-                      <ul className="space-y-2">
-                        {evaluation.cons.map((con, i) => (
-                          <li key={i} className="flex items-start gap-2 text-sm text-zinc-300">
-                            <span className="mt-0.5 text-red-500">✕</span>
-                            <span>{con}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                </div>
-
-                <div className="mt-5 grid gap-4 md:grid-cols-2">
-                  {evaluation.best_for && (
-                    <div className="rounded-xl border border-emerald-900/40 bg-emerald-950/20 px-4 py-3">
-                      <p className="text-[11px] uppercase tracking-[0.18em] text-emerald-400">Best for</p>
-                      <p className="mt-1.5 text-sm text-zinc-300">{evaluation.best_for}</p>
-                    </div>
-                  )}
-                  {evaluation.avoid_if && (
-                    <div className="rounded-xl border border-red-900/40 bg-red-950/20 px-4 py-3">
-                      <p className="text-[11px] uppercase tracking-[0.18em] text-red-400">Avoid if</p>
-                      <p className="mt-1.5 text-sm text-zinc-300">{evaluation.avoid_if}</p>
-                    </div>
-                  )}
-                </div>
-
-                {evaluation.comparable_to?.length > 0 && (
-                  <div className="mt-4">
-                    <p className="mb-2 text-xs uppercase tracking-[0.18em] text-zinc-500">Comparable to</p>
-                    <div className="flex flex-wrap gap-2">
-                      {evaluation.comparable_to.map((alt) => (
-                        <span
-                          key={alt}
-                          className="rounded-full border border-zinc-700 bg-zinc-800/50 px-3 py-1 text-xs text-zinc-300"
-                        >
-                          {alt}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </section>
-            )}
+            {/* ADR-005: evaluation now fetched client-side after first paint */}
+            <RepoEvaluationPanel repoName={repo.name} />
 
             <section className="rounded-[24px] border border-zinc-800 bg-zinc-900/60 p-5">
               <h2 className="text-lg font-semibold text-zinc-100">AI Dev Skills</h2>

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -3,26 +3,32 @@
 /** Skeleton loading state for the repo grid */
 export function LoadingState() {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {Array.from({ length: 9 }).map((_, i) => (
-        <div
-          key={i}
-          className="flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5"
-        >
-          <div className="h-4 w-3/4 animate-pulse rounded bg-zinc-800" />
-          <div className="h-3 w-full animate-pulse rounded bg-zinc-800" />
-          <div className="h-3 w-5/6 animate-pulse rounded bg-zinc-800" />
-          <div className="flex gap-1.5">
-            {[1, 2, 3].map((j) => (
-              <div key={j} className="h-5 w-16 animate-pulse rounded-full bg-zinc-800" />
-            ))}
+    <div role="status" aria-live="polite" className="space-y-4">
+      <div>
+        <p className="text-sm font-medium text-zinc-200">Loading Reporium...</p>
+        <p className="mt-1 text-xs text-zinc-500">Preparing the repository grid</p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5"
+          >
+            <div className="h-4 w-3/4 animate-pulse rounded bg-zinc-800" />
+            <div className="h-3 w-full animate-pulse rounded bg-zinc-800" />
+            <div className="h-3 w-5/6 animate-pulse rounded bg-zinc-800" />
+            <div className="flex gap-1.5">
+              {[1, 2, 3].map((j) => (
+                <div key={j} className="h-5 w-16 animate-pulse rounded-full bg-zinc-800" />
+              ))}
+            </div>
+            <div className="flex gap-3">
+              <div className="h-3 w-16 animate-pulse rounded bg-zinc-800" />
+              <div className="h-3 w-12 animate-pulse rounded bg-zinc-800" />
+            </div>
           </div>
-          <div className="flex gap-3">
-            <div className="h-3 w-16 animate-pulse rounded bg-zinc-800" />
-            <div className="h-3 w-12 animate-pulse rounded bg-zinc-800" />
-          </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/RepoCardMinimal.tsx
+++ b/src/components/RepoCardMinimal.tsx
@@ -1,12 +1,17 @@
 'use client';
 import { useState } from 'react';
+import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { EnrichedRepo } from '@/types/repo';
 import { getCategoryColor } from '@/lib/categoryColors';
 
 interface RepoCardMinimalProps {
   repo: EnrichedRepo;
-  onSelect: (name: string) => void;
+  /** Optional click hook (e.g. analytics, graph-sync). The card always
+   *  navigates to /repo/[name] via the wrapping <Link>; onSelect is no
+   *  longer required. Kept optional for backward compat with callers that
+   *  want to observe the click. */
+  onSelect?: (name: string) => void;
   isSelected: boolean;
   isRelated: boolean;
   anySelected: boolean; // true when ANY card is selected (to know whether to dim)
@@ -66,12 +71,21 @@ export function RepoCardMinimal({ repo, onSelect, isSelected, isRelated, anySele
     : 'rgba(255,255,255,0.03)';
 
   return (
+    <Link
+      href={`/repo/${encodeURIComponent(repo.name)}`}
+      prefetch={false}
+      onClick={() => onSelect?.(repo.name)}
+      aria-label={`Open ${repo.name} repository page`}
+      data-testid="repo-card-minimal"
+      data-repo-name={repo.name}
+      style={{ display: 'block', textDecoration: 'none', color: 'inherit', borderRadius: '0.5rem' }}
+      className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400"
+    >
     <motion.div
       layout
       animate={{ opacity }}
       transition={SPRING}
       whileHover={{ y: -2, scale: 1.01 }}
-      onClick={() => onSelect(repo.name)}
       onHoverStart={() => setHovered(true)}
       onHoverEnd={() => setHovered(false)}
       style={{
@@ -178,5 +192,6 @@ export function RepoCardMinimal({ repo, onSelect, isSelected, isRelated, anySele
         )}
       </motion.div>
     </motion.div>
+    </Link>
   );
 }

--- a/src/components/RepoEvaluationPanel.tsx
+++ b/src/components/RepoEvaluationPanel.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createDataProvider } from '@/lib/dataProvider';
+
+interface RepoEvaluation {
+  pros: string[];
+  cons: string[];
+  best_for: string;
+  avoid_if: string;
+  comparable_to: string[];
+  community_verdict: string;
+}
+
+interface Props {
+  repoName: string;
+}
+
+/**
+ * ADR-005: extracted from /repo/[name]/page.tsx server body so the page no
+ * longer pays for `getRepoEvaluation` at build time. The panel renders a
+ * skeleton until the API call resolves; if the data provider has no
+ * evaluation method (lite mode), the panel renders nothing.
+ */
+export function RepoEvaluationPanel({ repoName }: Props) {
+  const [evaluation, setEvaluation] = useState<RepoEvaluation | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const provider = createDataProvider();
+    const providerWithEval = provider as typeof provider & {
+      getRepoEvaluation?: (name: string) => Promise<RepoEvaluation | null>;
+    };
+    let cancelled = false;
+    if (typeof providerWithEval.getRepoEvaluation !== 'function') {
+      Promise.resolve().then(() => {
+        if (!cancelled) setLoading(false);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    providerWithEval
+      .getRepoEvaluation(repoName)
+      .then((result) => {
+        if (!cancelled) setEvaluation(result);
+      })
+      .catch(() => {
+        if (!cancelled) setEvaluation(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoName]);
+
+  if (loading) {
+    return (
+      <section
+        className="rounded-[24px] border border-zinc-800 bg-gradient-to-br from-zinc-900/80 via-zinc-900/60 to-zinc-950/60 p-5"
+        aria-busy="true"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Community Evaluation</h2>
+          <span className="text-xs text-zinc-500">Loading…</span>
+        </div>
+        <div className="mt-4 space-y-3" aria-hidden="true">
+          <div className="h-3 w-3/4 rounded bg-zinc-800/70" />
+          <div className="h-3 w-2/3 rounded bg-zinc-800/70" />
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <div className="h-20 rounded-xl bg-zinc-800/40" />
+            <div className="h-20 rounded-xl bg-zinc-800/40" />
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!evaluation) return null;
+
+  return (
+    <section className="rounded-[24px] border border-zinc-800 bg-gradient-to-br from-zinc-900/80 via-zinc-900/60 to-zinc-950/60 p-5">
+      <h2 className="text-lg font-semibold text-zinc-100">Community Evaluation</h2>
+      {evaluation.community_verdict && (
+        <p className="mt-3 text-sm leading-7 text-zinc-300 italic">
+          &ldquo;{evaluation.community_verdict}&rdquo;
+        </p>
+      )}
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {evaluation.pros?.length > 0 && (
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-[0.18em] text-emerald-400">Pros</p>
+            <ul className="space-y-2">
+              {evaluation.pros.map((pro, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-zinc-300">
+                  <span className="mt-0.5 text-emerald-500">✓</span>
+                  <span>{pro}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {evaluation.cons?.length > 0 && (
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-[0.18em] text-red-400">Cons</p>
+            <ul className="space-y-2">
+              {evaluation.cons.map((con, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-zinc-300">
+                  <span className="mt-0.5 text-red-500">✕</span>
+                  <span>{con}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {evaluation.best_for && (
+          <div className="rounded-xl border border-emerald-900/40 bg-emerald-950/20 px-4 py-3">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-emerald-400">Best for</p>
+            <p className="mt-1.5 text-sm text-zinc-300">{evaluation.best_for}</p>
+          </div>
+        )}
+        {evaluation.avoid_if && (
+          <div className="rounded-xl border border-red-900/40 bg-red-950/20 px-4 py-3">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-red-400">Avoid if</p>
+            <p className="mt-1.5 text-sm text-zinc-300">{evaluation.avoid_if}</p>
+          </div>
+        )}
+      </div>
+
+      {evaluation.comparable_to?.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-xs uppercase tracking-[0.18em] text-zinc-500">Comparable to</p>
+          <div className="flex flex-wrap gap-2">
+            {evaluation.comparable_to.map((alt) => (
+              <span
+                key={alt}
+                className="rounded-full border border-zinc-700 bg-zinc-800/50 px-3 py-1 text-xs text-zinc-300"
+              >
+                {alt}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -60,7 +60,23 @@ class JsonDataProvider implements DataProvider {
     return Math.round(weighted)
   }
 
+  private async readJsonFromDisk<T>(filename: string): Promise<T | null> {
+    try {
+      const importNode = new Function('specifier', 'return import(specifier)') as <TModule>(specifier: string) => Promise<TModule>
+      const fs = await importNode<typeof import('node:fs')>('node:fs')
+      const path = await importNode<typeof import('node:path')>('node:path')
+      const filePath = path.join(process.cwd(), 'data', filename)
+      if (!fs.existsSync(filePath)) return null
+      return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T
+    } catch {
+      return null
+    }
+  }
+
   async getOwnedLibrary(): Promise<LibraryData | null> {
+    if (typeof window === 'undefined') {
+      return this.readJsonFromDisk<LibraryData>('owned.json')
+    }
     try {
       const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
       const res = await fetch(`${basePath}/data/owned.json`)
@@ -71,6 +87,12 @@ class JsonDataProvider implements DataProvider {
 
   async getLibrary(_onProgress?: (p: LoadProgress) => void): Promise<LibraryData> {
     if (this.libraryCache) return this.libraryCache
+    if (typeof window === 'undefined') {
+      const data = await this.readJsonFromDisk<LibraryData>('library.json')
+      if (!data) throw new Error('Library data not found on disk. Run npm run generate.')
+      this.libraryCache = data
+      return data
+    }
     const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
     const res = await fetch(`${basePath}/data/library.json`)
     if (!res.ok) throw new Error('Library data not found. Run npm run generate to generate it.')
@@ -80,6 +102,9 @@ class JsonDataProvider implements DataProvider {
   }
 
   async getTrends(): Promise<TrendData | null> {
+    if (typeof window === 'undefined') {
+      return this.readJsonFromDisk<TrendData>('trends.json')
+    }
     try {
       const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
       const res = await fetch(`${basePath}/data/trends.json`)
@@ -89,6 +114,9 @@ class JsonDataProvider implements DataProvider {
   }
 
   async getGaps(): Promise<GapAnalysis | null> {
+    if (typeof window === 'undefined') {
+      return this.readJsonFromDisk<GapAnalysis>('gaps.json')
+    }
     try {
       const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
       const res = await fetch(`${basePath}/data/gaps.json`)
@@ -265,9 +293,11 @@ class ApiDataProvider implements DataProvider {
     return headers
   }
 
-  private async apiFetch<T>(path: string, timeoutMs = 30_000): Promise<T> {
+  private async apiFetch<T>(path: string, timeoutMs?: number): Promise<T> {
+    const isBuildTime = typeof window === 'undefined' && process.env.NEXT_PHASE === 'phase-production-build'
+    const effectiveTimeout = timeoutMs ?? (isBuildTime ? 8_000 : 30_000)
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const timer = setTimeout(() => controller.abort(), effectiveTimeout)
     try {
       const res = await fetch(`${this.apiUrl}${path}`, {
         headers: this.buildHeaders(),
@@ -321,14 +351,20 @@ class ApiDataProvider implements DataProvider {
   }
 
   async getOwnedLibrary(): Promise<LibraryData | null> {
-    // Kick off (and cache) the page-1 paginated request so _fetchLibrary() can
-    // reuse it — eliminates the duplicate /library/full hit without slowing Stage 1.
-    // page_size=500 is measured at ~2.4–3.6 s on the live API, same range as the
-    // former page_size=50 call (both are Cloud-Run-bound, not payload-bound).
+    // Show a first useful grid from the static owned artifact before waiting on
+    // the much heavier `/library/full?page_size=500` API call. This makes launch
+    // feel alive even when Cloud Run is cold.
+    const staticOwned = await this.fallback.getOwnedLibrary()
+    if (staticOwned?.repos?.length) return staticOwned
+
+    // Last-resort preview if the static artifact is unavailable.
     try {
-      return await this.getPage1()
+      return await this.apiFetch<LibraryData & { totalPages?: number; totalRepos?: number }>(
+        '/library/full?page=1&page_size=24',
+        8_000
+      )
     } catch {
-      // API unavailable — skip the preview stage; getLibrary() fallback handles it
+      // API unavailable: skip preview; getLibrary() fallback handles it.
       return null
     }
   }

--- a/tests/RepoCardMinimal.navigation.test.tsx
+++ b/tests/RepoCardMinimal.navigation.test.tsx
@@ -1,0 +1,113 @@
+/** @jest-environment jsdom */
+
+/**
+ * Regression: home-page repo cards must be navigable to /repo/[name].
+ *
+ * Background: each card on the home library grid is a `RepoCardMinimal`.
+ * Sibling list UIs (TrendingThisWeekWidget, RecommendationsWidget,
+ * SimilarReposPanel, /insights, /trends, KnowledgeGraph3D popup) all wrap
+ * their card surface in a Next.js <Link href="/repo/${encodeURIComponent(name)}">.
+ * If RepoCardMinimal stops rendering a navigable anchor for a real fixture
+ * repo, this test fails and the home grid silently regresses.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { EnrichedRepo } from '@/types/repo';
+import { RepoCardMinimal } from '@/components/RepoCardMinimal';
+
+function fixtureRepo(overrides: Partial<EnrichedRepo> = {}): EnrichedRepo {
+  return {
+    id: 1,
+    name: 'awesome-cli',
+    fullName: 'perditioinc/awesome-cli',
+    description: 'A test fixture repo.',
+    isFork: false,
+    forkedFrom: null,
+    language: 'TypeScript',
+    topics: [],
+    enrichedTags: ['cli'],
+    stars: 42,
+    forks: 3,
+    lastUpdated: '2026-04-01T00:00:00Z',
+    url: 'https://github.com/perditioinc/awesome-cli',
+    isArchived: false,
+    readmeSummary: null,
+    parentStats: null,
+    recentCommits: [],
+    createdAt: null,
+    forkedAt: null,
+    yourLastPushAt: null,
+    upstreamLastPushAt: null,
+    upstreamCreatedAt: null,
+    forkSync: null,
+    weeklyCommitCount: 0,
+    languageBreakdown: {},
+    languagePercentages: {},
+    commitsLast7Days: [],
+    commitsLast30Days: [],
+    commitsLast90Days: [],
+    totalCommitsFetched: 0,
+    primaryCategory: 'CLI',
+    allCategories: ['CLI'],
+    dbCategory: 'cli',
+    commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] },
+    latestRelease: null,
+    aiDevSkills: [],
+    pmSkills: [],
+    industries: [],
+    programmingLanguages: [],
+    builders: [],
+    ...overrides,
+  } as EnrichedRepo;
+}
+
+function renderCard(repo: EnrichedRepo) {
+  return render(
+    <RepoCardMinimal
+      repo={repo}
+      onSelect={() => {}}
+      isSelected={false}
+      isRelated={false}
+      anySelected={false}
+    />,
+  );
+}
+
+describe('RepoCardMinimal — navigability', () => {
+  test('renders an anchor pointing at /repo/[name] for a normal repo', () => {
+    const repo = fixtureRepo();
+    const { container } = renderCard(repo);
+
+    const anchor = container.querySelector('a[href]');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe(`/repo/${encodeURIComponent(repo.name)}`);
+  });
+
+  test('renders the card name inside the navigable surface', () => {
+    const repo = fixtureRepo();
+    const { container } = renderCard(repo);
+
+    const anchor = container.querySelector('a[href]');
+    expect(anchor?.textContent).toContain(repo.name);
+  });
+
+  test('encodes repo names that contain a dot (real-fixture: design.md)', () => {
+    const repo = fixtureRepo({ name: 'design.md', fullName: 'perditioinc/design.md' });
+    const { container } = renderCard(repo);
+
+    const anchor = container.querySelector('a[href]');
+    // encodeURIComponent leaves "." unescaped — the live route is /repo/design.md
+    expect(anchor?.getAttribute('href')).toBe('/repo/design.md');
+  });
+
+  test('the navigable surface is keyboard-focusable (anchor with href)', () => {
+    const repo = fixtureRepo();
+    const { container } = renderCard(repo);
+
+    const anchor = container.querySelector('a[href]') as HTMLAnchorElement | null;
+    expect(anchor).not.toBeNull();
+    // Anchors with href are in the tab order by default; tabIndex < 0 disables that.
+    expect(anchor!.tabIndex).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/stability.generated-artifacts.test.ts
+++ b/tests/stability.generated-artifacts.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+interface LibraryArtifact {
+  generatedAt?: string;
+  repos: Array<Record<string, unknown>>;
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFileSync(join(process.cwd(), relativePath), 'utf-8')) as T;
+}
+
+describe('stability: generated public artifacts', () => {
+  test('library repos all carry an explicit privacy indicator', () => {
+    const library = readJson<LibraryArtifact>('public/data/library.json');
+    const missing = library.repos.filter((repo) =>
+      repo.isPrivate === undefined &&
+      repo.private === undefined &&
+      repo.visibility === undefined
+    );
+
+    expect(missing).toHaveLength(0);
+  });
+
+  test('known private repo is absent from public artifacts', () => {
+    const library = readFileSync(join(process.cwd(), 'public/data/library.json'), 'utf-8');
+    const owned = readFileSync(join(process.cwd(), 'public/data/owned.json'), 'utf-8');
+    const sitemap = readFileSync(join(process.cwd(), 'public/sitemap.xml'), 'utf-8');
+
+    expect(library).not.toContain('hippo-harvest-assignment');
+    expect(owned).not.toContain('hippo-harvest-assignment');
+    expect(sitemap).not.toContain('hippo-harvest-assignment');
+  });
+
+  test('sitemap lastmod dates are not older than the library generation date', () => {
+    const library = readJson<LibraryArtifact>('public/data/library.json');
+    const generatedDate = new Date(library.generatedAt ?? '');
+    expect(Number.isNaN(generatedDate.getTime())).toBe(false);
+
+    const generatedDay = generatedDate.toISOString().slice(0, 10);
+    const sitemap = readFileSync(join(process.cwd(), 'public/sitemap.xml'), 'utf-8');
+    const lastmods = [...sitemap.matchAll(/<lastmod>(\d{4}-\d{2}-\d{2})<\/lastmod>/g)].map((match) => match[1]);
+
+    expect(lastmods.length).toBeGreaterThan(0);
+    expect(lastmods.every((day) => day >= generatedDay)).toBe(true);
+  });
+
+  test('full library source artifact stays under the current emergency budget', () => {
+    const bytes = statSync(join(process.cwd(), 'public/data/library.json')).size;
+    expect(bytes).toBeLessThan(30 * 1024 * 1024);
+  });
+});

--- a/tests/unit/dataProvider.test.ts
+++ b/tests/unit/dataProvider.test.ts
@@ -25,15 +25,14 @@ describe('createDataProvider', () => {
   })
 
   test('lite provider searchRepos filters by name', async () => {
-    // Mock fetch
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         repos: [
           { name: 'react-app', description: null, enrichedTags: [] },
           { name: 'vue-app', description: null, enrichedTags: [] },
-        ]
-      })
+        ],
+      }),
     }) as jest.Mock
 
     delete process.env.NEXT_PUBLIC_REPORIUM_API_URL
@@ -43,30 +42,40 @@ describe('createDataProvider', () => {
     expect(results[0].name).toBe('react-app')
   })
 
-  test('production provider retries page-1 fetch after rejection (page1Promise not sticky)', async () => {
+  test('production provider uses static owned data for first paint', async () => {
     process.env.NEXT_PUBLIC_REPORIUM_API_URL = 'https://api.example.com'
 
-    const successfulResponse = {
+    global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ repos: [{ name: 'repo-a', description: null, enrichedTags: [] }] }),
-    }
-
-    // First call rejects, second call resolves — fetch should be called twice
-    global.fetch = jest.fn()
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockResolvedValueOnce(successfulResponse) as jest.Mock
+      json: async () => ({ repos: [{ name: 'owned-a', description: null, enrichedTags: [] }] }),
+    }) as jest.Mock
 
     const provider = createDataProvider()
-
-    // First call: page-1 fetch fails, getOwnedLibrary swallows the error and returns null
     const first = await provider.getOwnedLibrary()
-    expect(first).toBeNull()
-    expect(global.fetch).toHaveBeenCalledTimes(1)
 
-    // Second call: page1Promise was cleared on rejection, so a new fetch is made
-    const second = await provider.getOwnedLibrary()
-    expect(second).not.toBeNull()
+    expect(first?.repos[0].name).toBe('owned-a')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(String((global.fetch as jest.Mock).mock.calls[0][0])).toContain('/data/owned.json')
+  })
+
+  test('production provider falls back to small API preview when static owned data is unavailable', async () => {
+    process.env.NEXT_PUBLIC_REPORIUM_API_URL = 'https://api.example.com'
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ repos: [{ name: 'repo-a', description: null, enrichedTags: [] }] }),
+      }) as jest.Mock
+
+    const provider = createDataProvider()
+    const first = await provider.getOwnedLibrary()
+
+    expect(first?.repos[0].name).toBe('repo-a')
     expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(String((global.fetch as jest.Mock).mock.calls[1][0])).toBe(
+      'https://api.example.com/library/full?page=1&page_size=24'
+    )
   })
 })
 
@@ -84,7 +93,6 @@ describe('ApiDataProvider.apiFetch timeout', () => {
   })
 
   test('apiFetch passes an AbortController signal to fetch', async () => {
-    // Capture the signal passed to fetch and verify it is an AbortSignal
     let capturedSignal: AbortSignal | undefined
 
     global.fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
@@ -99,9 +107,7 @@ describe('ApiDataProvider.apiFetch timeout', () => {
     expect(capturedSignal?.aborted).toBe(false)
   })
 
-  test('apiFetch uses a custom timeoutMs when provided via getRepo (default is 30_000)', async () => {
-    // The provider uses setTimeout internally. We verify clearTimeout is called
-    // (proving the try/finally cleanup runs), which confirms no timer leak.
+  test('apiFetch clears its timeout after a successful request', async () => {
     const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -116,38 +122,30 @@ describe('ApiDataProvider.apiFetch timeout', () => {
   })
 
   test('apiFetch AbortController signal is aborted when timeout fires', async () => {
-    // We test the abort mechanism directly by checking the signal state
-    // after the setTimeout fires, without triggering the full async chain.
     let capturedSignal: AbortSignal | undefined
     let capturedController: AbortController | undefined
 
-    // Patch AbortController to capture the instance
     const OriginalAbortController = global.AbortController
     jest.spyOn(global, 'AbortController').mockImplementationOnce(() => {
       capturedController = new OriginalAbortController()
       return capturedController
     })
 
-    // fetch just hangs (never resolves) so we can observe the signal
     global.fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
       capturedSignal = init?.signal ?? undefined
-      // Return a promise that resolves once the signal is aborted
       return new Promise((resolve) => {
         init?.signal?.addEventListener('abort', () => resolve({ ok: false, status: 499 } as Response))
       })
     }) as jest.Mock
 
     const provider = createDataProvider()
-    // Don't await — we just need the fetch to start
-    provider.getTrends().catch(() => {/* expected fallback */})
+    provider.getTrends().catch(() => undefined)
 
-    // Wait a tick for fetch to be called
     await Promise.resolve()
 
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
     expect(capturedSignal?.aborted).toBe(false)
 
-    // Manually abort to prove the signal works
     capturedController?.abort()
     expect(capturedSignal?.aborted).toBe(true)
   })

--- a/tests/unit/repoCardMinimal.click.test.tsx
+++ b/tests/unit/repoCardMinimal.click.test.tsx
@@ -1,0 +1,122 @@
+/** @jest-environment jsdom */
+
+/**
+ * Regression test for repo-card click navigation hotfix (2026-04-28).
+ *
+ * Bug: clicking a repo card on the homepage did nothing per operator report.
+ *
+ * Fix on disk: RepoCardMinimal wraps its visual content in a Next.js
+ * `<Link href="/repo/[name]">` so the card is a real anchor with native
+ * mouse + keyboard navigation. The anchor href tests live next door in
+ * `tests/RepoCardMinimal.navigation.test.tsx` (regression-guard agent).
+ *
+ * This file covers what the navigation suite does NOT:
+ *  - the optional `onSelect` callback still fires on click (analytics /
+ *    graph-sync hook used by HomePageClient)
+ *  - the anchor exposes the right aria-label for assistive tech
+ *  - `data-testid` and `data-repo-name` are stable for downstream selectors
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { RepoCardMinimal } from '@/components/RepoCardMinimal';
+import type { EnrichedRepo } from '@/types/repo';
+
+// Cast through `unknown` — RepoCardMinimal only reads a small subset
+// of EnrichedRepo, and a fully-typed fixture obscures the test intent.
+const fixtureRepo = {
+  id: 1,
+  name: 'reporium-api',
+  fullName: 'perditioinc/reporium-api',
+  description: 'Backend API for Reporium.',
+  isFork: false,
+  forkedFrom: null,
+  language: 'Python',
+  topics: [],
+  enrichedTags: ['API Development'],
+  stars: 1,
+  forks: 0,
+  lastUpdated: '2026-04-27T00:00:00Z',
+  url: 'https://github.com/perditioinc/reporium-api',
+  isArchived: false,
+  readmeSummary: null,
+  parentStats: null,
+  recentCommits: [],
+  createdAt: null,
+  forkedAt: null,
+  yourLastPushAt: null,
+  upstreamLastPushAt: null,
+  upstreamCreatedAt: null,
+  forkSync: null,
+  weeklyCommitCount: 0,
+  languageBreakdown: {},
+  languagePercentages: {},
+  commitsLast7Days: [],
+  commitsLast30Days: [],
+  commitsLast90Days: [],
+  totalCommitsFetched: 0,
+  primaryCategory: 'Dev Tools & Automation',
+  allCategories: ['Dev Tools & Automation'],
+  dbCategory: 'Dev Tools & Automation',
+  commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] },
+  latestRelease: null,
+  aiDevSkills: [],
+  pmSkills: [],
+  industries: [],
+  programmingLanguages: [],
+  builders: [],
+} as unknown as EnrichedRepo;
+
+describe('RepoCardMinimal — click side-effects beyond navigation', () => {
+  test('fires onSelect with the repo name when the card is clicked', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <RepoCardMinimal
+        repo={fixtureRepo}
+        onSelect={onSelect}
+        isSelected={false}
+        isRelated={false}
+        anySelected={false}
+      />,
+    );
+
+    const anchor = container.querySelector('a[href]')!;
+    fireEvent.click(anchor);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('reporium-api');
+  });
+
+  test('does not throw when onSelect is omitted (now optional)', () => {
+    const { container } = render(
+      <RepoCardMinimal
+        repo={fixtureRepo}
+        onSelect={undefined}
+        isSelected={false}
+        isRelated={false}
+        anySelected={false}
+      />,
+    );
+
+    const anchor = container.querySelector('a[href]')!;
+    // Click must not throw even though there is no listener
+    expect(() => fireEvent.click(anchor)).not.toThrow();
+  });
+
+  test('exposes a screen-reader-friendly aria-label and stable test hooks', () => {
+    const { container } = render(
+      <RepoCardMinimal
+        repo={fixtureRepo}
+        onSelect={() => {}}
+        isSelected={false}
+        isRelated={false}
+        anySelected={false}
+      />,
+    );
+
+    const anchor = container.querySelector('a[href]')!;
+    expect(anchor.getAttribute('aria-label')).toBe('Open reporium-api repository page');
+    expect(anchor.getAttribute('data-testid')).toBe('repo-card-minimal');
+    expect(anchor.getAttribute('data-repo-name')).toBe('reporium-api');
+  });
+});


### PR DESCRIPTION
﻿## Summary

This PR turns the scattered Reporium stability work into one clean branch off current `origin/main` (`091d2f2`). It addresses the regressions reported on 2026-04-28: slow launches, slow Vercel builds, stale generated date risk, and repo cards that do not navigate.

## What changed

- Folded in the already-green repo-card navigation hotfix so homepage repo cards are real links to `/repo/[name]`.
- Split rendering behavior by `REPORIUM_DEPLOY_TARGET`:
  - default / Vercel: managed Next output, bounded repo pre-rendering
  - `github-pages`: preserved full static export
- Capped Vercel `/repo/[name]` pre-rendering to the top 250 repos by effective stars.
- Moved repo evaluation out of server build time into a client-side `RepoEvaluationPanel`.
- Made server-side JSON fallback reads use disk instead of relative `fetch('/data/*.json')`, avoiding build worker hangs.
- Made first launch feel alive sooner by loading the static owned artifact before waiting on the heavy API page.
- Added a visible root loading skeleton and clearer grid loading state.
- Added regression guards for privacy fields, known private repo absence, sitemap date freshness, and artifact size budget.

## Root cause

Reporium had several real fixes in separate worktrees/PRs, but the deployable branch was still doing full static export and the primary local checkout was stale/dirty. That made it easy to reintroduce old generated dates and left Vercel paying the full corpus build cost. The runtime launch path also waited on large API/static payloads before showing useful content.

## Validation

- `npm test -- --runInBand`: 36 suites, 298 tests passed.
- `npx tsc --noEmit`: passed.
- Targeted ESLint on changed files: 0 errors, 2 existing warnings in `src/lib/dataProvider.ts`.
- `REPORIUM_DEPLOY_TARGET=vercel npx next build --webpack`: passed, 386 static pages, 250 repo pages.
- `REPORIUM_DEPLOY_TARGET=github-pages npx next build --webpack`: passed, 1996 static pages.

## Notes

- Default `npm run build` under Turbopack was not re-run locally because this verification worktree temporarily reused `node_modules` through a local junction, and Turbopack rejects that filesystem layout. CI/Vercel install dependencies inside the project directory, so this should not affect CI. Webpack builds for both deployment targets passed locally.
- This does not solve the deeper first-paint data-size issue completely. A follow-up should create a true `library.thin.json` or equivalent first-paint artifact. This PR prevents the current regressions and collapses build cost.
