### PR TITLE
fix(faq): drop cache:'force-cache' so the FAQ tree updates after each refresh

### DIFF
--- a/src/components/FAQPanel.tsx
+++ b/src/components/FAQPanel.tsx
@@ -169,7 +169,11 @@ export function FAQPanel() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/data/faq.json', { cache: 'force-cache' })
+    // Default cache (respect Cache-Control + revalidate via ETag) is what we want.
+    // 'force-cache' would hold the browser's cached response for the full max-age
+    // (3600s) without revalidation, so visitors would see a stale tree for an hour
+    // after each refresh-data.yml run. The CDN already handles efficiency upstream.
+    fetch('/data/faq.json')
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();


### PR DESCRIPTION
## Bug

FAQPanel's fetch used \`{ cache: 'force-cache' }\`, which tells the browser to use any cached response without freshness checks. Combined with the CDN's \`cache-control: public, max-age=3600\`, visitors saw the *previous* FAQ tree for up to an hour after each \`refresh-data.yml\` run.

## How it surfaced

Tonight after refresh-data.yml run [25201207202](https://github.com/perditioinc/reporium/actions/runs/25201207202) successfully shipped the 10-section / 100-answer \`faq.json\` to prod:

- Direct fetch with \`{ cache: 'no-store' }\` returned the new payload (\`generatedAt: 2026-05-01T05:01:43Z\`, 100 answers)
- FAQPanel still rendered the loading skeleton because its own \`force-cache\` fetch returned the prior 16-question payload from browser cache without revalidation
- Vercel's \`x-vercel-cache: HIT\` confirmed the CDN had the new asset; only the browser's HTTP cache was stale

## Fix

Remove the option entirely. Default \`fetch()\` respects \`Cache-Control\` AND revalidates with the ETag — browser still benefits from caching, picks up new versions immediately. The CDN's \`s-maxage=86400\` handles upstream efficiency; the browser doesn't need to amplify it.

\`\`\`diff
- fetch('/data/faq.json', { cache: 'force-cache' })
+ fetch('/data/faq.json')
\`\`\`

## Test

- jest 305/305 ✓
- Manual verification post-merge: load /faq, confirm 10 sections × 10 cards render, ~38 with answers + ~62 "Answer unavailable" pending the next refresh fill-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)