### PR TITLE
KAN-DRAFT: stop false '-100% cooling' trends from frozen commit data

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,23 +1,27 @@
 # Reporium Roadmap
 
-## Current State (March 2026)
+## Current State
 
 `reporium` is the human-facing Next.js frontend for the Reporium suite.
 
 - The main dashboard browses the live portfolio with keyword and semantic search modes
 - `/ask` provides a dedicated natural-language query page backed by the API intelligence layer
-- `/runs` shows ingestion run history and operational status
 - `/taxonomy` provides a Taxonomy Explorer for the live multi-dimensional taxonomy
+- `/trends` shows trending/emerging/cooling activity across the library
+- `/insights` surfaces portfolio insights, cross-dimension analytics, and gap analysis
+- `/graph` renders the knowledge-graph visualization of the library
+- `/stacks`, `/wiki`, `/ai-native`, and `/architecture` provide curated browse experiences over the taxonomy
 - `/repo/[name]` renders repo detail pages with taxonomy, quality, dependencies, similar repos, and related metadata
-- The dashboard surfaces portfolio insights, cross-dimension analytics, gap analysis, and a Trending This Week widget
+- `/faq` documents how the library and forking workflow work
 - Repo cards show quality badges, license badges, open issues, semantic match percentages, and taxonomy-aware metadata
 - Taxonomy filters are live in the sidebar across AI trends, industries, use cases, modalities, deployment context, license, skills, PM skills, tags, and builders
 
 ## Recent Platform Additions
 
 - Ask page and lightweight ask-entry points from the main dashboard
-- Run history page and reusable runs table
-- Taxonomy Explorer page for the 8-dimension taxonomy model
+- Trends page with trending/emerging/cooling signals and a staleness banner
+- Taxonomy Explorer page for the multi-dimension taxonomy model
+- Knowledge-graph visualization page
 - Similar Repos section on repo detail pages
 - Gap analysis grouped by taxonomy dimension
 - Trending widget and proactive portfolio insights widgets

--- a/src/lib/detectTrends.ts
+++ b/src/lib/detectTrends.ts
@@ -36,6 +36,18 @@ export function computeTrendSignals(
   const cooling: TrendSignal[] = [];
   const stable: TrendSignal[] = [];
 
+  // Guard against frozen commit-stat input: when the current snapshot has no
+  // commit activity at all (upstream collection stalled), every previously
+  // active tag would otherwise register as a false "-100% cooling" signal.
+  // Treat this as "no data to report" rather than fabricating a cooldown.
+  const currentTotalActivity = [...allTags].reduce(
+    (sum, tag) => (SYSTEM_TAGS.has(tag) ? sum : sum + tagActivity(currentSnapshot, tag).count),
+    0
+  );
+  if (currentTotalActivity === 0) {
+    return { trending, emerging, cooling, stable };
+  }
+
   for (const tag of allTags) {
     if (SYSTEM_TAGS.has(tag)) continue;
     const current = tagActivity(currentSnapshot, tag);

--- a/tests/unit/detectTrends.test.ts
+++ b/tests/unit/detectTrends.test.ts
@@ -163,6 +163,39 @@ describe('computeTrendSignals', () => {
     expect(signal?.changePercent).toBeLessThan(0);
   });
 
+  it('returns empty buckets when the current snapshot has zero total commit activity (frozen commit-stat input)', () => {
+    // Regression guard: when commit-stat collection freezes upstream, every
+    // repo's last7Days reads 0. Previously this produced a wall of false
+    // "-100% cooling" signals (and a public "everything slowed 100%" insight)
+    // because cooling only requires previous>5 + a >30% drop. With no current
+    // activity at all, there is nothing real to report — emit empty buckets.
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['RAG'], commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+      makeRepo({ name: 'b', enrichedTags: ['LLM'], commitStats: { today: 0, last7Days: 0, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['RAG'], commitStats: { today: 0, last7Days: 40, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+      makeRepo({ name: 'b', enrichedTags: ['LLM'], commitStats: { today: 0, last7Days: 70, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    expect(result.trending).toHaveLength(0);
+    expect(result.emerging).toHaveLength(0);
+    expect(result.cooling).toHaveLength(0);
+    expect(result.stable).toHaveLength(0);
+  });
+
+  it('still reports cooling when current activity is present but reduced', () => {
+    // Sanity: the zero-activity guard must NOT suppress genuine cooling.
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['OldTech'], commitStats: { today: 0, last7Days: 3, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['OldTech'], commitStats: { today: 0, last7Days: 10, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    expect(result.cooling.find(s => s.name === 'OldTech')).toBeDefined();
+  });
+
   it('filters out system tags (Forked, Active, etc.)', () => {
     const current = makeSnapshot([
       makeRepo({ name: 'a', enrichedTags: ['Active', 'Forked'], commitStats: { today: 0, last7Days: 20, last30Days: 0, last90Days: 0, recentCommits: [] } }),


### PR DESCRIPTION
## Summary
Public-facing correctness fix for the **Trends** widget. When upstream commit-stat collection freezes, every repo's `last7Days` reads 0, and the cooling rule (`previous>5` + a >30% drop) fired for *every* active tag — so reporium.com showed a false wall of "-100% cooling" and the insight *"Activity in X has slowed by 100% this week."*

`computeTrendSignals` now treats a current snapshot with **zero total commit activity** as "no data to report" and returns empty buckets; the insight generator falls back to its neutral message instead of fabricating a cooldown. Also refreshes `ROADMAP.md` to the live route set (drops the removed `/runs` and `/api/health`).

> This is the frontend guard. The underlying data freeze is fixed in reporium-ingestion #98 + reporium-api #495.

## Test plan
- [x] `jest tests/unit/detectTrends.test.ts` (degenerate zero-activity + non-degenerate cooling sanity)
- [x] trend-related suites green (17 passed)
- [x] `tsc --noEmit` clean
- [x] Codex review: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)