### PR TITLE
KAN-137: salvage frontend core smoke tests (now unblocked)

### DIFF
--- a/tests/smoke/_fixtures.ts
+++ b/tests/smoke/_fixtures.ts
@@ -1,0 +1,36 @@
+// Smoke-test fixture loader.
+//
+// Smoke tests use the live generated library at public/data/library.json so we
+// never hand-author repo names. Refreshes daily (chore: refresh library data
+// commits) — tests pick whatever is real today.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { LibraryData, EnrichedRepo } from '@/types/repo';
+
+const LIBRARY_PATH = join(process.cwd(), 'public', 'data', 'library.json');
+
+let cached: LibraryData | null = null;
+
+export function loadLibraryFixture(): LibraryData {
+  if (cached) return cached;
+  const raw = readFileSync(LIBRARY_PATH, 'utf-8');
+  cached = JSON.parse(raw) as LibraryData;
+  return cached;
+}
+
+// Pick a stable repo for tests that need a single sample. We use the first
+// item in the array — which has a deterministic position within a given
+// generated build — and validate it has the minimum fields needed for the
+// surfaces under test.
+export function pickSmokeRepo(): EnrichedRepo {
+  const lib = loadLibraryFixture();
+  const repo = lib.repos[0];
+  if (!repo) {
+    throw new Error('library.json contains no repos — fixture cannot be picked');
+  }
+  if (!repo.name) {
+    throw new Error('library.json repos[0] has no name field');
+  }
+  return repo;
+}

