### PR TITLE
KAN-138: site correctness — corpus label freshness, home JSON-LD, llms.txt taxonomy sync

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -40,7 +40,7 @@ Full API documentation: https://reporium-api-573778300586.us-central1.run.app/op
 Repository data includes:
 - Basic metadata: name, description, URL, owner stats
 - GitHub metrics: stars, forks, open issues, last updated
-- Enriched categories: AI taxonomy (28 categories)
+- Enriched categories: AI taxonomy (31 categories)
 - Tags: technology stack and domain tags
 - Relationships: dependency graphs and similar repo recommendations
 - Temporal data: commit trends, weekly activity, language breakdown

--- a/scripts/write-corpus-constants.cjs
+++ b/scripts/write-corpus-constants.cjs
@@ -44,25 +44,38 @@ fs.mkdirSync(path.dirname(OUT), { recursive: true });
 fs.writeFileSync(OUT, ts);
 console.log(`[corpus-constants] wrote ${OUT} (reposIndexed=${reposIndexed}, categories=${categories})`);
 
-// Also keep public/llms.txt in sync. The "Live Corpus" line drifts otherwise
-// (audit 2026-04-27 caught it at 1,825 vs actual 1,856). Replace just that
-// one line so any prose edits to the rest of the file are preserved.
+// Also keep public/llms.txt in sync. The "Live Corpus" line and "AI taxonomy
+// (X categories)" line both drift otherwise (audit 2026-04-27 caught the
+// corpus line at 1,825 vs actual 1,856; KAN-138 caught the taxonomy line at
+// 28 vs actual 31). Replace just those two lines so any prose edits to the
+// rest of the file are preserved.
 if (fs.existsSync(LLMS_TXT)) {
   const orig = fs.readFileSync(LLMS_TXT, 'utf-8');
-  // Match a line of the form: "**Live Corpus**: <num> AI development tools across <num> categories"
-  // Tolerate extra whitespace and an optional thousands separator.
-  const re = /\*\*Live Corpus\*\*:\s*[\d,]+\s+AI development tools across\s+\d+\s+categories/;
-  const replacement = `**Live Corpus**: ${reposIndexed.toLocaleString('en-US')} AI development tools across ${categories} categories`;
-  if (re.test(orig)) {
-    const next = orig.replace(re, replacement);
-    if (next !== orig) {
-      fs.writeFileSync(LLMS_TXT, next);
-      console.log(`[corpus-constants] updated ${LLMS_TXT} corpus line`);
-    } else {
-      console.log(`[corpus-constants] ${LLMS_TXT} already up to date`);
-    }
+  let next = orig;
+
+  // Match: "**Live Corpus**: <num> AI development tools across <num> categories"
+  const corpusRe = /\*\*Live Corpus\*\*:\s*[\d,]+\s+AI development tools across\s+\d+\s+categories/;
+  const corpusReplacement = `**Live Corpus**: ${reposIndexed.toLocaleString('en-US')} AI development tools across ${categories} categories`;
+  if (corpusRe.test(next)) {
+    next = next.replace(corpusRe, corpusReplacement);
   } else {
     console.warn(`[corpus-constants] ${LLMS_TXT} did not match expected "Live Corpus" pattern — left unchanged`);
+  }
+
+  // Match: "AI taxonomy (<num> categories)"
+  const taxonomyRe = /AI taxonomy \(\d+ categories\)/;
+  const taxonomyReplacement = `AI taxonomy (${categories} categories)`;
+  if (taxonomyRe.test(next)) {
+    next = next.replace(taxonomyRe, taxonomyReplacement);
+  } else {
+    console.warn(`[corpus-constants] ${LLMS_TXT} did not match expected "AI taxonomy (N categories)" pattern — left unchanged`);
+  }
+
+  if (next !== orig) {
+    fs.writeFileSync(LLMS_TXT, next);
+    console.log(`[corpus-constants] updated ${LLMS_TXT}`);
+  } else {
+    console.log(`[corpus-constants] ${LLMS_TXT} already up to date`);
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,10 @@
 import type { Metadata } from 'next';
 import { HomePageClient } from '@/components/HomePageClient';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
+import { REPOS_INDEXED_LABEL, CORPUS_STATS } from '@/lib/corpusConstants.generated';
+import { MARKETING_REPOS_LABEL } from '@/lib/corpusLabels';
 
-// Rounds down to the nearest 100 for marketing copy ("1,800+" not "1,825+").
-// Sourced from generated constants so meta stays fresh as corpus grows.
-function marketingCount(label: string): string {
-  const n = parseInt(label.replace(/,/g, ''), 10);
-  if (!Number.isFinite(n)) return label;
-  const rounded = Math.floor(n / 100) * 100;
-  return rounded.toLocaleString();
-}
-
-const description = `Search, filter, and explore ${marketingCount(REPOS_INDEXED_LABEL)}+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.`;
+const description = `Search, filter, and explore ${MARKETING_REPOS_LABEL}+ AI development tools with taxonomy filters, portfolio insights, and live repo intelligence.`;
 
 export const metadata: Metadata = {
   title: { absolute: 'Reporium' },
@@ -28,10 +20,63 @@ export const metadata: Metadata = {
   },
 };
 
+// JSON-LD for crawlers/agents — built from the same generated corpus constants
+// as the visible UI, so counts can never drift between the two surfaces.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': 'https://www.reporium.com/#website',
+      url: 'https://www.reporium.com',
+      name: 'Reporium',
+      description,
+      publisher: { '@id': 'https://www.reporium.com/#org' },
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: 'https://www.reporium.com/?q={search_term_string}',
+        },
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@type': 'Organization',
+      '@id': 'https://www.reporium.com/#org',
+      name: 'Reporium',
+      url: 'https://www.reporium.com',
+      sameAs: ['https://github.com/perditioinc/reporium'],
+    },
+    {
+      '@type': 'Dataset',
+      '@id': 'https://www.reporium.com/#corpus',
+      name: 'Reporium AI Dev Tools Corpus',
+      description: `${REPOS_INDEXED_LABEL} indexed open-source AI development tools across ${CORPUS_STATS.categories} categories.`,
+      url: 'https://www.reporium.com',
+      keywords: 'AI development tools, open-source repositories, knowledge graph',
+      isAccessibleForFree: true,
+      creator: { '@id': 'https://www.reporium.com/#org' },
+      variableMeasured: [
+        { '@type': 'PropertyValue', name: 'Repositories indexed', value: CORPUS_STATS.reposIndexed },
+        { '@type': 'PropertyValue', name: 'Categories', value: CORPUS_STATS.categories },
+      ],
+    },
+  ],
+};
+
 export default function Page() {
   return (
-    <ErrorBoundary>
-      <HomePageClient />
-    </ErrorBoundary>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
+      <ErrorBoundary>
+        <HomePageClient />
+      </ErrorBoundary>
+    </>
   );
 }

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -16,6 +16,7 @@ import { LoadingState } from '@/components/LoadingState';
 import { LoadingBanner } from '@/components/LoadingBanner';
 import { buildIntersectionMetrics } from '@/lib/buildTagMetrics';
 import { createDataProvider, SearchMode, LoadProgress } from '@/lib/dataProvider';
