### PR TITLE
KAN-139: AskBudgetIndicator — always-on client budget meter

### DIFF
--- a/src/components/AskBar.tsx
+++ b/src/components/AskBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
+import { AskBudgetIndicator } from './AskBudgetIndicator';
 
 // ---------------------------------------------------------------------------
 // Session ID management (KAN-158/KAN-159)
@@ -340,6 +341,11 @@ export function AskBar({ apiUrl }: AskBarProps) {
             'Ask'
           )}
         </button>
+      </div>
+
+      {/* Persistent client-side budget meter (Design Phase 1 — P2). */}
+      <div className="flex justify-end">
+        <AskBudgetIndicator className="w-40" />
       </div>
 
       {/* Loading status */}

--- a/src/components/AskBudgetIndicator.tsx
+++ b/src/components/AskBudgetIndicator.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Mirrors the constants in AskBar.tsx and StickyAskBar.tsx. Keeping them
+// duplicated (rather than imported) so this component stays a pure read-only
+// display with no coupling to the components that *write* the counter.
+const RATE_KEY = 'reporium_ask_timestamps';
+const RATE_PER_MIN = 10;
+const RATE_PER_DAY = 100;
+const REFRESH_MS = 10_000;
+
+const AMBER_MIN_THRESHOLD = Math.ceil(RATE_PER_MIN * 0.7);
+const AMBER_DAY_THRESHOLD = Math.ceil(RATE_PER_DAY * 0.7);
+
+interface BudgetState {
+  minuteCount: number;
+  dayCount: number;
+}
+
+function readBudget(): BudgetState {
+  if (typeof window === 'undefined') return { minuteCount: 0, dayCount: 0 };
+  try {
+    const raw = window.localStorage.getItem(RATE_KEY);
+    const timestamps: number[] = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(timestamps)) return { minuteCount: 0, dayCount: 0 };
+    const now = Date.now();
+    const oneMinAgo = now - 60_000;
+    const oneDayAgo = now - 86_400_000;
+    const minuteCount = timestamps.filter((t) => typeof t === 'number' && t > oneMinAgo).length;
+    const dayCount = timestamps.filter((t) => typeof t === 'number' && t > oneDayAgo).length;
+    return { minuteCount, dayCount };
+  } catch {
+    return { minuteCount: 0, dayCount: 0 };
+  }
+}
+
+function severityClass(count: number, cap: number, amberAt: number): string {
+  if (count >= cap) return 'text-red-400';
+  if (count >= amberAt) return 'text-amber-400';
+  return 'text-zinc-500';
+}
+
+function barColor(minuteCount: number, dayCount: number): string {
+  if (minuteCount >= RATE_PER_MIN || dayCount >= RATE_PER_DAY) return 'bg-red-500/70';
+  if (minuteCount >= AMBER_MIN_THRESHOLD || dayCount >= AMBER_DAY_THRESHOLD) return 'bg-amber-500/70';
+  return 'bg-zinc-600/60';
+}
+
+export interface AskBudgetIndicatorProps {
+  /** Optional className for the wrapper. */
+  className?: string;
+  /** Compact variant — drops the trailing "asks" word so it fits a status strip. */
+  compact?: boolean;
+}
+
+/**
+ * Always-on display of the client-side Ask budget (10/min · 100/day).
+ *
+ * Read-only: reads `localStorage['reporium_ask_timestamps']`, the same key
+ * that AskBar and StickyAskBar already write. Does not enforce or modify
+ * the budget. Refreshes on mount and every 10s.
+ *
+ * Design Principle P2 — "Show the budget, don't just enforce it."
+ * See .audit/2026-04-24/reporium-ask-faq-design-memo.md §3, §10.1.
+ */
+export function AskBudgetIndicator({ className, compact = false }: AskBudgetIndicatorProps) {
+  // Initial render is the SSR-safe zero state; a useEffect hydrates the real
+  // value after mount so server and client markup agree on first paint.
+  const [{ minuteCount, dayCount }, setBudget] = useState<BudgetState>({
+    minuteCount: 0,
+    dayCount: 0,
+  });
+
+  useEffect(() => {
+    setBudget(readBudget());
+    const id = window.setInterval(() => setBudget(readBudget()), REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const minutePct = Math.min(100, (minuteCount / RATE_PER_MIN) * 100);
+  const dayPct = Math.min(100, (dayCount / RATE_PER_DAY) * 100);
+  const fillPct = Math.max(minutePct, dayPct);
+
+  const minuteClass = severityClass(minuteCount, RATE_PER_MIN, AMBER_MIN_THRESHOLD);
+  const dayClass = severityClass(dayCount, RATE_PER_DAY, AMBER_DAY_THRESHOLD);
+  const fillClass = barColor(minuteCount, dayCount);
+
+  const tail = compact ? '' : ' asks';
+  const ariaLabel =
+    `Ask budget: ${minuteCount} of ${RATE_PER_MIN} this minute, ` +
+    `${dayCount} of ${RATE_PER_DAY} today.`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className={`select-none ${className ?? ''}`.trim()}
+      data-testid="ask-budget-indicator"
+    >
+      <div className="text-[11px] tabular-nums tracking-wide text-zinc-500">
+        <span className={minuteClass}>{minuteCount}/{RATE_PER_MIN}</span>
+        <span className="mx-1.5 text-zinc-700">·</span>
+        <span className={dayClass}>{dayCount}/{RATE_PER_DAY}{tail}</span>
+      </div>
+      <div className="mt-1 h-0.5 w-full overflow-hidden rounded-full bg-zinc-800/80">
+        <div
+          className={`h-full ${fillClass} transition-[width] duration-300 ease-out`}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default AskBudgetIndicator;

--- a/src/components/StickyAskBar.tsx
+++ b/src/components/StickyAskBar.tsx
@@ -17,6 +17,7 @@ import {
   sourceAnchorId,
 } from '@/lib/askCitations';
 import { CitationHoverCard, type CitationSource } from '@/components/CitationHoverCard';
+import { AskBudgetIndicator } from './AskBudgetIndicator';
 
 // ---------------------------------------------------------------------------
 // Memoized markdown renderer — only re-parses when answer content changes.
@@ -1818,6 +1819,11 @@ export function StickyAskBar() {
               <p className="text-sm text-zinc-300 italic">&ldquo;{askedQuestion}&rdquo;</p>
             </div>
           )}
+
+          {/* Persistent client-side budget meter (Design Phase 1 — P2). */}
+          <div className="flex justify-end pt-1">
+            <AskBudgetIndicator className="w-44" compact />
+          </div>
 
           {/* Rate limit warning */}
           {(nearMinuteLimit || nearDayLimit) && !atMinuteLimit && !atDayLimit && (

--- a/tests/AskBudgetIndicator.test.tsx
+++ b/tests/AskBudgetIndicator.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { AskBudgetIndicator } from '@/components/AskBudgetIndicator';
+
+const RATE_KEY = 'reporium_ask_timestamps';
+
+function seedTimestamps(count: number, ageMs = 5_000) {
+  const now = Date.now();
+  const timestamps = Array.from({ length: count }, (_, i) => now - ageMs - i * 10);
+  window.localStorage.setItem(RATE_KEY, JSON.stringify(timestamps));
+}
+
+describe('AskBudgetIndicator', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('renders zero budget when storage is empty', () => {
+    render(<AskBudgetIndicator />);
+    const indicator = screen.getByTestId('ask-budget-indicator');
+    expect(indicator.textContent).toContain('0/10');
+    expect(indicator.textContent).toContain('0/100');
+  });
+
+  test('reads recent timestamps and shows current minute and day counts', async () => {
+    seedTimestamps(3);
+    render(<AskBudgetIndicator />);
+    const indicator = await screen.findByTestId('ask-budget-indicator');
+    // Effect runs after mount; allow a microtask for state to flush.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(indicator.textContent).toContain('3/10');
+    expect(indicator.textContent).toContain('3/100');
+  });
+
+  test('exposes an aria-live status with the budget summary', () => {
+    seedTimestamps(2);
+    render(<AskBudgetIndicator />);
+    const indicator = screen.getByTestId('ask-budget-indicator');
+    expect(indicator.getAttribute('role')).toBe('status');
+    expect(indicator.getAttribute('aria-live')).toBe('polite');
+    expect(indicator.getAttribute('aria-label')).toMatch(/Ask budget/);
+  });
+
+  test('handles malformed localStorage gracefully', () => {
+    window.localStorage.setItem(RATE_KEY, 'not json');
+    render(<AskBudgetIndicator />);
+    const indicator = screen.getByTestId('ask-budget-indicator');
+    expect(indicator.textContent).toContain('0/10');
+  });
+
+  test('compact variant drops the trailing label', () => {
+    render(<AskBudgetIndicator compact />);
+    const indicator = screen.getByTestId('ask-budget-indicator');
+    expect(indicator.textContent).not.toMatch(/asks/);
+  });
+
+  test('refreshes on the polling interval', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<AskBudgetIndicator />);
+      const indicator = screen.getByTestId('ask-budget-indicator');
+      expect(indicator.textContent).toContain('0/10');
+
+      seedTimestamps(5);
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+      expect(indicator.textContent).toContain('5/10');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## What

Salvage of uncommitted edits from `.claude/worktrees/faq-ask-followup` (committed tip `8224e3a` was just a data-refresh; all the new work was uncommitted). Adds an always-on client-side Ask budget meter (10/min · 100/day) to `AskBar` and `StickyAskBar`.

JIRA: [KAN-139](https://perditio.atlassian.net/browse/KAN-139)

Implements Design Principle P2 from `.audit/2026-04-24/reporium-ask-faq-design-memo.md` §3, §10.1 — "Show the budget, don't just enforce it." Today users can't see how close they are to their per-minute or per-day cap until they hit it.

## Files

| File | Status | Notes |
|---|---|---|
| `src/components/AskBudgetIndicator.tsx` | new (117 LOC) | Read-only — reads the `reporium_ask_timestamps` localStorage key that `AskBar` / `StickyAskBar` already write. Severity colors at 70% (amber) / 100% (red). SSR-safe initial render; `useEffect` hydrates real value and polls every 10s. |
| `src/components/AskBar.tsx` | one-line import + one-line mount | Mounts `<AskBudgetIndicator className="w-40" />` after the Ask submit button. |
| `src/components/StickyAskBar.tsx` | one-line import + one-line mount | Mounts compact variant inside the existing status strip. |
| `tests/AskBudgetIndicator.test.tsx` | new (6 cases) | empty storage, recent-timestamp counts, aria-live status, malformed JSON, compact variant, polling interval (fake timers). |

## Why this is salvageable cleanly

P3 polish, no backend dep, no API contract change. The component is intentionally decoupled from the components that *write* the counter (constants are duplicated rather than imported) so it stays a pure read-only display.

## Test gate

```
Test Suites: 37 passed, 37 total
Tests:       304 passed, 304 total
```

`npm run prebuild` clean. `tsc --noEmit` clean. `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)