--- a/tests/smoke/ask-no-token-leak.smoke.test.tsx
+++ b/tests/smoke/ask-no-token-leak.smoke.test.tsx
@@ -1,0 +1,127 @@
+/** @jest-environment jsdom */
+
+// Smoke: the Ask surface does not leak NEXT_PUBLIC_APP_API_TOKEN into the
+// rendered DOM. Token transmission is via request body / X-App-Token header
+// only (see reporium-api/auth header reference: `app_token` body field and
+// `X-App-Token` header on the provider). Any DOM leak — value attribute,
+// data-*, text node — would be a credential exposure regression.
+//
+// We use a unique sentinel so a literal substring search is unambiguous.
+
+// AskPanel reads NEXT_PUBLIC_APP_API_TOKEN at module-load time. We must set
+// the env var BEFORE the import (so APP_TOKEN closes over our sentinel) and
+// must NOT use jest.resetModules — that would create a second React copy
+// whose hooks don't match the React used by @testing-library/react, raising
+// "Cannot read properties of null (reading 'useState')".
+const TOKEN_SENTINEL = 'SMOKE_TOKEN_SENTINEL_q7Hn4xPv9zLbR';
+process.env.NEXT_PUBLIC_APP_API_TOKEN = TOKEN_SENTINEL;
+process.env.NEXT_PUBLIC_REPORIUM_API_URL = 'https://api.example.com';
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const getSearchParams = jest.fn(() => new URLSearchParams());
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => getSearchParams(),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/ask',
+}));
+
+// askQuestion is the only entry point AskPanel calls. We capture the
+// options it receives so we can also assert the token is being passed
+// THROUGH the provider — proving AskPanel doesn't render it but DOES use
+// it for auth.
+const askQuestion = jest.fn();
+jest.mock('@/lib/dataProvider', () => ({
+  createDataProvider: () => ({
+    mode: 'production',
+    askQuestion,
+  }),
+}));
+
+describe('smoke: Ask surface does not expose NEXT_PUBLIC_APP_API_TOKEN', () => {
+  beforeEach(() => {
+    askQuestion.mockReset();
+    getSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
+  test('rendered DOM never contains the token sentinel — initial mount', () => {
+    // Module evaluation reads NEXT_PUBLIC_APP_API_TOKEN at the top level, so
+    // the env value above is what AskPanel will use.
+    const { AskPanel } = require('@/components/AskPanel');
+
+    const { container } = render(<AskPanel />);
+
+    expect(container.innerHTML).not.toContain(TOKEN_SENTINEL);
+    expect(document.body.innerHTML).not.toContain(TOKEN_SENTINEL);
+  });
+
+  test('rendered DOM never contains the token sentinel — after a query is submitted', async () => {
+    askQuestion.mockResolvedValue({
+      answer: 'Stub answer from the smoke harness.',
+      question: 'smoke question',
+      model: 'claude-test',
+      answered_at: new Date().toISOString(),
+      embedding_candidates: 0,
+      tokens_used: { input: 0, output: 0, total: 0 },
+      sources: [],
+    });
+
+    const { AskPanel } = require('@/components/AskPanel');
+    const { container } = render(<AskPanel />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'smoke question' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    // Wait for the answer to render — that's the moment when, if there
+    // were a leak path through props/state, it would be visible.
+    await screen.findByText('Stub answer from the smoke harness.');
+    await waitFor(() => {
+      expect(askQuestion).toHaveBeenCalled();
+    });
+
+    expect(container.innerHTML).not.toContain(TOKEN_SENTINEL);
+    expect(document.body.innerHTML).not.toContain(TOKEN_SENTINEL);
+
+    // No input should carry the sentinel as its value or any data-* attr
+    const inputs = container.querySelectorAll('input, textarea, button, [data-app-token]');
+    inputs.forEach((el) => {
+      const val = (el as HTMLInputElement).value;
+      if (typeof val === 'string') expect(val).not.toContain(TOKEN_SENTINEL);
+      for (const attr of Array.from(el.attributes)) {
+        expect(attr.value).not.toContain(TOKEN_SENTINEL);
+      }
+    });
+  });
+
+  test('token IS forwarded to the data provider — proves the value is wired, just not rendered', async () => {
+    askQuestion.mockResolvedValue({
+      answer: 'ok',
+      question: 'q',
+      model: 'm',
+      answered_at: '',
+      embedding_candidates: 0,
+      tokens_used: { input: 0, output: 0, total: 0 },
+      sources: [],
+    });
+
+    const { AskPanel } = require('@/components/AskPanel');
+    render(<AskPanel />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a question about AI dev tools...'), {
+      target: { value: 'wired test' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => expect(askQuestion).toHaveBeenCalled());
+
+    // The token MUST be in the options passed to askQuestion — that's the
+    // approved channel. If this fails, the provider isn't getting the
+    // token and the API will 401 in production.
+    const [, options] = askQuestion.mock.calls[0];
+    expect(options).toEqual(expect.objectContaining({ app_token: TOKEN_SENTINEL }));
+  });
+});

--- a/tests/smoke/homepage-renders.smoke.test.tsx
+++ b/tests/smoke/homepage-renders.smoke.test.tsx
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+
+// Smoke: the homepage shell renders meaningful content (search affordance +
+// stats hero) once the data provider resolves. Guards the "blank page"
+// regression class.
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { LibraryData } from '@/types/repo';
+import { loadLibraryFixture } from './_fixtures';
+
+var mockProvider: {
+  mode: 'production';
+  getOwnedLibrary: jest.Mock;
+  getLibrary: jest.Mock;
+  getDegradedState: jest.Mock;
+  clearDegradedState: jest.Mock;
+  getTrends: jest.Mock;
+  getGaps: jest.Mock;
+  getRepo: jest.Mock;
+  searchRepos: jest.Mock;
+  getTaxonomyValues: jest.Mock;
+  getPortfolioInsights: jest.Mock;
+  getCrossDimensionAnalytics: jest.Mock;
+  getSimilarRepos: jest.Mock;
+};
+
+jest.mock('@/lib/dataProvider', () => ({
+  createDataProvider: () => mockProvider,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Heavy widgets are not the surface under test; the smoke goal is "shell
+// renders + stats are visible". Stub them out so the test does not depend on
+// graph rendering, framer-motion timing, or three.js.
+jest.mock('@/components/HomeGraphWidget', () => ({ HomeGraphWidget: () => <div data-testid="graph-widget-stub" /> }));
+jest.mock('@/components/CrossDimensionWidget', () => ({ CrossDimensionWidget: () => null }));
+jest.mock('@/components/LibraryInsightsWidget', () => ({ LibraryInsightsWidget: () => null }));
+jest.mock('@/components/RecommendationsWidget', () => ({ RecommendationsWidget: () => null }));
+jest.mock('@/components/MetricsSidebar', () => ({ MetricsSidebar: () => null }));
+
+mockProvider = {
+  mode: 'production',
+  getOwnedLibrary: jest.fn(),
+  getLibrary: jest.fn(),
+  getDegradedState: jest.fn(),
+  clearDegradedState: jest.fn(),
+  getTrends: jest.fn(),
+  getGaps: jest.fn(),
+  getRepo: jest.fn(),
+  searchRepos: jest.fn(),
+  getTaxonomyValues: jest.fn(),
+  getPortfolioInsights: jest.fn(),
+  getCrossDimensionAnalytics: jest.fn(),
+  getSimilarRepos: jest.fn(),
+};
+
+describe('smoke: homepage renders meaningful content', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const real = loadLibraryFixture();
+    // Slim down the fixture so the grid does not render thousands of cards
+    // — but keep the structure (stats, categories, repos) intact so the
+    // hero/widgets have real shapes to render.
+    const trimmed: LibraryData = {
+      ...real,
+      repos: real.repos.slice(0, 5),
+      tagMetrics: real.tagMetrics?.slice(0, 5) ?? [],
+      categories: real.categories?.slice(0, 5) ?? [],
+    };
+    mockProvider.getOwnedLibrary.mockResolvedValue(null);
+    mockProvider.getLibrary.mockResolvedValue(trimmed);
+    mockProvider.getDegradedState.mockReturnValue(false);
+    mockProvider.getTrends.mockResolvedValue(null);
+    mockProvider.getGaps.mockResolvedValue(null);
+    mockProvider.getPortfolioInsights.mockResolvedValue(null);
+    mockProvider.getCrossDimensionAnalytics.mockResolvedValue(null);
+    mockProvider.getTaxonomyValues.mockResolvedValue([]);
+  });
+
+  test('renders the page shell with widget tabs once data resolves', async () => {
+    const { HomePageClient } = require('@/components/HomePageClient');
+
+    render(<HomePageClient />);
+
+    // The widget tabs (Overview / Stats / Insights / Analytics / Dashboard)
+    // are the load-bearing chrome of the home page — if NONE of them
+    // render, the shell is broken. Picking the most distinctive label
+    // ("Analytics") avoids collision with content elsewhere.
+    await waitFor(() => {
+      expect(screen.queryByText('Analytics')).not.toBeNull();
+    }, { timeout: 5000 });
+  });
+
+  test('renders library data once provider resolves', async () => {
+    const real = loadLibraryFixture();
+    const sampleRepoName = real.repos[0].name;
+    const { HomePageClient } = require('@/components/HomePageClient');
+
+    render(<HomePageClient />);
+
+    // The first repo's name should appear in the rendered tree once the
+    // grid mounts — proves the data path connects to the DOM.
+    await waitFor(() => {
+      const matches = screen.queryAllByText(sampleRepoName);
+      expect(matches.length).toBeGreaterThan(0);
+    }, { timeout: 5000 });
+  });
+});

--- a/tests/smoke/login-deterministic.smoke.test.ts
+++ b/tests/smoke/login-deterministic.smoke.test.ts
@@ -1,0 +1,68 @@
+/** @jest-environment node */
+
+// Smoke: login route/link behavior is deterministic.
+//
+// Reporium has no auth surface today — there is no /login, /signin, /sign-in,
+// or /auth route, and no nav link points at one. "Deterministic" here means:
+// (a) the absence is consistent (no half-built /login route appears that
+// would 404 in production), and (b) if someone wires up auth in the future,
+// they have to update both the route and the nav simultaneously, which this
+// test makes them confront.
+//
+// If real login is added later, replace this test with one that asserts the
+// link/route are CONSISTENT (link present iff route present), instead of
+// asserting both are absent.
+
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const APP_DIR = join(process.cwd(), 'src', 'app');
+const NAV_FILE = join(process.cwd(), 'src', 'components', 'StickyNavBar.tsx');
+
+const AUTH_ROUTE_PATTERN = /^(login|signin|sign-in|signup|sign-up|auth|logout|sign-out|signout)$/i;
+const AUTH_HREF_PATTERN = /href\s*=\s*['"`]\/(login|signin|sign-in|signup|sign-up|auth|logout|sign-out|signout)\b/i;
+const AUTH_NAV_LABEL_PATTERN = /label:\s*['"`](Sign\s*[Ii]n|Sign\s*[Uu]p|Log\s*[Ii]n|Logout|Log\s*[Oo]ut)/;
+
+describe('smoke: login route/link is deterministic', () => {
+  test('src/app/ contains no auth-related route directory', () => {
+    expect(existsSync(APP_DIR)).toBe(true);
+    const entries = readdirSync(APP_DIR, { withFileTypes: true });
+    const authDirs = entries
+      .filter((e) => e.isDirectory())
+      .filter((e) => AUTH_ROUTE_PATTERN.test(e.name));
+    // If auth is being added, this assertion will fail and force the
+    // accompanying nav-link assertion to be updated in lockstep.
+    expect(authDirs.map((d) => d.name)).toEqual([]);
+  });
+
+  test('StickyNavBar exposes no auth-route link', () => {
+    expect(existsSync(NAV_FILE)).toBe(true);
+    const source = readFileSync(NAV_FILE, 'utf-8');
+
+    // Either an explicit href to an auth route, or a NAV_LINKS entry whose
+    // label is a sign-in / sign-up / log-out word, would mean the nav has
+    // grown an auth affordance — both halves of the contract must move
+    // together with the route directory.
+    expect(source).not.toMatch(AUTH_HREF_PATTERN);
+    expect(source).not.toMatch(AUTH_NAV_LABEL_PATTERN);
+  });
+
+  test('no client component renders an auth-route href today', () => {
+    // This walks the most user-visible surfaces and checks for /login etc.
+    // hrefs. It is a containment test — if we ever add a real auth flow, we
+    // can update this list to reflect the canonical surface.
+    const filesToCheck = [
+      join(process.cwd(), 'src', 'app', 'page.tsx'),
+      join(process.cwd(), 'src', 'app', 'layout.tsx'),
+      join(process.cwd(), 'src', 'components', 'LayoutShell.tsx'),
+      join(process.cwd(), 'src', 'components', 'StickyAskBar.tsx'),
+      join(process.cwd(), 'src', 'components', 'StickyNavBar.tsx'),
+      join(process.cwd(), 'src', 'components', 'WikiNavBar.tsx'),
+    ];
+    for (const file of filesToCheck) {
+      if (!existsSync(file)) continue;
+      const source = readFileSync(file, 'utf-8');
+      expect({ file, leak: AUTH_HREF_PATTERN.test(source) }).toEqual({ file, leak: false });
+    }
+  });
+});

--- a/tests/smoke/no-private-repos.smoke.test.ts
+++ b/tests/smoke/no-private-repos.smoke.test.ts
@@ -1,0 +1,159 @@
+/** @jest-environment node */
+
+// Smoke: no private repository data leaks into the public static bundle.
+//
+// CONTEXT
+// 2026-04-27 P0 incident — the live `library.json` contained
+// `perditioinc/hippo-harvest-assignment` (private) because the build
+// pipeline had no field-driven privacy filter. The fix is being shipped
+// in the static-artifact privacy hotfix:
+//
+//   PR #278 — fix(privacy): P0 — static artifact privacy guard (fail-closed)
+//   Branch: claude/hotfix/static-private-artifact-2026-04-28
+//
+// The hotfix accepts ANY of three privacy fields per repo
+// (`isPrivate` / `private` / `visibility`) and FAILS CLOSED if the field
+// is missing, plus a static blocklist that pins the hippo regression.
+//
+// SMOKE SHAPE
+// This file is split into two halves:
+//
+//   1. BASELINE (green today) — schema hygiene that should always hold:
+//      no `private:true`, no non-public `visibility`, all URLs https,
+//      no PAT pattern in `fullName`, sitemap.xml does not list hippo.
+//
+//   2. PENDING — PR #278 contract (currently RED) — every repo declares a
+//      privacy indicator AND `library.json` does not contain hippo. These
+//      tests use `test.failing`: each turns the suite red when (and only
+//      when) the contract lands, prompting the maintainer to remove the
+//      `.failing` annotation.
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+interface MaybePrivate {
+  private?: unknown;
+  isPrivate?: unknown;
+  visibility?: unknown;
+  url?: unknown;
+  fullName?: unknown;
+  name?: unknown;
+}
+
+const HIPPO_FULL_NAME = 'perditioinc/hippo-harvest-assignment';
+const HIPPO_REPO_NAME = 'hippo-harvest-assignment';
+
+const PUBLIC_DATA_DIR = join(process.cwd(), 'public', 'data');
+const SITEMAP_PATH = join(process.cwd(), 'public', 'sitemap.xml');
+
+function readJson<T = unknown>(absPath: string): T {
+  return JSON.parse(readFileSync(absPath, 'utf-8')) as T;
+}
+
+function hasPrivacyIndicator(repo: MaybePrivate): boolean {
+  // The privacy filter in PR #278 accepts ANY of these three fields. A repo
+  // with NONE of them is "unknown verdict" and will be excluded by the
+  // fail-closed gate.
+  const has = (key: keyof MaybePrivate) =>
+    Object.prototype.hasOwnProperty.call(repo, key) && repo[key] != null;
+  return has('isPrivate') || has('private') || has('visibility');
+}
+
+function expectPublicShape(repo: MaybePrivate, where: string): void {
+  if (Object.prototype.hasOwnProperty.call(repo, 'private')) {
+    expect(repo.private).not.toBe(true);
+  }
+  if (typeof repo.visibility === 'string') {
+    expect(repo.visibility).toBe('public');
+  }
+  if (typeof repo.url === 'string') {
+    expect(repo.url).toMatch(/^https:\/\/github\.com\//);
+    expect(repo.url).not.toContain('@');
+    expect(repo.url).not.toContain('ssh://');
+  }
+  if (typeof repo.fullName === 'string') {
+    expect(repo.fullName).toMatch(/^[^/\s]+\/[^/\s]+$/);
+    expect(repo.fullName).not.toMatch(/(ghp_|github_pat_|gho_|ghs_)/);
+  }
+  expect(typeof repo.name).toBe('string');
+  expect((repo.name as string).length).toBeGreaterThan(0);
+  void where;
+}
+
+describe('smoke: no private repos in public static data — BASELINE', () => {
+  test('public/data/library.json has no explicit private:true / non-public visibility', () => {
+    const path = join(PUBLIC_DATA_DIR, 'library.json');
+    expect(existsSync(path)).toBe(true);
+    const lib = readJson<{ repos: MaybePrivate[] }>(path);
+    expect(Array.isArray(lib.repos)).toBe(true);
+    expect(lib.repos.length).toBeGreaterThan(0);
+    for (const repo of lib.repos) {
+      expectPublicShape(repo, `library.json:${repo.name}`);
+    }
+  });
+
+  test('public/data/owned.json (when present) has no explicit private:true', () => {
+    const path = join(PUBLIC_DATA_DIR, 'owned.json');
+    if (!existsSync(path)) return;
+    const owned = readJson<{ repos?: MaybePrivate[] }>(path);
+    if (!Array.isArray(owned.repos)) return;
+    for (const repo of owned.repos) {
+      expectPublicShape(repo, `owned.json:${repo.name}`);
+    }
+  });
+
+  test('public/sitemap.xml does not list hippo-harvest-assignment', () => {
+    // Sitemap is the agent-facing surface; even before library.json is
+    // regenerated, the sitemap edge MUST stay clean. PR #278 re-runs the
+    // privacy filter at the sitemap edge so the fail-closed shape can't be
+    // bypassed by a stale library.json.
+    if (!existsSync(SITEMAP_PATH)) return;
+    const xml = readFileSync(SITEMAP_PATH, 'utf-8');
+    expect(xml).not.toContain(HIPPO_REPO_NAME);
+    expect(xml).not.toContain(HIPPO_FULL_NAME);
+  });
+
+  test('public/data/owned.json does not list hippo-harvest-assignment', () => {
+    // owned.json is the perditioinc-owned-repos slice. It is already
+    // clean on origin/main today (the leak vector ran through library.json
+    // only) — this test PINS that state so a future regression can't
+    // re-introduce the repo via the owned-repos path.
+    const path = join(PUBLIC_DATA_DIR, 'owned.json');
+    if (!existsSync(path)) return;
+    const raw = readFileSync(path, 'utf-8');
+    expect(raw).not.toContain(HIPPO_FULL_NAME);
+    expect(raw).not.toContain(HIPPO_REPO_NAME);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMOTED — PR #278 (claude/hotfix/static-private-artifact-2026-04-28) has
+// landed; the privacy-filter contract is live. The two assertions below were
+// originally `test.failing` markers tied to that PR. With #278 + the
+// privacy-aware reporium-api change in main, they now pass on origin/main and
+// have been moved into the BASELINE describe block. Keep them there: any
+// future regression that drops the privacy field or re-introduces hippo will
+// flip these red.
+// ---------------------------------------------------------------------------
+describe('smoke: no private repos in public static data — PROMOTED (PR #278)', () => {
+  test('every repo in public/data/library.json declares a privacy indicator (isPrivate | private | visibility)', () => {
+    const path = join(PUBLIC_DATA_DIR, 'library.json');
+    const lib = readJson<{ repos: MaybePrivate[] }>(path);
+    const missing: string[] = [];
+    for (const repo of lib.repos) {
+      if (!hasPrivacyIndicator(repo)) {
+        missing.push((repo.name as string) ?? '<unnamed>');
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test('public/data/library.json does not contain perditioinc/hippo-harvest-assignment', () => {
+    // Pinned regression check — this repo MUST never appear in the public
+    // artifact again (privacy-filter.ts static blocklist mirrors this).
+    const path = join(PUBLIC_DATA_DIR, 'library.json');
+    const raw = readFileSync(path, 'utf-8');
+    expect(raw).not.toContain(HIPPO_FULL_NAME);
+    expect(raw).not.toContain(HIPPO_REPO_NAME);
+  });
+});

--- a/tests/smoke/repo-card-navigates.smoke.test.tsx
+++ b/tests/smoke/repo-card-navigates.smoke.test.tsx
@@ -1,0 +1,139 @@
+/** @jest-environment jsdom */
+
+// Smoke: clicking a repo card lands the user on /repo/<encoded-name>.
+//
+// CONTEXT
+// The home grid renders RepoCardMinimal. Two contracts are at play:
+//
+//   - On origin/main TODAY: the card is a `<motion.div onClick={() => onSelect(name)}>`
+//     that flips an internal "selected" state and surfaces a separate
+//     "Open full page →" Link. A click does not navigate by itself — the
+//     user has to click twice. That is the regression class the card-click
+//     hotfix is fixing.
+//
+//   - In the card-click hotfix lane (`claude/hotfix/repo-card-click-2026-04-28`):
+//     the card body is wrapped in `<Link href="/repo/<encoded-name>">`,
+//     `onSelect` is optional, and the card carries `data-testid="repo-card-minimal"`
+//     and `data-repo-name="<name>"`. A single click navigates.
+//
+// SMOKE SHAPE
+// This file is split into two halves:
+//
+//   1. BASELINE (green today) — TrendingThisWeekWidget already renders an
+//      explicit `<a href="/repo/<encoded>">` per repo. That is a stable
+//      deep-link surface that recommendations / similarity / trends share.
+//
+//   2. PENDING — card-click hotfix contract (currently RED) — the card
+//      itself MUST be the navigation target. Tests use `test.failing`
+//      until the hotfix lands; at that point each turns green and the
+//      `.failing` annotation must be removed.
+//
+// Owner / hotfix lane: claude/hotfix/repo-card-click-2026-04-28 (no PR yet
+// at the time of writing — branch lives in
+// `.worktrees/reporium-card-click-hotfix-2026-04-28`).
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RepoCardMinimal } from '@/components/RepoCardMinimal';
+import { TrendingThisWeekWidget } from '@/components/TrendingThisWeekWidget';
+import { pickSmokeRepo } from './_fixtures';
+
+// framer-motion's runtime mode introduces non-deterministic timers in jsdom;
+// for click-contract assertions we don't care about the animation, so render
+// the underlying tag directly. We strip motion-only props before forwarding
+// to the DOM element so React doesn't warn about unknown attributes.
+jest.mock('framer-motion', () => {
+  const ReactMod = require('react');
+  const MOTION_ONLY_PROPS = new Set([
+    'layout', 'layoutId', 'animate', 'initial', 'exit', 'transition',
+    'variants', 'whileHover', 'whileTap', 'whileFocus', 'whileDrag',
+    'whileInView', 'onHoverStart', 'onHoverEnd', 'onTap', 'onTapStart',
+    'onTapCancel', 'onPan', 'onPanStart', 'onPanEnd', 'drag', 'dragConstraints',
+    'dragElastic', 'dragMomentum', 'dragSnapToOrigin', 'viewport',
+    'onAnimationStart', 'onAnimationComplete', 'onUpdate',
+  ]);
+  function stripMotionProps(props: Record<string, unknown>): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(props)) {
+      if (!MOTION_ONLY_PROPS.has(k)) out[k] = v;
+    }
+    return out;
+  }
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: () => (props: any) =>
+          ReactMod.createElement(
+            props.as || 'div',
+            stripMotionProps(props),
+            props.children,
+          ),
+      },
+    ),
+  };
+});
+
+describe('smoke: repo card navigation — BASELINE', () => {
+  test('TrendingThisWeekWidget renders an internal link to /repo/<encoded-name>', () => {
+    const repo = pickSmokeRepo();
+
+    const { container } = render(<TrendingThisWeekWidget repos={[repo]} />);
+
+    const link = container.querySelector(
+      `a[href="/repo/${encodeURIComponent(repo.name)}"]`,
+    );
+    expect(link).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMOTED — card-click hotfix has landed on main. RepoCardMinimal is now
+// wrapped in `<Link href="/repo/<encoded>">` and exposes the
+// data-testid/data-repo-name handles. The two assertions below were
+// originally `test.failing` markers tied to that hotfix; promoted to
+// BASELINE so any future regression flips them red.
+// ---------------------------------------------------------------------------
+describe('smoke: repo card navigation — PROMOTED (card-click hotfix)', () => {
+  test('RepoCardMinimal exposes a single-click anchor to /repo/<encoded-name>', () => {
+    const repo = pickSmokeRepo();
+
+    const { container } = render(
+      <RepoCardMinimal
+        repo={repo}
+        onSelect={() => {}}
+        isSelected={false}
+        isRelated={false}
+        anySelected={false}
+      />,
+    );
+
+    // The hotfix wraps the card in an <a> (Next's <Link> emits one) with
+    // the encoded internal href.
+    const link = container.querySelector(
+      `a[href="/repo/${encodeURIComponent(repo.name)}"]`,
+    );
+    expect(link).not.toBeNull();
+  });
+
+  test('RepoCardMinimal exposes the data-testid + data-repo-name handles introduced by the hotfix', () => {
+    const repo = pickSmokeRepo();
+
+    render(
+      <RepoCardMinimal
+        repo={repo}
+        onSelect={() => {}}
+        isSelected={false}
+        isRelated={false}
+        anySelected={false}
+      />,
+    );
+
+    // These attributes are part of the hotfix contract — they exist so
+    // E2E / preview verification can target the card without depending
+    // on visible text (which can change with i18n / status-tag rules).
+    const card = screen.queryByTestId('repo-card-minimal');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-repo-name')).toBe(repo.name);
+  });
+});

--- a/tests/smoke/repo-detail-renders.smoke.test.tsx
+++ b/tests/smoke/repo-detail-renders.smoke.test.tsx
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+
+// Smoke: the /repo/[name] page can resolve a real repo from the local
+// fixture, generate static params, and produce valid metadata.
+//
+// /repo/[name]/page.tsx is a server component that reads from
+// data/library.json (synced from public/data/ at prebuild time). The page
+// is hard to render in jsdom, so we exercise the two pure functions it
+// exports — generateStaticParams() and generateMetadata() — which together
+// cover the page's data-binding contract.
+
+import { existsSync, mkdirSync, copyFileSync } from 'fs';
+import { join } from 'path';
+import { loadLibraryFixture } from './_fixtures';
+
+const DATA_DIR = join(process.cwd(), 'data');
+const SOURCE = join(process.cwd(), 'public', 'data', 'library.json');
+const DEST = join(DATA_DIR, 'library.json');
+
+// Ensure data/library.json exists — prebuild normally syncs it. In a fresh
+// checkout (or `npm test` without `npm run build`) the sync hasn't run, so
+// we replicate it here.
+beforeAll(() => {
+  if (!existsSync(DEST)) {
+    if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+    if (existsSync(SOURCE)) copyFileSync(SOURCE, DEST);
+  }
+});
+
+describe('smoke: repo detail page', () => {
+  test('generateStaticParams returns the names from the live library', async () => {
+    const lib = loadLibraryFixture();
+    expect(lib.repos.length).toBeGreaterThan(0);
+
+    const mod = require('@/app/repo/[name]/page');
+    const params = await mod.generateStaticParams();
+
+    expect(Array.isArray(params)).toBe(true);
+    // Every entry must have a `name` field — that's the dynamic-route shape.
+    expect(params.length).toBeGreaterThan(0);
+    expect(params[0]).toHaveProperty('name');
+    expect(typeof params[0].name).toBe('string');
+  });
+
+  test('generateMetadata produces a title and description for a real repo', async () => {
+    const lib = loadLibraryFixture();
+    const sampleName = lib.repos[0].name;
+
+    const mod = require('@/app/repo/[name]/page');
+    const metadata = await mod.generateMetadata({
+      params: Promise.resolve({ name: sampleName }),
+    });
+
+    expect(metadata).toBeTruthy();
+    // The page formats the title as "<owner>/<name>" — the repo name has to
+    // end up in the title somewhere, otherwise we are looking at a 404 page
+    // metadata, which would be the regression we want to catch.
+    expect(typeof metadata.title).toBe('string');
+    expect(metadata.title).toContain(sampleName);
+    expect(typeof metadata.description).toBe('string');
+    expect(metadata.description.length).toBeGreaterThan(0);
+    // OpenGraph URL must include the encoded repo name — guards against the
+    // "wrong canonical URL" regression.
+    expect(metadata.openGraph?.url).toContain(encodeURIComponent(sampleName));
+  });
+});


### PR DESCRIPTION
## What

Salvage of 7 smoke test files from parked branch `claude/feature/KAN-DRAFT-core-smoke-tests` (tip `5b60d1a`). The branch was parked on 2026-04-28 with 4 `test.failing` markers tied to two upstream lanes that have since landed on `main`:

| Marker | Owner | Status |
|---|---|---|
| `every repo declares a privacy indicator` | PR #278 (static-artifact privacy guard) | LANDED — promoted |
| `library.json does not contain hippo-harvest-assignment` | PR #278 | LANDED — promoted |
| `RepoCardMinimal exposes single-click anchor` | `claude/hotfix/repo-card-click-2026-04-28` | LANDED — promoted |
| `RepoCardMinimal exposes data-testid + data-repo-name` | card-click hotfix | LANDED — promoted |

After both hotfixes landed, the `.failing` markers started reporting "Failing test passed even though it was supposed to fail." Stripped them and moved each assertion into a new BASELINE-equivalent describe block (`PROMOTED (PR #278)`, `PROMOTED (card-click hotfix)`) so any future regression flips them red.

JIRA: [KAN-137](https://perditio.atlassian.net/browse/KAN-137)

## Files

- `tests/smoke/_fixtures.ts`
- `tests/smoke/ask-no-token-leak.smoke.test.tsx`
- `tests/smoke/homepage-renders.smoke.test.tsx`
- `tests/smoke/login-deterministic.smoke.test.ts`
- `tests/smoke/no-private-repos.smoke.test.ts`
- `tests/smoke/repo-card-navigates.smoke.test.tsx`
- `tests/smoke/repo-detail-renders.smoke.test.tsx`

## Overlap with KAN-136 (regression-tests salvage, PR #287)

Both salvages introduce some overlapping invariants. **Both kept** — they cover the same risks from different angles:

| Risk | KAN-136 (regression/) | KAN-137 (smoke/) |
|---|---|---|
| `/login` route absence | `loginRouteConsistency.test.tsx` — renders `StickyNavBar` and asserts no orphan auth link in the React tree (also asserts required NAV_LINKS hrefs are present) | `login-deterministic.smoke.test.ts` — filesystem scan of `src/app/` for any auth-route directory + multi-file source scan for auth hrefs |
| Repo card single-click navigation | `repoCardNavigation.test.tsx` (5 cases) | `repo-card-navigates.smoke.test.tsx` (2 cases, promoted) |
| Homepage renders cards | `homePageRendersCards.test.tsx` (2 cases) | `homepage-renders.smoke.test.tsx` |
| No private repos in static data | `privateRepoFilter.test.ts` (already on main) | `no-private-repos.smoke.test.ts` (4 cases incl. promoted) |

The two angles (React-render vs filesystem/source-scan) catch different regression classes and the cost of running both is negligible. If the duplication becomes painful later, the smoke/ versions are the cheaper-to-keep ones.

## Test gate

```
Test Suites: 42 passed, 42 total
Tests:       317 passed, 317 total
```

`npm run prebuild` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)