### PR TITLE
KAN-185: /insights/ + /trends/ migration to preview?include= (close 4h audit P0)

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -15,6 +15,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { EnrichedRepo, LibraryData } from '@/types/repo';
+import { createDataProvider } from '@/lib/dataProvider';
+import { previewToLibraryData } from '@/lib/previewToLibraryData';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? '';
 
@@ -119,20 +121,26 @@ export default function InsightsPage() {
 
   useEffect(() => {
     async function load() {
-      // page_size max is 500 per API constraint; use timeout to avoid cold-start hangs
+      // KAN-185: replace the 1.46 MB `/library/full?page_size=500` fetch with
+      // `/library/preview?include=stats,parent,quality` (~500 KB) — KAN-179
+      // backend (PR #472 @ 60e751e). All five sections (rising/most-active/
+      // newly-discovered/category-leaders/health-alerts) read commitStats,
+      // parentStats and qualitySignals which the include= tokens surface.
+      // `forkedAt`/`createdAt` are not in any include block; the
+      // newlyDiscovered section gracefully renders empty until lazy upgrade.
+      const provider = createDataProvider();
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const [libraryRes, trendRes] = await Promise.all([
-          fetch(`${API_URL}/library/full?page=1&page_size=500`, { signal: controller.signal }),
+        const [preview, trendRes] = await Promise.all([
+          provider.getPreview(300, { include: ['stats', 'parent', 'quality'] }),
           API_URL
             ? fetch(`${API_URL}/trends/report`, { signal: controller.signal }).catch(() => null)
             : Promise.resolve(null),
         ]);
         clearTimeout(timeoutId);
-        if (!libraryRes.ok) throw new Error(`API error ${libraryRes.status}`);
-        setData(await libraryRes.json());
-        if (trendRes?.ok) {
+        setData(previewToLibraryData(preview));
+        if (trendRes && 'ok' in trendRes && trendRes.ok) {
           const td = await trendRes.json() as { period?: { snapshots?: number } };
           setTrendSnapshotsAvailable((td.period?.snapshots ?? 0) > 0);
         } else {

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -14,6 +14,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { EnrichedRepo, LibraryData, TrendData } from '@/types/repo';
+import { createDataProvider } from '@/lib/dataProvider';
+import { previewToLibraryData } from '@/lib/previewToLibraryData';
 
 const API_URL = process.env.NEXT_PUBLIC_REPORIUM_API_URL ?? '';
 
@@ -216,20 +218,25 @@ export default function TrendsPage() {
 
   useEffect(() => {
     async function load() {
-      // page_size max is 500 per API constraint; use timeout to avoid cold-start hangs
+      // KAN-185: replace the 1.46 MB `/library/full?page_size=500` fetch with
+      // `/library/preview?include=stats,parent` (~400 KB) — KAN-179 backend
+      // (PR #472 @ 60e751e). Trends needs commitStats for category momentum
+      // and parentStats for upstream metadata; quality is unused on this page.
+      // `forkedAt`/`createdAt` are not in any include block; the
+      // newThisWeek section gracefully renders empty until lazy upgrade.
+      const provider = createDataProvider();
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10_000);
       try {
-        const [libraryRes, trendRes] = await Promise.all([
-          fetch(`${API_URL}/library/full?page=1&page_size=500`, { signal: controller.signal }),
+        const [preview, trendRes] = await Promise.all([
+          provider.getPreview(300, { include: ['stats', 'parent'] }),
           API_URL
             ? fetch(`${API_URL}/trends/report`, { signal: controller.signal }).catch(() => null)
             : Promise.resolve(null),
         ]);
         clearTimeout(timeoutId);
-        if (!libraryRes.ok) throw new Error(`API error ${libraryRes.status}`);
-        setData(await libraryRes.json());
-        if (trendRes?.ok) {
+        setData(previewToLibraryData(preview));
+        if (trendRes && 'ok' in trendRes && trendRes.ok) {
           setTrendData(await trendRes.json());
         }
       } catch (e) {

--- a/src/lib/dataProvider.ts
+++ b/src/lib/dataProvider.ts
@@ -29,6 +29,12 @@ export interface LoadProgress {
  * Note: `stars` and `forks` are pre-coalesced server-side via
  * `COALESCE(parent_stars, stargazers_count, 0)` — clients should NOT need
  * `parentStats?.stars` fallback when consuming preview data.
+ *
+ * KAN-185: optional fields are surfaced when the caller asks for them via
+ * `getPreview(limit, { include: ['stats', 'parent', 'quality'] })`. The
+ * server projection (KAN-179) attaches each block independently — `stats`
+ * adds `commitStats`, `parent` adds `parentStats` + `upstreamCreatedAt`,
+ * `quality` adds `qualitySignals`. Consumers MUST treat each as optional.
  */
 export interface PreviewRepo {
   id: string
@@ -46,6 +52,31 @@ export interface PreviewRepo {
   enrichedTags: string[]
   isArchived: boolean
   url: string
+  /** KAN-185 / KAN-179: present when `?include=stats` is passed. */
+  commitStats?: { last7Days: number; last30Days: number; last90Days: number }
+  /** KAN-185 / KAN-179: present when `?include=parent` is passed. */
+  parentStats?: {
+    owner: string
+    repo: string
+    stars: number
+    forks: number
+    isArchived: boolean
+    lastCommitDate: string | null
+    description: string | null
+    url: string
+  }
+  /** KAN-185 / KAN-179: present when `?include=parent` is passed. */
+  upstreamCreatedAt?: string | null
+  /** KAN-185 / KAN-179: present when `?include=quality` is passed. */
+  qualitySignals?: Record<string, unknown>
+}
+
+/** KAN-185: opt-in field-set tokens for `GET /library/preview?include=`. */
+export type PreviewIncludeToken = 'stats' | 'parent' | 'quality'
+
+/** KAN-185: options accepted by `getPreview()`. */
+export interface GetPreviewOptions {
+  include?: PreviewIncludeToken[]
 }
 
 /** KAN-152: response shape for `GET /library/preview`. */
@@ -67,8 +98,14 @@ export interface DataProvider {
    * repos sorted by stars. Falls back to a `LibraryData`-shaped synthesis
    * (via `getOwnedLibrary()` + first page of `getLibrary()`) when the API is
    * unavailable so callers never see a hard failure.
+   *
+   * KAN-185: pass `{ include: [...] }` to opt into KAN-179's optional field
+   * blocks (`stats` -> commitStats, `parent` -> parentStats + upstreamCreatedAt,
+   * `quality` -> qualitySignals). Cache key is keyed on the include set, so
+   * a baseline preview and an enriched preview can co-exist in the same SPA
+   * session without clobbering each other.
    */
-  getPreview(limit?: number): Promise<PreviewData>
+  getPreview(limit?: number, options?: GetPreviewOptions): Promise<PreviewData>
   getLibrary(onProgress?: (p: LoadProgress) => void): Promise<LibraryData>
   getDegradedState(): boolean
   clearDegradedState(): void
@@ -138,29 +175,64 @@ class JsonDataProvider implements DataProvider {
    * running in lite/JSON mode. The home page treats preview as the primary
    * first-paint shape; without this fallback, a JSON-only build would crash
    * before the lazy `getLibrary()` ever fires.
+   *
+   * KAN-185: when `options.include` requests a block, surface that block from
+   * the in-memory `EnrichedRepo` so /insights and /trends keep working under
+   * lite-mode (jest, JSON-only builds) without requiring the API.
    */
-  async getPreview(limit = 300): Promise<PreviewData> {
+  async getPreview(limit = 300, options?: GetPreviewOptions): Promise<PreviewData> {
     const lib = await this.getLibrary()
     const sorted = [...lib.repos].sort(
       (a, b) => (b.parentStats?.stars ?? b.stars ?? 0) - (a.parentStats?.stars ?? a.stars ?? 0),
     )
-    const repos: PreviewRepo[] = sorted.slice(0, limit).map((r) => ({
-      id: String(r.id),
-      name: r.name,
-      fullName: r.fullName,
-      description: r.description,
-      isFork: r.isFork,
-      forkedFrom: r.forkedFrom,
-      language: r.language,
-      stars: r.parentStats?.stars ?? r.stars ?? 0,
-      forks: r.parentStats?.forks ?? r.forks ?? 0,
-      lastUpdated: r.lastUpdated,
-      primaryCategory: r.primaryCategory ?? null,
-      dbCategory: r.dbCategory ?? null,
-      enrichedTags: r.enrichedTags ?? [],
-      isArchived: r.isArchived,
-      url: r.url,
-    }))
+    const wantStats = options?.include?.includes('stats') ?? false
+    const wantParent = options?.include?.includes('parent') ?? false
+    const wantQuality = options?.include?.includes('quality') ?? false
+    const repos: PreviewRepo[] = sorted.slice(0, limit).map((r) => {
+      const base: PreviewRepo = {
+        id: String(r.id),
+        name: r.name,
+        fullName: r.fullName,
+        description: r.description,
+        isFork: r.isFork,
+        forkedFrom: r.forkedFrom,
+        language: r.language,
+        stars: r.parentStats?.stars ?? r.stars ?? 0,
+        forks: r.parentStats?.forks ?? r.forks ?? 0,
+        lastUpdated: r.lastUpdated,
+        primaryCategory: r.primaryCategory ?? null,
+        dbCategory: r.dbCategory ?? null,
+        enrichedTags: r.enrichedTags ?? [],
+        isArchived: r.isArchived,
+        url: r.url,
+      }
+      if (wantStats && r.commitStats) {
+        base.commitStats = {
+          last7Days: r.commitStats.last7Days ?? 0,
+          last30Days: r.commitStats.last30Days ?? 0,
+          last90Days: r.commitStats.last90Days ?? 0,
+        }
+      }
+      if (wantParent) {
+        if (r.parentStats) {
+          base.parentStats = {
+            owner: r.parentStats.owner,
+            repo: r.parentStats.repo,
+            stars: r.parentStats.stars,
+            forks: r.parentStats.forks,
+            isArchived: r.parentStats.isArchived,
+            lastCommitDate: r.parentStats.lastCommitDate ?? null,
+            description: r.parentStats.description,
+            url: r.parentStats.url,
+          }
+        }
+        base.upstreamCreatedAt = r.upstreamCreatedAt ?? null
+      }
+      if (wantQuality && r.qualitySignals) {
+        base.qualitySignals = r.qualitySignals as Record<string, unknown>
+      }
+      return base
+    })
     return {
       generatedAt: lib.generatedAt,
       totalRepos: lib.repos.length,
@@ -463,29 +535,40 @@ class ApiDataProvider implements DataProvider {
    * Cached in-memory for the session; on API failure we fall back to the
    * `JsonDataProvider` synthesis so the home page never loses its first
    * paint to a transient outage.
+   *
+   * KAN-185: opt-in field blocks via `/library/preview?include=stats,parent,quality`
+   * (server: KAN-179, PR #472 @ 60e751e). Per-include cache keys keep the home
+   * baseline (~165 KB / no include tokens) and the enriched insights/trends
+   * payload (~500 KB / 3 tokens) co-resident in the same SPA session.
    */
-  private previewCache: PreviewData | null = null
-  private previewPromise: Promise<PreviewData> | null = null
-  async getPreview(limit = 300): Promise<PreviewData> {
-    if (this.previewCache) return this.previewCache
-    if (this.previewPromise) return this.previewPromise
-    this.previewPromise = (async () => {
+  private previewCache: Map<string, PreviewData> = new Map()
+  private previewPromises: Map<string, Promise<PreviewData>> = new Map()
+  async getPreview(limit = 300, options?: GetPreviewOptions): Promise<PreviewData> {
+    const includeSorted = [...(options?.include ?? [])].sort()
+    const cacheKey = `preview:${limit}:${includeSorted.join(',') || 'none'}`
+    const cached = this.previewCache.get(cacheKey)
+    if (cached) return cached
+    const inflight = this.previewPromises.get(cacheKey)
+    if (inflight) return inflight
+    const includeParam = includeSorted.length ? `&include=${includeSorted.join(',')}` : ''
+    const promise = (async () => {
       try {
-        const data = await this.apiFetch<PreviewData>(`/library/preview?limit=${limit}`)
-        this.previewCache = data
+        const data = await this.apiFetch<PreviewData>(`/library/preview?limit=${limit}${includeParam}`)
+        this.previewCache.set(cacheKey, data)
         return data
       } catch {
         // API unavailable — synthesise from the bundled library JSON so the
         // home page still renders. Mark degraded so the banner appears.
         this.degraded = true
-        const fallback = await this.fallback.getPreview(limit)
-        this.previewCache = fallback
+        const fallback = await this.fallback.getPreview(limit, options)
+        this.previewCache.set(cacheKey, fallback)
         return fallback
       } finally {
-        this.previewPromise = null
+        this.previewPromises.delete(cacheKey)
       }
     })()
-    return this.previewPromise
+    this.previewPromises.set(cacheKey, promise)
+    return promise
   }
 
   getDegradedState(): boolean {

--- a/src/lib/previewToLibraryData.ts
+++ b/src/lib/previewToLibraryData.ts
@@ -29,13 +29,40 @@ import type {
 import type { PreviewData, PreviewRepo } from '@/lib/dataProvider'
 
 /**
+ * Promote the preview's optional `parentStats` block (when KAN-179
+ * `?include=parent` was requested) to a full `ParentRepoStats`. The preview
+ * shape omits `openIssues`, so we default it to 0; nothing on the card
+ * surface reads it.
+ */
+function liftParentStats(p: PreviewRepo): ParentRepoStats | null {
+  if (!p.parentStats) return null
+  return {
+    owner: p.parentStats.owner,
+    repo: p.parentStats.repo,
+    stars: p.parentStats.stars,
+    forks: p.parentStats.forks,
+    openIssues: 0,
+    lastCommitDate: p.parentStats.lastCommitDate ?? '',
+    isArchived: p.parentStats.isArchived,
+    description: p.parentStats.description,
+    url: p.parentStats.url,
+  }
+}
+
+/**
  * For a forked preview repo, synthesise the minimum `parentStats` fields the
  * card surface reads. The preview's `stars`/`forks` values are already
  * pre-coalesced server-side (`COALESCE(parent_stars, ...)`) so we mirror
  * those into the synth `parentStats` to keep the card's
  * `parentStats?.stars ?? stars` lookup behaving identically.
+ *
+ * KAN-185: prefer the real `parentStats` block from `?include=parent` when
+ * present, since it carries the genuine `isArchived` flag /insights/ Health
+ * Alerts depends on. Falls back to the fork-only synth otherwise.
  */
 function synthParentStatsForFork(p: PreviewRepo): ParentRepoStats | null {
+  const lifted = liftParentStats(p)
+  if (lifted) return lifted
   if (!p.isFork || !p.forkedFrom) return null
   const [owner, repo] = p.forkedFrom.split('/')
   if (!owner || !repo) return null
@@ -66,6 +93,19 @@ function idHash(s: string): number {
 
 /** Promote a `PreviewRepo` to an `EnrichedRepo` with empty aggregates. */
 export function previewToEnrichedRepo(p: PreviewRepo): EnrichedRepo {
+  // KAN-185: surface optional include blocks when present. Empty-default
+  // shapes match the previous behaviour for the home-page baseline (no
+  // include tokens) so downstream consumers continue to see safe zeros.
+  const commitStats = p.commitStats
+    ? {
+        today: 0,
+        last7Days: p.commitStats.last7Days,
+        last30Days: p.commitStats.last30Days,
+        last90Days: p.commitStats.last90Days,
+        recentCommits: [],
+      }
+    : { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] }
+
   return {
     id: idHash(p.id),
     name: p.name,
@@ -90,7 +130,7 @@ export function previewToEnrichedRepo(p: PreviewRepo): EnrichedRepo {
     forkedAt: null,
     yourLastPushAt: null,
     upstreamLastPushAt: null,
-    upstreamCreatedAt: null,
+    upstreamCreatedAt: p.upstreamCreatedAt ?? null,
     forkSync: null,
     weeklyCommitCount: 0,
     languageBreakdown: {},
@@ -102,7 +142,7 @@ export function previewToEnrichedRepo(p: PreviewRepo): EnrichedRepo {
     primaryCategory: p.primaryCategory ?? '',
     allCategories: p.primaryCategory ? [p.primaryCategory] : [],
     dbCategory: p.dbCategory,
-    commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] },
+    commitStats,
     latestRelease: null,
     aiDevSkills: [],
     pmSkills: [],
@@ -110,6 +150,7 @@ export function previewToEnrichedRepo(p: PreviewRepo): EnrichedRepo {
     programmingLanguages: p.language ? [p.language] : [],
     builders: [],
     taxonomy: [],
+    qualitySignals: (p.qualitySignals as EnrichedRepo['qualitySignals']) ?? null,
   }
 }
 

--- a/tests/InsightsPage.test.tsx
+++ b/tests/InsightsPage.test.tsx
@@ -1,0 +1,147 @@
+/** @jest-environment jsdom */
+
+/**
+ * KAN-185: /insights migration to `/library/preview?include=stats,parent,quality`.
+ *
+ * Pins the contract that the page no longer fetches `/library/full` on initial
+ * load. The previous flow shipped 1.46 MB to mobile every visit; this test
+ * fails if a future regression re-introduces the heavy endpoint.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { PreviewData } from '@/lib/dataProvider';
+
+jest.mock('next/link', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockLink = ({ children, href }: any) => <a href={href}>{children}</a>;
+  MockLink.displayName = 'MockLink';
+  return { __esModule: true, default: MockLink };
+});
+
+const mockGetPreview = jest.fn();
+
+jest.mock('@/lib/dataProvider', () => ({
+  createDataProvider: () => ({ mode: 'production', getPreview: mockGetPreview }),
+}));
+
+function buildPreview(): PreviewData {
+  return {
+    generatedAt: new Date().toISOString(),
+    totalRepos: 2,
+    limit: 300,
+    sort: 'stars',
+    category: null,
+    repos: [
+      {
+        id: 'r1',
+        name: 'rising-star',
+        fullName: 'p/rising-star',
+        description: 'A rising-fast repo',
+        isFork: false,
+        forkedFrom: null,
+        language: 'Python',
+        stars: 5000,
+        forks: 100,
+        lastUpdated: new Date().toISOString(),
+        primaryCategory: 'agents',
+        dbCategory: 'agents',
+        enrichedTags: ['agents', 'llm'],
+        isArchived: false,
+        url: 'https://github.com/p/rising-star',
+        commitStats: { last7Days: 10, last30Days: 40, last90Days: 100 },
+        parentStats: {
+          owner: 'upstream',
+          repo: 'rising-star',
+          stars: 5000,
+          forks: 100,
+          isArchived: false,
+          lastCommitDate: new Date().toISOString(),
+          description: 'A rising-fast repo',
+          url: 'https://github.com/upstream/rising-star',
+        },
+        upstreamCreatedAt: '2024-01-01T00:00:00Z',
+        qualitySignals: { activity_score: 60, overall_score: 80 },
+      },
+      {
+        id: 'r2',
+        name: 'archived-repo',
+        fullName: 'p/archived-repo',
+        description: 'An archived repo',
+        isFork: false,
+        forkedFrom: null,
+        language: 'Go',
+        stars: 200,
+        forks: 5,
+        lastUpdated: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString(),
+        primaryCategory: 'orchestration',
+        dbCategory: 'orchestration',
+        enrichedTags: [],
+        isArchived: false,
+        url: 'https://github.com/p/archived-repo',
+        commitStats: { last7Days: 0, last30Days: 0, last90Days: 0 },
+        parentStats: {
+          owner: 'upstream',
+          repo: 'archived-repo',
+          stars: 200,
+          forks: 5,
+          isArchived: true,
+          lastCommitDate: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString(),
+          description: 'An archived repo',
+          url: 'https://github.com/upstream/archived-repo',
+        },
+        upstreamCreatedAt: '2018-01-01T00:00:00Z',
+        qualitySignals: { activity_score: 1, overall_score: 1 },
+      },
+    ],
+  };
+}
+
+describe('InsightsPage KAN-185 preview migration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPreview.mockReset();
+  });
+
+  test('fetches /library/preview with include=stats,parent,quality and never /library/full', async () => {
+    mockGetPreview.mockResolvedValueOnce(buildPreview());
+    // Trends report fetch is `fetch()` directly; mock it as a 503.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 503 } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+
+    const InsightsPage = (await import('@/app/insights/page')).default;
+    render(<InsightsPage />);
+
+    // Provider was called exactly once with the include= triplet.
+    await waitFor(() => {
+      expect(mockGetPreview).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetPreview).toHaveBeenCalledWith(300, {
+      include: ['stats', 'parent', 'quality'],
+    });
+
+    // Critically: NO direct fetch to /library/full on initial paint.
+    const directLibraryFullCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/library/full')
+    );
+    expect(directLibraryFullCalls).toHaveLength(0);
+  });
+
+  test('renders Rising Fast and Health Alerts sections from preview data alone', async () => {
+    mockGetPreview.mockResolvedValueOnce(buildPreview());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 } as any);
+
+    const InsightsPage = (await import('@/app/insights/page')).default;
+    render(<InsightsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Rising Fast')).toBeTruthy();
+    });
+    // Health Alerts should appear because archived-repo has parentStats.isArchived=true
+    // (only possible because `?include=parent` lifted the real flag).
+    expect(screen.getByText('Health Alerts')).toBeTruthy();
+  });
+});

--- a/tests/TrendsPage.preview.test.tsx
+++ b/tests/TrendsPage.preview.test.tsx
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+
+/**
+ * KAN-185: /trends migration to `/library/preview?include=stats,parent`.
+ *
+ * Pins the contract that the page no longer fetches `/library/full` on initial
+ * load. The previous flow shipped 1.46 MB to mobile every visit. This sits
+ * alongside `TrendsPage.staleness.test.tsx` (which still uses raw fetch mocks)
+ * because that suite predates the dataProvider migration.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { PreviewData } from '@/lib/dataProvider';
+
+jest.mock('next/link', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockLink = ({ children, href }: any) => <a href={href}>{children}</a>;
+  MockLink.displayName = 'MockLink';
+  return { __esModule: true, default: MockLink };
+});
+
+const mockGetPreview = jest.fn();
+
+jest.mock('@/lib/dataProvider', () => ({
+  createDataProvider: () => ({ mode: 'production', getPreview: mockGetPreview }),
+}));
+
+function buildPreview(): PreviewData {
+  return {
+    generatedAt: new Date().toISOString(),
+    totalRepos: 1,
+    limit: 300,
+    sort: 'stars',
+    category: null,
+    repos: [
+      {
+        id: 't1',
+        name: 'busy-bee',
+        fullName: 'p/busy-bee',
+        description: 'Active recently',
+        isFork: false,
+        forkedFrom: null,
+        language: 'TypeScript',
+        stars: 800,
+        forks: 30,
+        lastUpdated: new Date().toISOString(),
+        primaryCategory: 'agents',
+        dbCategory: 'agents',
+        enrichedTags: ['agents'],
+        isArchived: false,
+        url: 'https://github.com/p/busy-bee',
+        commitStats: { last7Days: 7, last30Days: 25, last90Days: 70 },
+        parentStats: {
+          owner: 'upstream',
+          repo: 'busy-bee',
+          stars: 800,
+          forks: 30,
+          isArchived: false,
+          lastCommitDate: new Date().toISOString(),
+          description: 'Active recently',
+          url: 'https://github.com/upstream/busy-bee',
+        },
+        upstreamCreatedAt: '2024-06-01T00:00:00Z',
+      },
+    ],
+  };
+}
+
+describe('TrendsPage KAN-185 preview migration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPreview.mockReset();
+  });
+
+  test('fetches /library/preview with include=stats,parent and never /library/full', async () => {
+    mockGetPreview.mockResolvedValueOnce(buildPreview());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 503 } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+
+    const TrendsPage = (await import('@/app/trends/page')).default;
+    render(<TrendsPage />);
+
+    await waitFor(() => {
+      expect(mockGetPreview).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetPreview).toHaveBeenCalledWith(300, {
+      include: ['stats', 'parent'],
+    });
+
+    const directLibraryFullCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/library/full')
+    );
+    expect(directLibraryFullCalls).toHaveLength(0);
+  });
+
+  test('renders Category Momentum section using commitStats from preview', async () => {
+    mockGetPreview.mockResolvedValueOnce(buildPreview());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 } as any);
+
+    const TrendsPage = (await import('@/app/trends/page')).default;
+    render(<TrendsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Category Momentum')).toBeTruthy();
+    });
+    // The Most Active section also derives from commitStats.last7Days which
+    // only exists because `?include=stats` is requested.
+    expect(screen.getByText('Most Active This Week')).toBeTruthy();
+  });
+});

--- a/tests/TrendsPage.staleness.test.tsx
+++ b/tests/TrendsPage.staleness.test.tsx
@@ -14,8 +14,8 @@
  *   2. libraryData.generatedAt
  *   3. trendData.period.to
  *
- * The page hits two endpoints in parallel:
- *   GET ${API_URL}/library/full?... -> { generatedAt, repos: [...] }
+ * The page hits two endpoints in parallel (KAN-185 migration):
+ *   provider.getPreview(...)        -> { generatedAt, repos: [...] }
  *   GET ${API_URL}/trends/report    -> { generatedAt, period: {...}, ... }
  */
 
@@ -55,15 +55,27 @@ const emptyTrends = (generatedAt: string): TrendData => ({
 });
 
 function mockFetchSequence(library: LibraryData, trends: TrendData | null) {
-  // The component fires both fetches in parallel via Promise.all and matches by URL.
+  // KAN-185: /library/full has been replaced with `dataProvider.getPreview()`.
+  // The provider still calls `fetch()` internally with /library/preview; we
+  // match on either path so the test is resilient to that refactor.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fetchMock = jest.fn((url: any) => {
     const urlStr = String(url);
-    if (urlStr.includes('/library/full')) {
+    if (urlStr.includes('/library/preview') || urlStr.includes('/library/full')) {
+      // Translate the LibraryData fixture into a PreviewData-shaped response
+      // so dataProvider.getPreview() returns the same `generatedAt` the
+      // freshness logic compares against.
       return Promise.resolve({
         ok: true,
         status: 200,
-        json: async () => library,
+        json: async () => ({
+          generatedAt: library.generatedAt,
+          totalRepos: library.repos.length,
+          limit: 300,
+          sort: 'stars',
+          category: null,
+          repos: [],
+        }),
       } as Response);
     }
     if (urlStr.includes('/trends/report')) {
@@ -84,8 +96,18 @@ function mockFetchSequence(library: LibraryData, trends: TrendData | null) {
 }
 
 describe('TrendsPage staleness UI', () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // KAN-185: TrendsPage uses createDataProvider() now; we need the API
+    // provider so /library/preview is fetched (and intercepted) instead of
+    // the JsonDataProvider's /data/library.json fallback.
+    process.env = { ...originalEnv, NEXT_PUBLIC_REPORIUM_API_URL: 'https://api.example.com' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   test('fresh data: renders an "as of" stamp and NO stale banner', async () => {

--- a/tests/unit/dataProvider.test.ts
+++ b/tests/unit/dataProvider.test.ts
@@ -79,6 +79,151 @@ describe('createDataProvider', () => {
   })
 })
 
+describe('ApiDataProvider.getPreview KAN-185 include= option', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.NEXT_PUBLIC_REPORIUM_API_URL = 'https://api.example.com'
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.restoreAllMocks()
+  })
+
+  test('getPreview without include= calls /library/preview?limit=N (no include param)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        generatedAt: '2026-05-03T00:00:00Z',
+        totalRepos: 1,
+        limit: 300,
+        sort: 'stars',
+        category: null,
+        repos: [],
+      }),
+    })
+    global.fetch = fetchMock as jest.Mock
+
+    const provider = createDataProvider()
+    await provider.getPreview(300)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://api.example.com/library/preview?limit=300'
+    )
+  })
+
+  test('getPreview with include=stats,parent,quality appends sorted include= param', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        generatedAt: '2026-05-03T00:00:00Z',
+        totalRepos: 1,
+        limit: 300,
+        sort: 'stars',
+        category: null,
+        repos: [],
+      }),
+    })
+    global.fetch = fetchMock as jest.Mock
+
+    const provider = createDataProvider()
+    await provider.getPreview(300, { include: ['quality', 'stats', 'parent'] })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Tokens are sorted to give a stable cache key, so request URL is also stable.
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://api.example.com/library/preview?limit=300&include=parent,quality,stats'
+    )
+  })
+
+  test('getPreview caches per include set; baseline + enriched coexist', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        generatedAt: '2026-05-03T00:00:00Z',
+        totalRepos: 1,
+        limit: 300,
+        sort: 'stars',
+        category: null,
+        repos: [],
+      }),
+    })
+    global.fetch = fetchMock as jest.Mock
+
+    const provider = createDataProvider()
+    await provider.getPreview(300)
+    await provider.getPreview(300) // cache hit
+    await provider.getPreview(300, { include: ['stats'] })
+    await provider.getPreview(300, { include: ['stats'] }) // cache hit
+    await provider.getPreview(300, { include: ['stats', 'parent', 'quality'] })
+
+    // Three distinct cache keys -> three network requests.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls).toContain('https://api.example.com/library/preview?limit=300')
+    expect(urls).toContain('https://api.example.com/library/preview?limit=300&include=stats')
+    expect(urls).toContain(
+      'https://api.example.com/library/preview?limit=300&include=parent,quality,stats'
+    )
+  })
+
+  test('getPreview surfaces optional include blocks from server response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        generatedAt: '2026-05-03T00:00:00Z',
+        totalRepos: 1,
+        limit: 300,
+        sort: 'stars',
+        category: null,
+        repos: [
+          {
+            id: 'r1',
+            name: 'demo',
+            fullName: 'p/demo',
+            description: null,
+            isFork: false,
+            forkedFrom: null,
+            language: 'Python',
+            stars: 1234,
+            forks: 12,
+            lastUpdated: '2026-05-01T00:00:00Z',
+            primaryCategory: 'agents',
+            dbCategory: 'agents',
+            enrichedTags: ['agents'],
+            isArchived: false,
+            url: 'https://github.com/p/demo',
+            commitStats: { last7Days: 3, last30Days: 12, last90Days: 40 },
+            parentStats: {
+              owner: 'upstream',
+              repo: 'demo',
+              stars: 9999,
+              forks: 200,
+              isArchived: false,
+              lastCommitDate: '2026-05-02T00:00:00Z',
+              description: 'desc',
+              url: 'https://github.com/upstream/demo',
+            },
+            upstreamCreatedAt: '2024-01-01T00:00:00Z',
+            qualitySignals: { activity_score: 42, overall_score: 88 },
+          },
+        ],
+      }),
+    }) as jest.Mock
+
+    const provider = createDataProvider()
+    const data = await provider.getPreview(300, { include: ['stats', 'parent', 'quality'] })
+    const repo = data.repos[0]
+    expect(repo.commitStats).toEqual({ last7Days: 3, last30Days: 12, last90Days: 40 })
+    expect(repo.parentStats?.isArchived).toBe(false)
+    expect(repo.upstreamCreatedAt).toBe('2024-01-01T00:00:00Z')
+    expect(repo.qualitySignals).toEqual({ activity_score: 42, overall_score: 88 })
+  })
+})
+
 describe('ApiDataProvider.apiFetch timeout', () => {
   const originalEnv = process.env
 


### PR DESCRIPTION
## Summary
- Migrates `/insights/` and `/trends/` from `/library/full?page_size=500` (1.46 MB warm) to `/library/preview?include=...` (~400-500 KB), eliminating the largest remaining mobile perf hot-spot from the 4h audit.
- Backend dependency: KAN-179 (reporium-api PR #472, squash `60e751e`) shipped the `?include=stats,parent,quality` projection. Live verified.
- Per-include cache keys keep the home baseline (no tokens) and the new enriched payload coexisting in one SPA session.

## Field projection per page
- `/insights/` -> `?include=stats,parent,quality` (rising-fast / most-active / category-leaders / health-alerts use commitStats, parentStats.isArchived, qualitySignals.activity_score|overall_score)
- `/trends/`   -> `?include=stats,parent` (category momentum + most-active + parent metadata)

## Graceful degradation (mirrors KAN-152 home pattern)
Sections that depend on `forkedAt`/`createdAt` (newlyDiscovered on /insights/, newThisWeek on /trends/) are not in any include block and render empty until a future lazy upgrade. The page never crashes — `previewToLibraryData()` returns safe defaults.

## Expected impact (per 4h audit baseline)
| Page | Metric | Baseline | Target |
|---|---|---|---|
| /insights/ | Mobile perf | 74 (RED) | 85+ |
| /insights/ | LCP | 11.63s | <4s |
| /insights/ | Transfer | 1.97 MB | ~0.5 MB |
| /trends/ | Mobile perf | 84 (Yellow) | 90+ |
| /trends/ | TBT | 384ms | <200ms |
| /trends/ | Transfer | 1.86 MB | ~0.4 MB |

Lighthouse runs on the Vercel preview will be added to this PR once the deployment is ready.

## Tests
- `tests/InsightsPage.test.tsx` (new) — asserts no `/library/full` fetch on initial load + `getPreview` invoked with `['stats','parent','quality']`
- `tests/TrendsPage.preview.test.tsx` (new) — same contract for `/trends/` with `['stats','parent']`
- `tests/unit/dataProvider.test.ts` — 4 new cases for include= URL composition, cache-key separation, field surfacing
- `tests/TrendsPage.staleness.test.tsx` — adapted to the new `/library/preview` path; existing freshness contract still pinned

Suite: 60 -> 62 suites, 399 -> 407 tests. Type-check + build green.

## Test plan
- [ ] CI green
- [ ] Vercel preview deploys
- [ ] Lighthouse mobile on preview /insights/ — perf >= 85, transfer < 800 KB
- [ ] Lighthouse mobile on preview /trends/ — perf >= 90, TBT < 200ms
- [ ] Production verification post-merge (separate Lighthouse run on www.reporium.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)