### PR TITLE
KAN-183: /faq/ TBT optimization (option A — defer markdown render)

### DIFF
--- a/src/components/FAQPanel.tsx
+++ b/src/components/FAQPanel.tsx
@@ -83,9 +83,35 @@ function isAnswer(e: FAQEntry | undefined): e is FAQAnswer {
   return !!e && 'answer' in e;
 }
 
+// KAN-183: render-on-demand for FAQ markdown bodies.
+//
+// Why: with ~100 questions, mounting <ReactMarkdown> for every entry up-front
+// (even inside a collapsed <details>) blows the main-thread budget. Mobile
+// Lighthouse measured TBT=342ms / main-thread-work=2.2s on this page. The
+// <details> element only hides the body visually; React still renders all
+// children regardless of open state.
+//
+// Fix: track the open state per card via the native <details> onToggle event,
+// and ONLY mount <ReactMarkdown> once the user expands the card. Once mounted,
+// keep it mounted ('renderedOnce') so re-collapsing+re-expanding is instant
+// and the prose state (e.g. text selection) survives a toggle.
+//
+// SEO note: this is a 'use client' component that fetches /data/faq.json on
+// mount, so the answer body is never in the SSR HTML in the first place. The
+// question text (the SEO-relevant part) remains in the rendered <summary>.
+// Deferring the markdown render does not change the SSR output.
 function FAQCard({ question, entry }: { question: string; entry: FAQEntry | undefined }) {
+  const [renderedOnce, setRenderedOnce] = useState(false);
+
   return (
-    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/60 open:bg-zinc-900 transition-colors">
+    <details
+      className="group rounded-lg border border-zinc-800 bg-zinc-900/60 open:bg-zinc-900 transition-colors"
+      onToggle={(e) => {
+        if ((e.currentTarget as HTMLDetailsElement).open) {
+          setRenderedOnce(true);
+        }
+      }}
+    >
       <summary className="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-3">
         <span className="text-sm font-medium text-zinc-100">{question}</span>
         <span
@@ -105,13 +131,15 @@ function FAQCard({ question, entry }: { question: string; entry: FAQEntry | unde
         {isAnswer(entry) && (
           <div className="space-y-3">
             <div className="prose prose-invert prose-sm max-w-none text-sm text-zinc-200">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeSanitize]}
-                components={MARKDOWN_COMPONENTS}
-              >
-                {entry.answer}
-              </ReactMarkdown>
+              {renderedOnce ? (
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeSanitize]}
+                  components={MARKDOWN_COMPONENTS}
+                >
+                  {entry.answer}
+                </ReactMarkdown>
+              ) : null}
             </div>
             {entry.sources.length > 0 && (
               <div>

--- a/tests/FAQPanel.test.tsx
+++ b/tests/FAQPanel.test.tsx
@@ -1,0 +1,133 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { FAQPanel } from '@/components/FAQPanel';
+
+// KAN-183: assert that the FAQ list defers markdown render until a card is
+// expanded. Without deferral, mounting <ReactMarkdown> for ~100 entries up
+// front blows the main-thread budget (TBT 342ms on mobile Lighthouse).
+
+// react-markdown is ESM-only in v9+ and trips ts-jest's CJS pipeline. Mock it
+// to a marker element so we can count rendered bodies via querySelector.
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => (
+    <div data-testid="rendered-markdown">{children}</div>
+  ),
+}));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => () => undefined }));
+jest.mock('rehype-sanitize', () => ({ __esModule: true, default: () => () => undefined }));
+
+const FAQ_FIXTURE = {
+  generatedAt: '2026-05-03T00:00:00Z',
+  sections: [
+    {
+      title: 'Section A',
+      blurb: 'blurb a',
+      questions: ['Q1?', 'Q2?', 'Q3?'],
+    },
+    {
+      title: 'Section B',
+      blurb: 'blurb b',
+      questions: ['Q4?', 'Q5?'],
+    },
+  ],
+  answers: {
+    'Q1?': {
+      answer: '**Answer for Q1.**',
+      sources: [],
+      model: 'claude-test',
+      generatedAt: '2026-05-03T00:00:00Z',
+    },
+    'Q2?': {
+      answer: 'Answer for Q2.',
+      sources: [],
+      model: 'claude-test',
+      generatedAt: '2026-05-03T00:00:00Z',
+    },
+    'Q3?': {
+      answer: 'Answer for Q3.',
+      sources: [],
+      model: 'claude-test',
+      generatedAt: '2026-05-03T00:00:00Z',
+    },
+    'Q4?': {
+      answer: 'Answer for Q4.',
+      sources: [],
+      model: 'claude-test',
+      generatedAt: '2026-05-03T00:00:00Z',
+    },
+    'Q5?': {
+      answer: 'Answer for Q5.',
+      sources: [],
+      model: 'claude-test',
+      generatedAt: '2026-05-03T00:00:00Z',
+    },
+  },
+};
+
+describe('FAQPanel (KAN-183 render-on-demand)', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => FAQ_FIXTURE,
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders all question summaries up-front (preserves SEO/text)', async () => {
+    render(<FAQPanel />);
+
+    // Wait for the fetched data to resolve and questions to appear.
+    expect(await screen.findByText('Q1?')).toBeTruthy();
+    expect(screen.getByText('Q2?')).toBeTruthy();
+    expect(screen.getByText('Q3?')).toBeTruthy();
+    expect(screen.getByText('Q4?')).toBeTruthy();
+    expect(screen.getByText('Q5?')).toBeTruthy();
+  });
+
+  test('does NOT render any markdown bodies until a card is expanded', async () => {
+    const { container } = render(<FAQPanel />);
+
+    // Wait for FAQ data to load (questions appear).
+    await screen.findByText('Q1?');
+
+    // No markdown bodies should be mounted yet — that's the whole point of the
+    // KAN-183 fix. Even though five <details> elements are in the DOM, none of
+    // them should have rendered <ReactMarkdown>.
+    const renderedBodies = container.querySelectorAll('[data-testid="rendered-markdown"]');
+    expect(renderedBodies.length).toBe(0);
+  });
+
+  test('renders a single markdown body after one card is expanded', async () => {
+    const { container } = render(<FAQPanel />);
+
+    await screen.findByText('Q1?');
+
+    // Expand Q1 by toggling its <details>. JSDOM fires onToggle when `open`
+    // changes; toggling the property directly + dispatching the event mimics
+    // the browser's native click-to-open behavior.
+    const detailsList = container.querySelectorAll('details');
+    expect(detailsList.length).toBe(5);
+
+    const first = detailsList[0] as HTMLDetailsElement;
+    act(() => {
+      first.open = true;
+      first.dispatchEvent(new Event('toggle', { bubbles: false }));
+    });
+
+    await waitFor(() => {
+      const rendered = container.querySelectorAll('[data-testid="rendered-markdown"]');
+      expect(rendered.length).toBe(1);
+    });
+
+    // The other four cards are still un-rendered.
+    const stillCollapsed = container.querySelectorAll('[data-testid="rendered-markdown"]');
+    expect(stillCollapsed.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Defer markdown render in `FAQPanel` until a card is expanded. Closes KAN-183, the 4h audit P1 for `/faq/` mobile TBT.

JIRA: https://perditio.atlassian.net/browse/KAN-183

## Problem

Mobile Lighthouse for `/faq/`:

| Metric | Before |
|---|---|
| Performance | 90 (Yellow) |
| TBT | **342 ms** |
| Main-thread work | 2.2 s |
| Bootup time | 0.6 s |

Root cause: `FAQPanel` mounts `<ReactMarkdown>` (`remark-gfm` + `rehype-sanitize`) for **100 questions** up-front. The `<details>` element only hides the body visually — React renders all children regardless of open state.

## Fix (Option A — render-on-demand)

Track each card's open state via the native `<details>` `onToggle` event; only mount `<ReactMarkdown>` the first time the user expands the card. Once mounted, keep it mounted (`renderedOnce`) so toggling collapse/expand is instant and prose state (text selection, etc.) survives.

Picked over Option B (virtualize) because the existing collapse-by-default UX already gives us a natural deferral signal — no new dep, minimal surface change. Picked over Option C (precompute HTML at build time) because the perf win from A is expected to clear the budget on its own and C is materially larger scope.

## Constraints honored

- No new dependencies
- `data/faq.json` schema unchanged
- Search (browser find-in-page on `<summary>` text), anchors, deeplinks, `/ask?q=…` handoff all preserved
- SEO unchanged: `FAQPanel` is `'use client'` and fetches `/data/faq.json` on mount, so the answer body was never in SSR HTML; question text in `<summary>` remains rendered/indexable

## Tests

`tests/FAQPanel.test.tsx` asserts:
- All question summaries render up-front (SEO/text preservation)
- **0** markdown bodies render before any expand (the perf invariant)
- Exactly **1** markdown body renders after a single card expand

`type-check` clean. Full Jest suite: 60 suites / 399 tests pass.

## Lighthouse before/after

Will fill in after Vercel preview deploy:

| Metric | Before (main) | After (preview) | Delta |
|---|---|---|---|
| TBT | 342 ms | _pending_ | _pending_ |
| Performance | 90 | _pending_ | _pending_ |
| LCP | _pending_ | _pending_ | _pending_ |

## Files changed

- `src/components/FAQPanel.tsx` — `FAQCard` now mounts `<ReactMarkdown>` only after `onToggle` fires with `open=true`
- `tests/FAQPanel.test.tsx` — new

## Test plan

- [x] `npm run type-check`
- [x] `npm test`
- [x] `npm run build`
- [ ] Vercel preview Lighthouse `/faq/` mobile run; expect TBT < 100 ms (or ≥ 50% reduction)
- [ ] Click a card — markdown body renders
- [ ] Click into `/ask` deeplink — handoff works

🤖 Generated with [Claude Code](https://claude.com/claude-code)