### PR TITLE
KAN-153: implement KAN-121 mobile gate on HomeGraphWidget

### DIFF
--- a/src/components/HomeGraphWidget.tsx
+++ b/src/components/HomeGraphWidget.tsx
@@ -7,12 +7,14 @@
  */
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import type { GraphEdge, NodeMeta } from '@/components/KnowledgeGraph3D';
 import { loadGraphDataset } from '@/lib/graphData';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { GraphFallbackPanel } from '@/components/GraphFallbackPanel';
+import { useIsMobile } from '@/lib/useIsMobile';
 
 // Dynamic import — Three.js doesn't work with SSR/static export
 const KnowledgeGraph = dynamic(
@@ -31,6 +33,7 @@ interface HomeGraphWidgetProps {
 
 export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGraphWidgetProps = {}) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [edges, setEdges] = useState<GraphEdge[]>([]);
@@ -43,7 +46,10 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
   // Defer graph fetch until the widget scrolls into view — prevents loading
   // the graph (and its fallback library data) on pages where the user never
   // scrolls below the fold (saves up to ~27 MB on mobile).
+  // KAN-153: also short-circuit on mobile so the IntersectionObserver never
+  // attaches to the (mobile) link card.
   useEffect(() => {
+    if (isMobile) return;
     const el = containerRef.current;
     if (!el) { setIsVisible(true); return; }
     if (!('IntersectionObserver' in window)) { setIsVisible(true); return; }
@@ -58,10 +64,11 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  }, [isMobile]);
 
   useEffect(() => {
-    if (!isVisible) return;
+    // KAN-153: skip the 10k-edge fetch entirely on mobile.
+    if (isMobile || !isVisible) return;
     let cancelled = false;
     const controller = new AbortController();
     setLoading(true);
@@ -94,7 +101,7 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
       cancelled = true;
       controller.abort();
     };
-  }, [isVisible]);
+  }, [isVisible, isMobile]);
 
   const nodeCount = useMemo(
     () => nodeMetadata.size || new Set(edges.flatMap((e) => [e.source, e.target])).size,
@@ -114,6 +121,30 @@ export function HomeGraphWidget({ selectedRepoName, onGraphNodeSelect }: HomeGra
     },
     [router, onGraphNodeSelect],
   );
+
+  // KAN-153 (KAN-121 design): on mobile, replace the heavy 3D widget with a
+  // static link card. Skips the 10k-edge fetch and the Three.js + d3-force-3d
+  // chunks entirely. SSR renders the desktop tree (isMobile=false initial),
+  // hydration corrects post-mount; the placeholder height matches the
+  // desktop widget's 420px so layout settles without a perceptible jump.
+  if (isMobile) {
+    return (
+      <Link
+        href="/graph"
+        data-testid="home-graph-mobile-cta"
+        className="flex h-[420px] flex-col justify-center rounded-xl border border-zinc-800 bg-[#0a0a0f] p-6 text-center transition-colors hover:border-cyan-500/40 hover:bg-zinc-900/40"
+      >
+        <h2 className="text-base font-semibold text-zinc-200">Knowledge Graph</h2>
+        <p className="mx-auto mt-2 max-w-xs text-xs text-zinc-500">
+          The interactive 3D graph is desktop-optimized. Open the full graph to explore every repo
+          and its connections.
+        </p>
+        <span className="mx-auto mt-4 inline-flex items-center gap-1 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-2 text-sm text-zinc-100">
+          View graph <span aria-hidden>→</span>
+        </span>
+      </Link>
+    );
+  }
 
   return (
     <div ref={containerRef} className="rounded-xl border border-zinc-800 bg-[#0a0a0f] overflow-hidden">

--- a/src/lib/useIsMobile.ts
+++ b/src/lib/useIsMobile.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export const MOBILE_QUERY = '(max-width: 767px)';
+
+/**
+ * SSR-safe mobile viewport detector. Returns `false` on the server and on the
+ * first client render to match SSR output, then corrects to the actual
+ * viewport state after hydration. Listens for viewport changes via
+ * `matchMedia` so the value updates if the user resizes or rotates the
+ * device.
+ *
+ * KAN-153 (extracted from src/app/graph/GraphPageClient.tsx pattern). Used
+ * by HomeGraphWidget to skip mounting Three.js + the 10k-edge graph fetch
+ * on mobile viewports — see KAN-121 design spec for context.
+ */
+export function useIsMobile(query: string = MOBILE_QUERY): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia(query);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing initial viewport match after SSR hydration
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [query]);
+
+  return isMobile;
+}