+import { reposIndexedLabel } from '@/lib/corpusLabels';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { CategoryFilterBar } from '@/components/CategoryFilterBar';
 import { CyberpunkBillboard } from '@/components/CyberpunkBillboard';
@@ -1290,7 +1291,7 @@ export function HomePageClient() {
                 <h4 className="text-zinc-300 font-medium mb-2">About</h4>
                 <ul className="space-y-1.5">
                   <li><span className="text-zinc-600">Built by perditioinc</span></li>
-                  <li><span className="text-zinc-600">{data?.repos.length ?? 0} repos indexed</span></li>
+                  <li><span className="text-zinc-600">{reposIndexedLabel(data?.repos.length)} repos indexed</span></li>
                   <li><span className="text-zinc-600">Next.js + FastAPI</span></li>
                 </ul>
               </div>

--- a/src/lib/corpusLabels.ts
+++ b/src/lib/corpusLabels.ts
@@ -1,0 +1,35 @@
+import { REPOS_INDEXED_LABEL } from './corpusConstants.generated';
+
+/**
+ * Returns the formatted repos-indexed count for footer/UI display.
+ *
+ * When `liveCount` is null/undefined (initial render before data loads, or
+ * provider failure), falls back to the build-time `REPOS_INDEXED_LABEL`
+ * constant so the visible label never reads "0" while the corpus is non-zero.
+ *
+ * Audit ref S2 (2026-04-27): footer "0 repos indexed" while API reports 1,856.
+ */
+export function reposIndexedLabel(liveCount: number | null | undefined): string {
+  if (liveCount == null) return REPOS_INDEXED_LABEL;
+  return liveCount.toLocaleString('en-US');
+}
+
+/**
+ * Rounds a corpus-count label down to the nearest 100 for marketing copy.
+ * Example: "1,856" → "1,800" (used in metadata description as "1,800+ AI dev tools").
+ *
+ * Audit ref S3 (2026-04-27): meta description must not lag the corpus
+ * (was hardcoded "1,400+" while corpus is 1,856).
+ */
+export function marketingCount(label: string): string {
+  const n = parseInt(label.replace(/,/g, ''), 10);
+  if (!Number.isFinite(n)) return label;
+  const rounded = Math.floor(n / 100) * 100;
+  return rounded.toLocaleString('en-US');
+}
+
+/**
+ * The marketing-rounded corpus count derived from the generated constant.
+ * Single source of truth for any "1,800+" / "X+ AI dev tools" copy.
+ */
+export const MARKETING_REPOS_LABEL = marketingCount(REPOS_INDEXED_LABEL);

--- a/tests/unit/corpusLabels.test.ts
+++ b/tests/unit/corpusLabels.test.ts
@@ -1,0 +1,69 @@
+import { reposIndexedLabel, marketingCount, MARKETING_REPOS_LABEL } from '@/lib/corpusLabels';
+import { REPOS_INDEXED_LABEL, CORPUS_STATS } from '@/lib/corpusConstants.generated';
+
+describe('reposIndexedLabel', () => {
+  it('falls back to REPOS_INDEXED_LABEL when live count is null', () => {
+    expect(reposIndexedLabel(null)).toBe(REPOS_INDEXED_LABEL);
+  });
+
+  it('falls back to REPOS_INDEXED_LABEL when live count is undefined', () => {
+    expect(reposIndexedLabel(undefined)).toBe(REPOS_INDEXED_LABEL);
+  });
+
+  it('never returns "0" while corpus is non-zero (audit S2 fix)', () => {
+    // The fallback path: data?.repos.length === undefined → must not render "0"
+    // unless CORPUS_STATS.reposIndexed is genuinely 0.
+    expect(CORPUS_STATS.reposIndexed).toBeGreaterThan(0);
+    expect(reposIndexedLabel(null)).not.toBe('0');
+    expect(reposIndexedLabel(undefined)).not.toBe('0');
+  });
+
+  it('formats live count with thousands separator', () => {
+    expect(reposIndexedLabel(1856)).toBe('1,856');
+    expect(reposIndexedLabel(42)).toBe('42');
+  });
+
+  it('passes through 0 when corpus is genuinely zero', () => {
+    // The label is allowed to read "0" only when the live count is explicitly 0,
+    // not when it's null/undefined. This protects against the fallback masking
+    // a real "no data" state if it ever becomes accurate.
+    expect(reposIndexedLabel(0)).toBe('0');
+  });
+});
+
+describe('marketingCount', () => {
+  it('rounds down to the nearest 100', () => {
+    expect(marketingCount('1,856')).toBe('1,800');
+    expect(marketingCount('1,825')).toBe('1,800');
+    expect(marketingCount('1,400')).toBe('1,400');
+    expect(marketingCount('999')).toBe('900');
+  });
+
+  it('handles labels with commas', () => {
+    expect(marketingCount('12,345')).toBe('12,300');
+  });
+
+  it('returns the label unchanged when not parseable', () => {
+    expect(marketingCount('not-a-number')).toBe('not-a-number');
+  });
+});
+
+describe('MARKETING_REPOS_LABEL', () => {
+  it('is derived from the generated REPOS_INDEXED_LABEL', () => {
+    expect(MARKETING_REPOS_LABEL).toBe(marketingCount(REPOS_INDEXED_LABEL));
+  });
+
+  it('does not contain stale "1,400" when corpus has grown past it (audit S3 fix)', () => {
+    // The site previously hardcoded "1,400+" in the meta description while
+    // the corpus had grown to 1,856. The marketing label must always be at
+    // least as fresh as the generated corpus constant.
+    if (CORPUS_STATS.reposIndexed >= 1500) {
+      expect(MARKETING_REPOS_LABEL).not.toBe('1,400');
+    }
+  });
+
+  it('rounds-down to a multiple of 100', () => {
+    const n = parseInt(MARKETING_REPOS_LABEL.replace(/,/g, ''), 10);
+    expect(n % 100).toBe(0);
+  });
+});

--- a/tests/unit/homeMetadata.test.ts
+++ b/tests/unit/homeMetadata.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ *
+ * Server-component metadata test. Runs in the Node environment because the
+ * page module imports server-only Next types and our Metadata object is
+ * computed at module load.
+ */
+import { metadata } from '@/app/page';
+import { CORPUS_STATS, REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
+import { MARKETING_REPOS_LABEL } from '@/lib/corpusLabels';
+
+describe('home page metadata', () => {
+  it('description references the marketing-rounded corpus label', () => {
+    expect(metadata.description).toContain(`${MARKETING_REPOS_LABEL}+ AI development tools`);
+  });
+
+  it('does not contain stale "1,400+" copy when corpus is past 1,400', () => {
+    // Audit S3 (2026-04-27): meta description was hardcoded "1,400+" while
+    // corpus had grown to 1,856. Guard against the regression.
+    if (CORPUS_STATS.reposIndexed >= 1500) {
+      expect(metadata.description).not.toMatch(/\b1,400\+/);
+    }
+  });
+
+  it('marketing label is rounded down to a multiple of 100', () => {
+    const n = parseInt(MARKETING_REPOS_LABEL.replace(/,/g, ''), 10);
+    expect(n % 100).toBe(0);
+    expect(n).toBeLessThanOrEqual(parseInt(REPOS_INDEXED_LABEL.replace(/,/g, ''), 10));
+  });
+
+  it('openGraph and twitter descriptions match the meta description', () => {
+    expect(metadata.openGraph?.description).toBe(metadata.description);
+    expect(metadata.twitter?.description).toBe(metadata.description);
+  });
+});

--- a/tests/unit/llmsTxt.test.ts
+++ b/tests/unit/llmsTxt.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { CORPUS_STATS, REPOS_INDEXED_LABEL } from '@/lib/corpusConstants.generated';
+
+describe('public/llms.txt freshness', () => {
+  const llmsPath = join(process.cwd(), 'public', 'llms.txt');
+  const text = readFileSync(llmsPath, 'utf-8');
+
+  it('embeds the current REPOS_INDEXED_LABEL', () => {
+    // Catches the same drift the audit flagged on 2026-04-27 — llms.txt
+    // hardcoded "1,825 AI development tools" while the corpus had grown to 1,856.
+    expect(text).toContain(REPOS_INDEXED_LABEL);
+  });
+
+  it('embeds the current categories count', () => {
+    expect(text).toMatch(new RegExp(`across ${CORPUS_STATS.categories} categories`));
+    expect(text).toMatch(new RegExp(`AI taxonomy \\(${CORPUS_STATS.categories} categories\\)`));
+  });
+
+  it('does not contain unsubstituted template placeholders', () => {
+    // If the template was not run through write-corpus-constants.cjs, we'd
+    // see literal {{REPOS_INDEXED_LABEL}} etc. — guard against that.
+    expect(text).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it('does not contain stale "1,825" if corpus has moved past it', () => {
+    if (CORPUS_STATS.reposIndexed > 1825) {
+      expect(text).not.toMatch(/\b1,825 AI/);
+    }
+  });
+});


### PR DESCRIPTION
## What

Closes [KAN-87](https://perditio.atlassian.net/browse/KAN-87).

Salvage of uncommitted edits from `.claude/worktrees/site-correctness` onto a fresh branch off `origin/main`. The site-correctness lane was branched off `57901f7` (now 10 commits behind main); a verbatim cherry-pick would have re-introduced regressions that PR #228 / #278 already fixed upstream. This PR takes the substantive changes only.

JIRA: [KAN-138](https://perditio.atlassian.net/browse/KAN-138)

## Changes

| # | File | What | Audit ref |
|---|---|---|---|
| 1 | `src/components/HomePageClient.tsx:1294` | Footer "0 repos indexed" fix — replace `data?.repos.length ?? 0` with `reposIndexedLabel(data?.repos.length)` so initial paint and provider-failure paths fall back to build-time `REPOS_INDEXED_LABEL`. **KAN-87 root cause.** | S2 |
| 2 | `src/app/page.tsx` | Home-page JSON-LD: 3 `@graph` entries (WebSite + SearchAction, Organization, Dataset). Variables pulled from `CORPUS_STATS` so SEO/agent surfaces and UI cannot drift. | S10 / S1 partial |
| 3 | `src/lib/corpusLabels.ts` (new) | Extracts `reposIndexedLabel`, `marketingCount`, `MARKETING_REPOS_LABEL` to a single source of truth. | S3 |
| 4 | `scripts/write-corpus-constants.cjs` + `public/llms.txt` | Extends in-place regex sync to also rewrite the "AI taxonomy (N categories)" line. Was stale at "(28 categories)" while corpus has 31. | S10 |
| 5 | `tests/unit/{corpusLabels,homeMetadata,llmsTxt}.test.ts` (new) | +20 unit cases across 3 files. | — |

## Deliberately NOT salvaged from the source worktree

- The full `write-corpus-constants.cjs` replacement (would have removed the `.well-known/ai-plugin.json` sync that was added to main after the lane branched).
- `scripts/templates/llms.txt.template` (template approach is redundant with main's in-place regex sync — same outcome, less moving parts).
- `public/sitemap.xml` (auto-generated, today's date drift).

## Test gate

```
Test Suites: 39 passed, 39 total
Tests:       317 passed, 317 total
```

`npm run prebuild` clean. `tsc --noEmit` clean. **`npm run build` SUCCEEDS** — main now uses managed output by default per ADR-005, so the static-export `/repo/[name]` timeout that blocked the original branch no longer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)