### PR TITLE
KAN-132: validate-privacy must cover data/library.json

### DIFF
--- a/scripts/validate-privacy.ts
+++ b/scripts/validate-privacy.ts
@@ -23,9 +23,20 @@ import {
   type PrivacyEvaluable,
 } from './lib/privacy-filter';
 
+// KAN-132: cover BOTH static-export source paths.
+//   - public/data/library.json: served as a static asset, ships in the
+//     Vercel/static build output. This is the primary leak surface.
+//   - public/data/owned.json:  the owned-repos sidecar, same asset path.
+//   - data/library.json:        synthesized by scripts/sync-data-dir.cjs
+//     during prebuild and read at runtime by generateStaticParams /
+//     getRepoDetail's local-fallback path. Today the sync runs AFTER
+//     this validator, so the two artifacts are identical at validation
+//     time, but a future re-ordering of build steps would silently
+//     bypass the gate. Validating both pins the contract.
 const FILES_TO_CHECK = [
   path.join(process.cwd(), 'public', 'data', 'library.json'),
   path.join(process.cwd(), 'public', 'data', 'owned.json'),
+  path.join(process.cwd(), 'data', 'library.json'),
 ];
 
 let hadFailure = false;

--- a/tests/unit/validatePrivacy.scope.test.ts
+++ b/tests/unit/validatePrivacy.scope.test.ts
@@ -1,0 +1,59 @@
+/**
+ * validatePrivacy.scope.test.ts
+ * --------------------------------------------------------------------------
+ * KAN-132: pin the FILES_TO_CHECK contract for scripts/validate-privacy.ts.
+ *
+ * Background:
+ *   - public/data/library.json is the served static asset.
+ *   - data/library.json is synthesized by scripts/sync-data-dir.cjs during
+ *     prebuild and read at runtime by generateStaticParams +
+ *     getRepoDetail's local-fallback path.
+ *   - Today the sync step runs AFTER validate-privacy in `npm run prebuild`,
+ *     so both files are identical at validation time. But a future
+ *     re-ordering of build steps would silently bypass the gate.
+ *
+ * This test simply verifies the validator's source declares BOTH paths.
+ * It is intentionally a string-level assertion against the script source —
+ * the validator is a CLI runner that calls process.exit(), which is awkward
+ * to invoke from jest without spawning a child process. Pinning the source
+ * contract is sufficient and fast.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const VALIDATOR_PATH = path.join(
+  process.cwd(),
+  'scripts',
+  'validate-privacy.ts',
+);
+
+describe('scripts/validate-privacy.ts FILES_TO_CHECK scope — KAN-132', () => {
+  const source = fs.readFileSync(VALIDATOR_PATH, 'utf-8');
+
+  test('covers public/data/library.json (the served static asset)', () => {
+    expect(source).toMatch(/path\.join\(process\.cwd\(\),\s*['"]public['"],\s*['"]data['"],\s*['"]library\.json['"]\)/);
+  });
+
+  test('covers public/data/owned.json (the owned-repos sidecar)', () => {
+    expect(source).toMatch(/path\.join\(process\.cwd\(\),\s*['"]public['"],\s*['"]data['"],\s*['"]owned\.json['"]\)/);
+  });
+
+  test('covers data/library.json (the prebuild-synced runtime copy)', () => {
+    // This is the KAN-132 addition. The path SHOULD be present.
+    expect(source).toMatch(/path\.join\(process\.cwd\(\),\s*['"]data['"],\s*['"]library\.json['"]\)/);
+  });
+
+  test('FILES_TO_CHECK array contains exactly the three known paths', () => {
+    // Defensive: if someone adds another artifact, this test will flag it
+    // and force the contract owner to update the regression set.
+    const arrayMatch = source.match(/const FILES_TO_CHECK = \[([\s\S]*?)\];/);
+    expect(arrayMatch).not.toBeNull();
+    const body = arrayMatch![1];
+    const pathLines = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('path.join'));
+    expect(pathLines.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

JIRA: [KAN-132](https://perditio.atlassian.net/browse/KAN-132)

`scripts/validate-privacy.ts` was checking `public/data/library.json` and `public/data/owned.json` only. But `data/library.json` is also read at runtime by `generateStaticParams` and the local-fallback path of `getRepoDetail`.

Today the two are kept in sync by `scripts/sync-data-dir.cjs` in the prebuild AFTER the validator runs, so they're identical at validation time. But a future re-ordering of build steps would silently bypass the privacy gate on the runtime copy. Pinning the contract closes a latent risk.

## What changed

- `scripts/validate-privacy.ts`: add `path.join(process.cwd(), 'data', 'library.json')` to `FILES_TO_CHECK`.
- `tests/unit/validatePrivacy.scope.test.ts`: pin the contract and flag if future changes alter the set.

## Verified locally

```
[validate-privacy] OK  — public/data/library.json (1861 repos)
[validate-privacy] OK  — public/data/owned.json (18 repos)
[validate-privacy] OK  — data/library.json (1861 repos)
[validate-privacy] all artifacts pass privacy gates.
```

## Test results (last lines)

```
Test Suites: 37 passed, 37 total
Tests:       302 passed, 302 total
Snapshots:   0 total
Time:        3.209 s
Ran all test suites.
```

`npm run build` succeeded; lint baseline unchanged (52 errors / 33 warnings — all pre-existing on origin/main).