--- a/tests/unit/HomeGraphWidget.mobile.test.tsx
+++ b/tests/unit/HomeGraphWidget.mobile.test.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+
+/**
+ * KAN-153: HomeGraphWidget mobile branch — renders a static link card to /graph
+ * and does not trigger any graph-data fetch.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+const loadGraphDataset = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// Force mobile gate to true regardless of jsdom matchMedia behaviour.
+jest.mock('@/lib/useIsMobile', () => ({
+  useIsMobile: () => true,
+  MOBILE_QUERY: '(max-width: 767px)',
+}));
+
+jest.mock('next/dynamic', () => () => {
+  const NeverRendered = () => null;
+  return NeverRendered;
+});
+
+jest.mock('@/lib/graphData', () => ({
+  loadGraphDataset: (...args: unknown[]) => loadGraphDataset(...args),
+}));
+
+jest.mock('@/components/KnowledgeGraph3D', () => ({
+  KnowledgeGraph3D: () => null,
+}));
+
+describe('HomeGraphWidget — mobile branch (KAN-153)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders the mobile CTA card linking to /graph', () => {
+    const { HomeGraphWidget } = require('@/components/HomeGraphWidget');
+    render(<HomeGraphWidget />);
+
+    const cta = screen.getByTestId('home-graph-mobile-cta');
+    expect(cta).toBeTruthy();
+    expect(cta.getAttribute('href')).toBe('/graph');
+    expect(screen.getByText('Knowledge Graph')).toBeTruthy();
+    expect(screen.getByText('View graph')).toBeTruthy();
+  });
+
+  test('does NOT call loadGraphDataset on mobile', () => {
+    const { HomeGraphWidget } = require('@/components/HomeGraphWidget');
+    render(<HomeGraphWidget />);
+    expect(loadGraphDataset).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/useIsMobile.test.ts
+++ b/tests/unit/useIsMobile.test.ts
@@ -1,0 +1,85 @@
+/** @jest-environment jsdom */
+
+import { renderHook, act } from '@testing-library/react';
+import { useIsMobile } from '@/lib/useIsMobile';
+
+type Listener = (e: MediaQueryListEvent) => void;
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  addEventListener: jest.Mock;
+  removeEventListener: jest.Mock;
+}
+
+interface Harness {
+  mql: MockMql;
+  fire(matches: boolean): void;
+}
+
+function installMatchMedia(initialMatches: boolean): Harness {
+  const listeners: Listener[] = [];
+  const mql: MockMql = {
+    matches: initialMatches,
+    media: '(max-width: 767px)',
+    addEventListener: jest.fn((_: string, cb: Listener) => {
+      listeners.push(cb);
+    }),
+    removeEventListener: jest.fn((_: string, cb: Listener) => {
+      const idx = listeners.indexOf(cb);
+      if (idx !== -1) listeners.splice(idx, 1);
+    }),
+  };
+  // jest.setup.js installs matchMedia as a writable property; reassign rather
+  // than defineProperty (which fails on the second test because the property
+  // is not configurable).
+  (window as unknown as { matchMedia: (q: string) => MockMql }).matchMedia = jest
+    .fn()
+    .mockReturnValue(mql);
+  return {
+    mql,
+    fire(matches: boolean) {
+      mql.matches = matches;
+      const event = { matches } as MediaQueryListEvent;
+      listeners.slice().forEach((cb) => cb(event));
+    },
+  };
+}
+
+describe('useIsMobile', () => {
+  test('returns false when matchMedia.matches is false (desktop viewport)', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  test('corrects to true after hydration when matchMedia.matches is true', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  test('updates when the media query change event fires', () => {
+    const harness = installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      harness.fire(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      harness.fire(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  test('cleans up the change listener on unmount', () => {
+    const harness = installMatchMedia(false);
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(harness.mql.addEventListener).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(harness.mql.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements KAN-121 design spec Option A: hide `HomeGraphWidget` entirely on mobile (`<=767px`) and replace it with a static `View graph ->` link card pointing at `/graph` (which already shows the existing `MobileGraphFallback` from PR #220).

This is the next-biggest mobile perf lever after KAN-152 (`f21c5eb`).

### Why now

After KAN-152, mobile total transfer dropped from 6.9 MB -> 1.87 MB and TBT collapsed 75.9s -> 4.5-5.9s, but Lighthouse mobile perf only moved 25 -> 31 (TBT/CLS still saturated in the "poor" zone). Network panel after KAN-152 shows the dominant remaining costs are:

1. `graph/edges?limit=10000` = ~665 KB on initial home load (triggered by `HomeGraphWidget`)
2. `HomeGraphWidget` + `CyberpunkBillboard` layout shifts contributing ~1.18 of 1.28 cumulative CLS

This PR eliminates both on mobile by short-circuiting the data-fetch effect AND the IntersectionObserver effect when `useIsMobile()` returns true, then early-returning a reserved-height (`h-[420px]`) link card.

### Changes

- **New file** `src/lib/useIsMobile.ts` -- SSR-safe hook with `(max-width: 767px)` default, extracted from the inline `matchMedia` pattern in `/graph`'s `GraphPageClient.tsx`. Listens for viewport changes and cleans up the listener on unmount.
- **Edit** `src/components/HomeGraphWidget.tsx`:
  - `useIsMobile()` invoked at the top, alongside the other hooks.
  - IntersectionObserver effect early-returns when `isMobile` is true (so the observer never attaches to the link card).
  - `loadGraphDataset` effect early-returns when `isMobile` is true (so the 10k-edge fetch never fires on mobile).
  - Mobile branch returns a `<Link href="/graph">` card with `data-testid="home-graph-mobile-cta"`, reserved 420px height to match the desktop widget's footprint and keep CLS stable.
  - Desktop branch unchanged.
- **New** `tests/unit/useIsMobile.test.ts` (4 tests): desktop returns false, mobile returns true post-hydration, change-event updates, listener cleanup on unmount.
- **New** `tests/unit/HomeGraphWidget.mobile.test.tsx` (2 tests): mobile CTA renders + links to `/graph`; `loadGraphDataset` never called on mobile.

### Out of scope (per design spec)

- `/graph`'s `GraphPageClient.tsx` still uses inline `matchMedia` -- mechanical follow-up KAN ticket. Not migrated here to keep the diff focused (and `GraphPageClient` has more local state around its mobile gate that warrants its own review).
- Telemetry on the mobile CTA (would inform whether to revisit Option B "load on tap" later).
- Removing the one-frame "desktop card flash" on first hydration -- requires a pre-React script setting a class on `<html>`.

### Validation (local)

- `npm run type-check`: passes
- `npm test`: **57 suites / 386 tests pass** (baseline post-KAN-152: 55/380; +2 suites, +6 tests are the new ones in this PR)
- `npm run build`: 386 pages generated, no errors

### Test plan

- [ ] Vercel preview opens
- [ ] Mobile Lighthouse on preview URL: capture perf score, LCP, TBT, CLS
- [ ] Network panel mobile: confirm `graph/edges?limit=10000` is **absent**
- [ ] Network panel desktop: confirm `graph/edges?limit=10000` still fires (1 request)
- [ ] Visual: 1280px shows desktop widget unchanged; 375px shows the link card; 768px exact = desktop, 767px exact = mobile
- [ ] Tap the CTA on mobile -> lands on `/graph` -> shows the existing `MobileGraphFallback`