### PR TITLE
KAN-201 PR1: FilterBar derives category tags from repos (frontend prereq)

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -7,6 +7,15 @@ interface FilterBarProps {
   categories: Category[];
   languages: string[];
   allTags: string[];
+  /**
+   * KAN-201: Map from category name → set of tags appearing in repos
+   * assigned to that category. Replaces the trimmed `Category.tags` field
+   * that previously came from /library/aggregates. Derived in
+   * `HomePageClient` from per-repo `enrichedTags` filtered by
+   * `allCategories.includes(cat.name)` (mirrors the `MetricsSidebar`
+   * `CategoryDetailView` pattern).
+   */
+  categoryTagsMap?: Map<string, Set<string>>;
   tagMetrics: TagMetrics[];
   selectedCategory: string;
   selectedType: 'all' | 'built' | 'forked';
@@ -100,6 +109,7 @@ type TabId =
 /** Filter and sort controls for the repo library */
 export function FilterBar({
   categories,
+  categoryTagsMap,
   languages,
   allTags,
   tagMetrics,
@@ -159,10 +169,19 @@ export function FilterBar({
 
   const tagMetricsMap = new Map(tagMetrics.map((m) => [m.tag, m]));
 
-  // Determine which tags to show in tag row (used in categories tab)
+  // Determine which tags to show in tag row (used in categories tab).
+  // KAN-201: when a category is selected, we used to read `selectedCat.tags`
+  // straight from /library/aggregates. The API field has been removed; instead
+  // the parent component derives a Map<categoryName, Set<tag>> from per-repo
+  // `enrichedTags` filtered by `allCategories.includes(cat.name)`. If the map
+  // is missing (e.g. tests not passing it), fall back to showing all tags so
+  // the UI stays usable rather than empty.
   const selectedCat = categories.find(c => c.id === selectedCategory);
-  const tagsToShow: string[] = selectedCat
-    ? allTags.filter(t => selectedCat.tags.includes(t))
+  const selectedCatTagSet = selectedCat
+    ? categoryTagsMap?.get(selectedCat.name)
+    : undefined;
+  const tagsToShow: string[] = selectedCat && selectedCatTagSet
+    ? allTags.filter(t => selectedCatTagSet.has(t))
     : [...allTags].sort((a, b) => {
         const ca = tagMetricsMap.get(a)?.repoCount ?? 0;
         const cb = tagMetricsMap.get(b)?.repoCount ?? 0;

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -467,6 +467,32 @@ export function HomePageClient() {
     return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([t]) => t);
   }, [data]);
 
+  /**
+   * KAN-201: Map of category name → set of tags appearing in that category's
+   * repos. Replaces the trimmed `categories[].tags` field that previously came
+   * straight from /library/aggregates (largest single payload contributor at
+   * ~1.52 MB / 40%; see KAN-195 audit). FilterBar consumes this to drive the
+   * per-category tag row when a category is selected. Same derivation pattern
+   * as `MetricsSidebar.CategoryDetailView` (which reads from the local
+   * hardcoded `CATEGORIES` array).
+   */
+  const categoryTagsMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    if (!data) return map;
+    for (const repo of data.repos) {
+      const cats = repo.allCategories ?? [];
+      for (const catName of cats) {
+        let set = map.get(catName);
+        if (!set) {
+          set = new Set<string>();
+          map.set(catName, set);
+        }
+        for (const tag of repo.enrichedTags) set.add(tag);
+      }
+    }
+    return map;
+  }, [data]);
+
   // Stable sidebar data object — only recalculates when data or categories change
   const sidebarData = useMemo(() => {
     if (!data) return null;
@@ -1169,6 +1195,7 @@ export function HomePageClient() {
                     selectedSyncStatus={selectedSyncStatus}
                     sortBy={sortBy}
                     categories={normalizedCategories}
+                    categoryTagsMap={categoryTagsMap}
                     selectedCategory={selectedCategory}
                     onCategoryChange={setSelectedCategory}
                     onTypeChange={setSelectedType}

--- a/src/lib/buildCategories.ts
+++ b/src/lib/buildCategories.ts
@@ -1,12 +1,22 @@
 import { EnrichedRepo, Category } from '@/types/repo';
 
 /**
+ * Internal category definition: same shape as the public `Category` plus the
+ * `tags` array used to assign repos to categories. KAN-201 removed `tags` from
+ * the public `Category` type to drop ~1.52 MB from /library/aggregates; the
+ * tag list lives here only and is not serialized over the wire.
+ */
+export interface CategoryDefinition extends Category {
+  tags: string[]; // enrichedTags that belong to this category
+}
+
+/**
  * Hardcoded list of exactly 58 content categories across 6 lifecycle groups.
  * These are fixed buckets — never derived dynamically from tags.
  * A repo can belong to multiple categories (allCategories).
  * primaryCategory = category with the most matching tags.
  */
-export const CATEGORIES: Category[] = [
+export const CATEGORIES: CategoryDefinition[] = [
 
   // ─── Group 1: Foundation & Training ────────────────────────────────────────
 
@@ -742,8 +752,12 @@ export function buildCategories(repos: EnrichedRepo[]): Category[] {
   }
 
   // Build repoCount for each category (count repos where category is in allCategories)
+  // KAN-201: strip the internal `tags` field — it is not part of the public
+  // `Category` shape and would otherwise leak through static-data exports
+  // and the API library serialization (see `dataProvider.ts`).
   return CATEGORIES
-    .map(cat => ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .map(({ tags: _tags, ...cat }) => ({
       ...cat,
       repoCount: repos.filter(r => r.allCategories.includes(cat.name)).length,
     }))

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -236,12 +236,20 @@ export interface GapAnalysis {
   gaps: Gap[];
 }
 
-/** A broad content category grouping multiple tags */
+/**
+ * A broad content category grouping multiple tags.
+ *
+ * KAN-201: `tags` removed from this public type. The category-tag mapping is
+ * an internal implementation detail of `lib/buildCategories.ts` (see
+ * `CategoryDefinition`). Frontend consumers must derive category-tag
+ * intersection from per-repo `enrichedTags` filtered by
+ * `allCategories.includes(cat.name)`. This trim drops ~1.52 MB / 40% of
+ * the `/library/aggregates` payload (KAN-195 audit).
+ */
 export interface Category {
   id: string;           // kebab-case identifier
   name: string;
   description: string;
-  tags: string[];        // enrichedTags that belong to this category
   repoCount: number;
   color: string;         // hex color for visualization
   icon: string;         // emoji icon

--- a/tests/FilterBar.categoryTags.test.tsx
+++ b/tests/FilterBar.categoryTags.test.tsx
@@ -1,0 +1,204 @@
+/** @jest-environment jsdom */
+
+/**
+ * KAN-201: Verify FilterBar's per-category tag row uses the derived
+ * `categoryTagsMap` prop (replacement for the trimmed `Category.tags` field
+ * that previously came from /library/aggregates).
+ *
+ * Asserts:
+ *   - When a category is selected, only tags belonging to that category
+ *     (per the categoryTagsMap) are surfaced in the tag row.
+ *   - When no category is selected, all tags are shown.
+ *   - Selecting a different category swaps the visible tags accordingly.
+ *
+ * Mirrors the derivation pattern in MetricsSidebar.CategoryDetailView and
+ * matches how HomePageClient builds the map from per-repo enrichedTags.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterBar } from '@/components/FilterBar';
+import type { Category } from '@/types/repo';
+
+const categories: Category[] = [
+  {
+    id: 'rag',
+    name: 'RAG Pipelines',
+    description: 'rag stuff',
+    repoCount: 2,
+    color: '#000',
+    icon: '📚',
+  },
+  {
+    id: 'agents',
+    name: 'Agent Frameworks',
+    description: 'agent stuff',
+    repoCount: 1,
+    color: '#111',
+    icon: '🤖',
+  },
+  {
+    id: 'mlops',
+    name: 'MLOps',
+    description: 'ops stuff',
+    repoCount: 1,
+    color: '#222',
+    icon: '⚙️',
+  },
+];
+
+const allTags = ['rag-pipeline', 'vector-search', 'agent', 'tool-use', 'mlflow'];
+
+const categoryTagsMap = new Map<string, Set<string>>([
+  ['RAG Pipelines', new Set(['rag-pipeline', 'vector-search'])],
+  ['Agent Frameworks', new Set(['agent', 'tool-use'])],
+  ['MLOps', new Set(['mlflow'])],
+]);
+
+const tagMetricsFixture = allTags.map((tag, i) => ({
+  tag,
+  repoCount: allTags.length - i,
+  percentage: 0,
+  topLanguage: null,
+  languageBreakdown: {},
+  updatedLast30Days: 0,
+  updatedLast90Days: 0,
+  olderThan90Days: 0,
+  activityScore: 0,
+  relatedTags: [],
+  mostRecentRepo: '',
+  mostRecentDate: '',
+  repos: [],
+  avgUpstreamAge: 0,
+  avgTimeSinceForked: 0,
+  mostOutdatedRepo: '',
+  avgBehindBy: 0,
+}));
+
+function renderFilterBar(selectedCategory: string) {
+  return render(
+    <FilterBar
+      categories={categories}
+      categoryTagsMap={categoryTagsMap}
+      languages={[]}
+      allTags={allTags}
+      tagMetrics={tagMetricsFixture}
+      selectedCategory={selectedCategory}
+      selectedType="all"
+      selectedLanguage=""
+      selectedLicense=""
+      selectedTags={[]}
+      selectedActivity="all"
+      selectedSyncStatus="all"
+      sortBy="updated"
+      filteredCount={0}
+      onCategoryChange={() => {}}
+      onTypeChange={() => {}}
+      onLanguageChange={() => {}}
+      onLicenseChange={() => {}}
+      onTagToggle={() => {}}
+      onTagRemove={() => {}}
+      onActivityChange={() => {}}
+      onSyncStatusChange={() => {}}
+      onSortChange={() => {}}
+      onClear={() => {}}
+    />
+  );
+}
+
+describe('FilterBar — KAN-201 categoryTagsMap derivation', () => {
+  it('shows only tags belonging to the selected category', () => {
+    renderFilterBar('rag');
+    // Tags within RAG Pipelines should appear
+    expect(screen.getAllByText('rag-pipeline').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('vector-search').length).toBeGreaterThan(0);
+    // Tags from a different category should NOT appear in the in-category tag row
+    expect(screen.queryByText('mlflow')).toBeNull();
+    expect(screen.queryByText('tool-use')).toBeNull();
+  });
+
+  it('swaps visible tags when a different category is selected', () => {
+    const { rerender } = renderFilterBar('agents');
+    expect(screen.getAllByText('agent').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('tool-use').length).toBeGreaterThan(0);
+    expect(screen.queryByText('rag-pipeline')).toBeNull();
+
+    rerender(
+      <FilterBar
+        categories={categories}
+        categoryTagsMap={categoryTagsMap}
+        languages={[]}
+        allTags={allTags}
+        tagMetrics={tagMetricsFixture}
+        selectedCategory="mlops"
+        selectedType="all"
+        selectedLanguage=""
+        selectedLicense=""
+        selectedTags={[]}
+        selectedActivity="all"
+        selectedSyncStatus="all"
+        sortBy="updated"
+        filteredCount={0}
+        onCategoryChange={() => {}}
+        onTypeChange={() => {}}
+        onLanguageChange={() => {}}
+        onLicenseChange={() => {}}
+        onTagToggle={() => {}}
+        onTagRemove={() => {}}
+        onActivityChange={() => {}}
+        onSyncStatusChange={() => {}}
+        onSortChange={() => {}}
+        onClear={() => {}}
+      />
+    );
+
+    expect(screen.getAllByText('mlflow').length).toBeGreaterThan(0);
+    expect(screen.queryByText('agent')).toBeNull();
+    expect(screen.queryByText('rag-pipeline')).toBeNull();
+  });
+
+  it('shows all tags when no category is selected', () => {
+    renderFilterBar('');
+    // With no category selected, the broad tag list should include tags from
+    // every category — none are filtered out.
+    expect(screen.getAllByText('rag-pipeline').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('agent').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('mlflow').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to all tags when categoryTagsMap is missing', () => {
+    // Defensive: if the parent forgets to pass the map, the UI must not be
+    // empty — it should behave the same as having no category selected.
+    render(
+      <FilterBar
+        categories={categories}
+        languages={[]}
+        allTags={allTags}
+        tagMetrics={tagMetricsFixture}
+        selectedCategory="rag"
+        selectedType="all"
+        selectedLanguage=""
+        selectedLicense=""
+        selectedTags={[]}
+        selectedActivity="all"
+        selectedSyncStatus="all"
+        sortBy="updated"
+        filteredCount={0}
+        onCategoryChange={() => {}}
+        onTypeChange={() => {}}
+        onLanguageChange={() => {}}
+        onTagToggle={() => {}}
+        onTagRemove={() => {}}
+        onActivityChange={() => {}}
+        onSyncStatusChange={() => {}}
+        onSortChange={() => {}}
+        onClear={() => {}}
+      />
+    );
+    expect(screen.getAllByText('rag-pipeline').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('mlflow').length).toBeGreaterThan(0);
+  });
+});
+
+// silence the unused fireEvent import lint warning if it isn't otherwise referenced
+void fireEvent;

--- a/tests/unit/buildCategories.test.ts
+++ b/tests/unit/buildCategories.test.ts
@@ -145,7 +145,19 @@ describe('buildCategories', () => {
     expect(evalCat?.id).toBe('eval-frameworks');
     expect(evalCat?.icon).toBeDefined();
     expect(evalCat?.color).toBeDefined();
-    expect(Array.isArray(evalCat?.tags)).toBe(true);
+  });
+
+  it('KAN-201: build output strips internal `tags` field from public Category shape', () => {
+    const repos = [makeRepo({ enrichedTags: ['evals'] })];
+    const categories = buildCategories(repos);
+    for (const cat of categories) {
+      // The internal CATEGORIES table still carries tags, but the public
+      // shape returned to the frontend (and serialized over /library/aggregates)
+      // should not. KAN-201 dropped this to trim ~1.52 MB / 40% from the
+      // payload — frontend derives category-tag intersection from per-repo
+      // enrichedTags filtered by allCategories.
+      expect((cat as { tags?: unknown }).tags).toBeUndefined();
+    }
   });
 
   it('assigns allCategories with all matching categories', () => {

--- a/tests/unit/previewToLibraryData.test.ts
+++ b/tests/unit/previewToLibraryData.test.ts
@@ -133,7 +133,7 @@ describe('mergeAggregatesIntoLibraryData KAN-189', () => {
         avgBehindBy: 0,
       },
     ],
-    categories: [{ id: 'agents', name: 'Agents', description: '', tags: [], color: '#000', icon: '🤖', repoCount: 100 }],
+    categories: [{ id: 'agents', name: 'Agents', description: '', color: '#000', icon: '🤖', repoCount: 100 }],
     builderStats: [{ login: 'microsoft', displayName: 'Microsoft', category: 'big-tech', repoCount: 66, totalParentStars: 1, topRepos: [], avatarUrl: '' }],
     aiDevSkillStats: [{ skill: 'Foundation Model Architecture', lifecycleGroup: 'Foundation & Training', repoCount: 456, coverage: 'strong', topRepos: [] }],
     pmSkillStats: [{ skill: 'AI-Native Architecture', repoCount: 582, coverage: 'strong', topRepos: [] }],


### PR DESCRIPTION
## Summary

KAN-201 trims `categories[].tags` from `/library/aggregates`, the largest single contributor to the payload at **~1.52 MB / 40%** (per KAN-195 audit). This PR is the **frontend prereq** that removes the only consumer of that field — `FilterBar.tsx:165` — so PR2 against `reporium-api` can drop it without breaking anything.

JIRA: https://perditio.atlassian.net/browse/KAN-201

## Changes

- **`src/types/repo.ts`** — Drop `tags: string[]` from the public `Category` interface. The category→tag mapping is now an internal implementation detail (lives only in `lib/buildCategories.ts`).
- **`src/lib/buildCategories.ts`** — Introduce internal `CategoryDefinition extends Category` so the hardcoded `CATEGORIES` table can keep `tags` for primary-category assignment, but `buildCategories()` strips the field from public output (this is what serializes through the API).
- **`src/components/FilterBar.tsx`** — Accept a new optional `categoryTagsMap: Map<string, Set<string>>` prop. When a category is selected, filter `tagsToShow` against the per-category tag set. Falls back to the full tag list when the map is absent (defensive).
- **`src/components/HomePageClient.tsx`** — Derive `categoryTagsMap` via `useMemo` from per-repo `enrichedTags` filtered by `allCategories.includes(cat.name)` — same pattern `MetricsSidebar.CategoryDetailView` already uses against the local `CATEGORIES` table.
- **Tests** — New `tests/FilterBar.categoryTags.test.tsx` asserts the derivation drives the tag row correctly. Updated `buildCategories.test.ts` to assert the public output strips the field. Updated `previewToLibraryData.test.ts` fixture.

## Sequencing — important

This PR ships first and must be merged + deployed to production main **before** PR2 drops the field server-side. After this lands, the API still serializes `tags` but nothing reads it; once the API trim merges, the field is gone.

## Verification

- `npm run type-check` — clean
- `npm test` — 419/419 pass (including 4 new FilterBar derivation tests + 1 new shape-strip test)
- `npm run build` — succeeds

## Test plan

- [x] Unit tests pass
- [x] Type-check passes
- [x] Build succeeds
- [ ] Vercel preview: filter UI surfaces category-specific tags when a category is selected
- [ ] Vercel preview: switching categories swaps the tag row

🤖 Generated with [Claude Code](https://claude.com/claude-code)