### PR TITLE
KAN-123: regen sitemap.xml in Refresh Library Data cron

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -48,10 +48,20 @@ jobs:
           # static page renders without per-visitor API calls. Paces at 11s/question
           # to stay under the /intelligence/ask 6/min-per-IP server limit.
           npm run build:faq
+      - name: Regenerate sitemap
+        run: |
+          # KAN-123: regen public/sitemap.xml against the freshly written
+          # public/data/library.json so <lastmod> dates stay >= library.generatedAt
+          # day. Without this, tests/stability.generated-artifacts.test.ts
+          # 'sitemap lastmod dates are not older than the library generation
+          # date' goes red on every PR until the next manual sitemap regen.
+          # generate-sitemap.ts re-runs the centralized privacy filter as
+          # defense-in-depth (scripts/lib/sitemap.ts -> filterPrivateRepos).
+          npm run sitemap
       - name: Commit updated data
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add public/data/library.json public/data/trends.json public/data/faq.json DIGEST.md
+          git add public/data/library.json public/data/trends.json public/data/faq.json public/sitemap.xml DIGEST.md
           git commit -m "chore: refresh library data $(date -u +%Y-%m-%d)" || echo "No changes to commit"
           git push


### PR DESCRIPTION
## Why

`tests/stability.generated-artifacts.test.ts > sitemap lastmod dates are not older than the library generation date` has been going red on every PR's `lint-and-build (vercel)` and `lint-and-build (github-pages)` checks (e.g. CI run [25196380869](https://github.com/perditioinc/reporium/actions/runs/25196380869)).

Root cause: `.github/workflows/refresh-data.yml` regenerates `public/data/library.json` daily but never regenerates `public/sitemap.xml`. So `library.generatedAt` drifts ahead of every `<lastmod>` day in the sitemap and the stability test fails until the next PR-build bake regenerates the sitemap on its own. PR #281 (T5 trends staleness UI) is one current victim.

## What

Two-line change to `.github/workflows/refresh-data.yml`:

1. Add `Regenerate sitemap` step (`npm run sitemap`) after `Build FAQ answers` and before `Commit updated data`. The generator (`scripts/generate-sitemap.ts`) reads the freshly-written `public/data/library.json`, uses today's UTC date for every `<lastmod>`, and re-runs the centralized privacy filter (`scripts/lib/sitemap.ts -> filterPrivateRepos`) as defense-in-depth.
2. Add `public/sitemap.xml` to the `git add` list in the commit step.

No code under `src/` or `scripts/` is touched. No test or build config is changed.

## Why no manual sitemap commit in this PR

`origin/main`'s `public/sitemap.xml` is already fresh today (2026-05-01, regenerated by PR #283's build) so the test currently passes on `main`. This PR is the systemic prevention. PRs whose branch base predates the next `Refresh Library Data` run will pick up the fresh sitemap as soon as they rebase or merge from main once this lands.

## Verification

- Reproduced the failure locally by injecting `generatedAt: 2026-05-03T07:00:00Z` into `public/data/library.json` — stability test failed at line 45, exactly matching CI run 25196380869.
- Restored `library.json`, ran `npm run sitemap`, re-ran the stability test → 4/4 pass.
- `npx jest --testPathIgnorePatterns="/node_modules/" --testPathIgnorePatterns="HomeGraphWidget.test.tsx"`: 36 suites / 298 tests pass.
- `npx tsc --noEmit`: clean.
- `REPORIUM_DEPLOY_TARGET=vercel npm run build`: success (286 routes + 250 repo pages).
- `npm run lint`: 50 errors / 32 warnings, all pre-existing on `main`, none in files this PR touches. CI does not run `npm run lint` as a gate.

## Branch

`origin/dev` does not exist on this repo — confirmed via `git ls-remote --heads origin | grep -E '\b(main|dev)\b'`. PR targets `main` per the explicit override in the ticket.

## Unblocks

- PR #281 (KAN-DRAFT trends-staleness-ui) — currently red on this exact assertion
- Every future PR whose branch base predates a daily refresh

## JIRA

[KAN-123](https://perditio.atlassian.net/browse/KAN-123)