### PR TITLE
KAN-164: segment-level not-found.tsx for HTTP 404 on /repo/[name]

### DIFF
--- a/src/app/repo/[name]/not-found.tsx
+++ b/src/app/repo/[name]/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+// KAN-164: completes KAN-162's incomplete 404 fix.
+//
+// The app-level src/app/not-found.tsx (KAN-162) made the body render the 404
+// page correctly, but in Next.js 16 static export with prerender the HTTP
+// status for /repo/[name]/<missing-or-private> stayed 200. The fix is to
+// place a not-found.tsx AT THE ROUTE SEGMENT — Next.js then propagates the
+// 404 status through prerender for that route's notFound() calls.
+//
+// The body intentionally avoids echoing any URL slug — see KAN-131 (#289)
+// for the matching defense in /repo/[name]/page.tsx generateMetadata().
+export const metadata: Metadata = {
+  title: 'Not found | Reporium',
+  description: 'The page you requested could not be found.',
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-6 text-center">
+      <p className="text-xs font-mono uppercase tracking-widest text-zinc-500">
+        404
+      </p>
+      <h1 className="text-2xl font-semibold text-zinc-100">Page not found</h1>
+      <p className="max-w-md text-sm text-zinc-400">
+        The page you requested isn&apos;t available. It may have been moved, the
+        repository may be private, or the URL may be incorrect.
+      </p>
+      <Link
+        href="/"
+        className="mt-2 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-violet-500"
+      >
+        Back to library
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

KAN-162 ([#300](https://github.com/perditioinc/reporium/pull/300)) added an app-level `src/app/not-found.tsx` so the body renders the 404 page correctly. **However in Next.js 16 static export with prerender, `notFound()` calls in `/repo/[name]/page.tsx` still produced HTTP 200** — only the body flipped, not the status.

Per Next.js App Router semantics, a `not-found.tsx` placed **at the route segment** is required for the runtime to propagate the 404 status through prerender for that segment's `notFound()` calls.

## Change

Adds `src/app/repo/[name]/not-found.tsx` with the same body as the app-level fallback (consistency; no URL slug echo per KAN-131). The app-level `not-found.tsx` is **retained** — it still covers all other routes.

No changes to `page.tsx`, no new dependencies, no `error.tsx` or other touchpoints.

## Why the segment-level file is needed (Next.js prerender semantics)

For static-export pages prerendered at build time, the HTTP status is baked into the prerender output. Next.js only emits a 404-status prerender for `notFound()` calls in a segment when there is a `not-found.tsx` co-located with the page. The app-level fallback handles **runtime** SSR/ISR navigations but not the prerendered HTML response status — that's what KAN-162 missed.

## Verification

Local:
- `npm run type-check` passes
- `npm test` — 58 suites / 388 tests passing (matches post-KAN-162 baseline)
- `npm run build` — 386 pages, build succeeds; segment's compiled `page.js` references `not-found`

Post-deploy targets:
- `curl -sI https://www.reporium.com/repo/hippo-harvest-assignment/` -> **HTTP 404** (private repo)
- `curl -sI https://www.reporium.com/repo/this-clearly-does-not-exist-zzz/` -> **HTTP 404** (missing slug)
- `curl -sI https://www.reporium.com/repo/agno/` -> **HTTP 200** (public repo unchanged)
- `curl -sI https://www.reporium.com/` -> **HTTP 200** (sanity)

## Linked

- JIRA: https://perditio.atlassian.net/browse/KAN-164
- Related: KAN-162 ([#300](https://github.com/perditioinc/reporium/pull/300)), KAN-131 ([#289](https://github.com/perditioinc/reporium/pull/289))

🤖 Generated with [Claude Code](https://claude.com/claude-code)