### PR TITLE
KAN-150: wire @next/bundle-analyzer + drop staticPageGenerationTimeout

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { withSentryConfig } = require('@sentry/nextjs');
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 // ADR-005: deployment-target conditional rendering.
 // - REPORIUM_DEPLOY_TARGET=github-pages keeps full static export for forks.
@@ -12,10 +15,6 @@ const IS_STATIC_EXPORT = DEPLOY_TARGET === 'github-pages';
 const nextConfig = {
   output: IS_STATIC_EXPORT ? 'export' : undefined,
   trailingSlash: true,
-
-  // Retained for the github-pages target. The Vercel target no longer renders
-  // the full repo corpus at build time, so this is now a defensive fence.
-  staticPageGenerationTimeout: 240,
 
   // Explicitly expose NEXT_PUBLIC_* vars. Sentry's process polyfill can prevent
   // the default build-time inlining of `process.env.NEXT_PUBLIC_*`, leaving
@@ -46,16 +45,18 @@ const nextConfig = {
   },
 }
 
-module.exports = withSentryConfig(nextConfig, {
-  // Suppress Sentry build-time logs (sourcemap upload etc.)
-  silent: true,
-  // org/project intentionally undefined here — set via SENTRY_ORG / SENTRY_PROJECT
-  // env vars in Vercel / Cloud Run once the DSN is provisioned.
-  org: undefined,
-  project: undefined,
-  // Static export: no server-side Sentry route instrumentation needed.
-  // Re-enable for the Vercel target in a follow-up if server tracing is desired.
-  autoInstrumentServerFunctions: false,
-  // Disable source map upload (no auth token configured yet)
-  disableSourceMapUpload: true,
-});
+module.exports = withBundleAnalyzer(
+  withSentryConfig(nextConfig, {
+    // Suppress Sentry build-time logs (sourcemap upload etc.)
+    silent: true,
+    // org/project intentionally undefined here — set via SENTRY_ORG / SENTRY_PROJECT
+    // env vars in Vercel / Cloud Run once the DSN is provisioned.
+    org: undefined,
+    project: undefined,
+    // Static export: no server-side Sentry route instrumentation needed.
+    // Re-enable for the Vercel target in a follow-up if server tracing is desired.
+    autoInstrumentServerFunctions: false,
+    // Disable source map upload (no auth token configured yet)
+    disableSourceMapUpload: true,
+  }),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "three": "^0.183.2"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.4",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -692,6 +693,16 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2370,6 +2381,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.4.tgz",
+      "integrity": "sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
@@ -3069,6 +3090,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.6.0",
@@ -5479,6 +5507,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -6620,6 +6661,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6821,6 +6869,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -8422,6 +8477,22 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9219,6 +9290,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -12291,6 +12372,16 @@
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12694,6 +12785,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -14104,6 +14205,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14838,6 +14954,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -15537,6 +15663,66 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prebuild": "npm run validate:privacy && node scripts/write-corpus-constants.cjs && node scripts/sync-data-dir.cjs",
     "refresh-stats": "node scripts/write-corpus-constants.cjs",
     "build": "npx tsx scripts/generate-sitemap.ts && next build",
+    "build:analyze": "npx tsx scripts/generate-sitemap.ts && node -e \"process.env.ANALYZE='true'; require('child_process').execSync('next build --webpack', { stdio: 'inherit', env: process.env })\"",
     "postbuild": "node scripts/strip-large-static-json.cjs",
     "sitemap": "npx tsx scripts/generate-sitemap.ts",
     "generate": "npx tsx scripts/fetch-library.ts",
@@ -54,6 +55,7 @@
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.4",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

Two small `next.config.js` cleanups per ADR-005 follow-up #7. JIRA: [KAN-150](https://perditio.atlassian.net/browse/KAN-150). Closes more of #248.

### (1) Wire `@next/bundle-analyzer`

`@next/bundle-analyzer` was not installed and not wired — `ANALYZE=true npm run build` has been a no-op since the audit flagged it. This PR:

- Adds `@next/bundle-analyzer@^16.2.4` (matches `next@16.2.4`) as a `devDependency`.
- Wraps `module.exports` with `withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' })`, outermost over the existing `withSentryConfig` wrapper.
- Adds a `build:analyze` script that passes `--webpack` to `next build`. **Why a separate script:** Next 16 defaults to Turbopack, which is incompatible with `@next/bundle-analyzer` (webpack-only). The official runtime guidance from the analyzer itself is "pass the `--webpack` flag to `next build`". The main `build` script is untouched.

Verified output:
```
.next/analyze/client.html    552 KB
.next/analyze/edge.html      275 KB
.next/analyze/nodejs.html    798 KB
```

### (2) Drop `staticPageGenerationTimeout: 240`

PR #274 (2026-04-26) set `staticPageGenerationTimeout: 240` as a defensive fence after `/repo/[name]` builds were hanging at the 240s mark. PR #280 (2026-04-28) closed the underlying cause by adding `TOP_N_REPOS_FOR_BUILD = 250` bounded prerender. Per ADR-005 follow-up item #7: drop back to the Next.js default of 60s.

Build wall-time is well under 60s/page — the fence is no longer earning its keep.

## Validation

| Check | Result |
| --- | --- |
| `node -e "require('./next.config.js')"` | OK (Sentry deprecation warning is pre-existing) |
| `npm run type-check` | Clean |
| `npm run lint` | 52 pre-existing errors, 33 warnings — none from this change |
| `npm test` | 38 suites / 305 tests pass (baseline 36/298 — suite has grown) |
| `npm run build` (no analyze) | 1m02s, 383 pages, no `/repo/[name]` hangs |
| `npm run build:analyze` | 1m07s, 383 pages, all 3 HTML reports produced |
| Build wall-time vs KAN-122 baseline (1m18s) | Faster (-16s) |
| `git check-ignore .next/analyze/client.html` | Gitignored via `.next/` |

## Test plan

- [x] `next.config.js` loads without throwing
- [x] `npm run build` succeeds and stays well under 60s/page (default timeout)
- [x] `npm run build:analyze` produces `.next/analyze/{client,edge,nodejs}.html`
- [x] `.next/analyze/` is gitignored (no build artifacts committed)
- [x] Type-check + tests pass
- [ ] Vercel preview deploys cleanly post-merge