### PR TITLE
KAN-131: stop reflecting URL slug into <title> on /repo/[name] not-found

### DIFF
--- a/src/app/repo/[name]/page.tsx
+++ b/src/app/repo/[name]/page.tsx
@@ -192,6 +192,13 @@ const getRepoDetail = cache(async (name: string): Promise<RepoDetail | null> => 
   try {
     const provider = createDataProvider();
     const apiRepo = await provider.getRepo(name);
+    // Defense-in-depth: if the API surfaced a private repo via the wire field
+    // from reporium-api#450, treat it as not-found here. The API filter
+    // (#450) and validator (#278) already block private exposure; this guard
+    // is a belt-and-braces check at the page layer.
+    if (apiRepo !== null && (apiRepo as EnrichedRepo & { isPrivate?: boolean }).isPrivate === true) {
+      return null;
+    }
     if (apiRepo !== null && provider.mode === 'production') {
       // Provider returned data from API (or fell back internally)
       const repo = apiRepo;
@@ -340,8 +347,22 @@ interface RepoPageProps {
 export async function generateMetadata({ params }: RepoPageProps): Promise<Metadata> {
   const { name } = await params;
   const repo = await getRepoDetail(name);
-  const title = repo ? `${repo.owner}/${repo.name}` : name;
-  const description = repo?.readme_summary ?? repo?.description ?? `Explore ${title} on Reporium.`;
+
+  // KAN-131: when the repo cannot be resolved (private / not found / API error),
+  // do NOT echo the URL slug into title/og/twitter. The page renders notFound()
+  // for the body, but metadata is committed before that — historically this
+  // leaked attacker-controlled `name` into <title>${slug} | Reporium</title>.
+  // Return a generic, non-indexable metadata block instead.
+  if (!repo) {
+    return {
+      title: 'Repository not found | Reporium',
+      description: 'This repository could not be found.',
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = `${repo.owner}/${repo.name}`;
+  const description = repo.readme_summary ?? repo.description ?? `Explore ${title} on Reporium.`;
 
   return {
     title,

--- a/tests/regression/privacyMetadataReflection.test.tsx
+++ b/tests/regression/privacyMetadataReflection.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * privacyMetadataReflection.test.tsx
+ * --------------------------------------------------------------------------
+ * KAN-131 regression: /repo/[name] generateMetadata used to echo the URL
+ * `name` parameter into <title>${slug} | Reporium</title> when the repo
+ * lookup returned null. notFound() rendered the 404 body, but the metadata
+ * block (with the leaked / attacker-controlled slug) was already committed.
+ *
+ * This test pins the fix:
+ *   - generateMetadata({ params }) with a non-existent slug must NOT include
+ *     the slug anywhere in the returned Metadata object.
+ *   - It must mark robots noindex/nofollow.
+ *   - It must return a generic, non-reflective title.
+ *
+ * Filed for: KAN-131 ("Privacy status-code regression on /repo/[name] —
+ * HTTP 200 with reflected slug in title").
+ */
+
+// We mock the data provider so getRepoDetail() falls through to "null" without
+// hitting the local data/library.json. The page also imports filesystem code
+// at module top — that's fine, the readFileSync only fires inside the catch
+// path of getRepoDetail when the API path returned null.
+jest.mock('@/lib/dataProvider', () => ({
+  createDataProvider: () => ({
+    mode: 'production',
+    // Always return null — simulates "repo not in our index", which is what
+    // happens for any garbage slug a crawler / attacker probes.
+    getRepo: jest.fn().mockResolvedValue(null),
+  }),
+}));
+
+// Avoid hitting the real library.json in the local-fallback branch.
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    readFileSync: jest.fn(() => JSON.stringify({ repos: [] })),
+  };
+});
+
+describe('repo/[name] generateMetadata — KAN-131 regression', () => {
+  test('does NOT echo the URL slug into title when repo is missing', async () => {
+    const { generateMetadata } = await import('@/app/repo/[name]/page');
+
+    const slug = 'totally-bogus-xyz-attacker-controlled-99';
+    const meta = await generateMetadata({
+      params: Promise.resolve({ name: slug }),
+    });
+
+    // Title must be the generic not-found copy, not the reflected slug.
+    expect(typeof meta.title).toBe('string');
+    expect(meta.title).not.toContain(slug);
+    expect(meta.title).toBe('Repository not found | Reporium');
+  });
+
+  test('marks robots noindex/nofollow for missing repos', async () => {
+    const { generateMetadata } = await import('@/app/repo/[name]/page');
+
+    const meta = await generateMetadata({
+      params: Promise.resolve({ name: 'nonexistent-zzz999' }),
+    });
+
+    // robots can be a string or an object — assert the typed-object shape we set.
+    expect(meta.robots).toBeDefined();
+    expect(typeof meta.robots).toBe('object');
+    const robots = meta.robots as { index?: boolean; follow?: boolean };
+    expect(robots.index).toBe(false);
+    expect(robots.follow).toBe(false);
+  });
+
+  test('does not leak slug in description / openGraph / twitter for missing repos', async () => {
+    const { generateMetadata } = await import('@/app/repo/[name]/page');
+
+    const slug = 'leak-probe-xyz';
+    const meta = await generateMetadata({
+      params: Promise.resolve({ name: slug }),
+    });
+
+    const blob = JSON.stringify(meta);
+    expect(blob).not.toContain(slug);
+  });
+});


### PR DESCRIPTION
## Summary

JIRA: [KAN-131](https://perditio.atlassian.net/browse/KAN-131)

`generateMetadata` in `src/app/repo/[name]/page.tsx` used to echo the URL `name` parameter into `<title>${slug} | Reporium</title>` when `getRepoDetail()` returned null. `notFound()` rendered the 404 body, but the metadata block was already committed — so `/repo/<any-slug>/` returned HTTP 200 with a 44KB Next.js 404 body and a reflected slug in the title.

## What changed

- `generateMetadata` now returns generic, non-reflective metadata when repo is null:
  - `title: 'Repository not found | Reporium'`
  - `description: 'This repository could not be found.'`
  - `robots: { index: false, follow: false }`
- Added defense-in-depth `isPrivate` guard inside `getRepoDetail` to drop API responses where `isPrivate === true` (wire field from reporium-api#450).
- New regression test `tests/regression/privacyMetadataReflection.test.tsx` mocks the data provider to return null and asserts the slug never appears in the returned Metadata object.

## Test results (last 30 lines)

```
Test Suites: 37 passed, 37 total
Tests:       301 passed, 301 total
Snapshots:   0 total
Time:        5.081 s
Ran all test suites.
```

`npm run prebuild` and `npm run build` both succeeded; lint baseline unchanged (52 errors / 33 warnings — all pre-existing on origin/main).

## Severity

Low / cosmetic. API filter (reporium-api#450) and static-artifact validator (reporium#278) already block real private exposure. This closes the metadata-reflection edge.

Cross-references: KAN-66 is a separate bug on the same file (categories/builders losing).