### PR TITLE
KAN-DRAFT: require a real baseline to trend + clamp change %

### DIFF
--- a/src/lib/detectTrends.ts
+++ b/src/lib/detectTrends.ts
@@ -2,6 +2,11 @@ import { LibraryData, TrendSignal } from '@/types/repo';
 
 const SYSTEM_TAGS = new Set(['Forked', 'Built by Me', 'Active', 'Inactive', 'Archived', 'Popular']);
 
+// Minimum previous-week activity for a tag to qualify as "trending" rather than
+// "emerging". Below this, a growth percentage off the near-zero base is noise
+// (e.g. 1→20 reads as +1900%), so the tag is treated as newly emerging instead.
+const TREND_BASELINE = 5;
+
 /**
  * Compute total commit activity for a given tag across repos in a snapshot.
  * Uses commitStats.last7Days if available, falls back to commitsLast7Days length or weeklyCommitCount.
@@ -60,13 +65,22 @@ export function computeTrendSignals(
       type: 'tag',
       currentActivity: current.count,
       previousActivity: previous.count,
-      changePercent: Math.round(changePercent),
+      // Clamp the DISPLAYED percent to a sane band. Growth off a tiny base
+      // produces nonsense numbers (a 0→20 jump is "+2000%"); even with the
+      // baseline gate below, clamp so the UI never shows "+22800%".
+      changePercent: Math.max(-100, Math.min(Math.round(changePercent), 999)),
       repoCount,
       representativeRepos: current.repos,
     };
 
-    if (changePercent > 50 && current.count > 5) trending.push(signal);
-    else if (previous.count < 2 && current.count > 5) emerging.push(signal);
+    // A tag can only "trend" if it had a real previous baseline — otherwise the
+    // growth percent is meaningless (a tag going 0→20 isn't trending +2000%,
+    // it's newly active). This matters most right after a commit-stat thaw,
+    // when the prior ~7 days of snapshots are still all-zero: every active tag
+    // would otherwise explode into the trending bucket with absurd percentages.
+    // Low-baseline tags are routed to "emerging" instead. (checked FIRST.)
+    if (previous.count < TREND_BASELINE && current.count > 5) emerging.push(signal);
+    else if (changePercent > 50 && current.count > 5) trending.push(signal);
     else if (changePercent < -30 && previous.count > 5) cooling.push(signal);
     else if (Math.abs(changePercent) < 20 && current.count > 3) stable.push(signal);
   }

--- a/tests/unit/detectTrends.test.ts
+++ b/tests/unit/detectTrends.test.ts
@@ -128,26 +128,21 @@ describe('computeTrendSignals', () => {
     expect(ragSignal?.changePercent).toBe(100);
   });
 
-  it('identifies an emerging tag (previous activity 0, current > 5)', () => {
-    // A tag that didn't exist in previous snapshot (count = 0) but has activity now
-    // previous.count will be 0 which is < 2, and current.count = 10 > 5
-    // changePercent = (10-0)/max(0,1)*100 = 1000% > 50, so it goes into trending first
-    // To test emerging specifically: need previous.count < 2 AND changePercent <= 50
-    // That's hard to achieve, so just verify the tag shows up in either trending OR emerging
+  it('identifies an emerging tag (previous activity below baseline, current > 5)', () => {
+    // A tag absent from the previous snapshot (count = 0 < TREND_BASELINE) with
+    // activity now. It must land in `emerging` — NOT `trending` — so its
+    // meaningless growth-off-zero percent never surfaces as a trend.
     const current = makeSnapshot([
       makeRepo({ name: 'a', enrichedTags: ['NewTech'], commitStats: { today: 0, last7Days: 10, last30Days: 0, last90Days: 0, recentCommits: [] } }),
     ]);
     const previous = makeSnapshot([
-      // NewTech not in previous at all (count = 0 < 2), current = 10 > 5
       makeRepo({ name: 'a', enrichedTags: ['OtherTag'], commitStats: { today: 0, last7Days: 1, last30Days: 0, last90Days: 0, recentCommits: [] } }),
     ]);
     const result = computeTrendSignals(current, previous);
-    // With previous.count = 0, changePercent = 1000% > 50, so trending wins over emerging
-    // The tag should appear in trending (since changePercent > 50 and current.count > 5)
-    const allSignals = [...result.trending, ...result.emerging, ...result.cooling, ...result.stable];
-    const signal = allSignals.find(s => s.name === 'NewTech');
+    const signal = result.emerging.find(s => s.name === 'NewTech');
     expect(signal).toBeDefined();
     expect(signal?.currentActivity).toBe(10);
+    expect(result.trending.find(s => s.name === 'NewTech')).toBeUndefined();
   });
 
   it('identifies a cooling tag (>30% decrease, previous > 5)', () => {
@@ -194,6 +189,60 @@ describe('computeTrendSignals', () => {
     ]);
     const result = computeTrendSignals(current, previous);
     expect(result.cooling.find(s => s.name === 'OldTech')).toBeDefined();
+  });
+
+  it('routes a near-zero-baseline tag to emerging, not trending with an absurd percent', () => {
+    // Post-thaw shape: current snapshot has real activity, previous is ~0.
+    // Must NOT explode into trending at +4000%.
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['Postthaw'], commitStats: { today: 0, last7Days: 40, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['OtherTag'], commitStats: { today: 0, last7Days: 8, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    expect(result.trending.find(s => s.name === 'Postthaw')).toBeUndefined();
+    const emerging = result.emerging.find(s => s.name === 'Postthaw');
+    expect(emerging).toBeDefined();
+    expect(emerging!.changePercent).toBeLessThanOrEqual(999);
+  });
+
+  it('requires a previous baseline >= 5 to trend (low baseline => emerging)', () => {
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['LowBase'], commitStats: { today: 0, last7Days: 50, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['LowBase'], commitStats: { today: 0, last7Days: 4, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    expect(result.trending.find(s => s.name === 'LowBase')).toBeUndefined();
+    expect(result.emerging.find(s => s.name === 'LowBase')).toBeDefined();
+  });
+
+  it('clamps the displayed changePercent to <= 999 even for a real-baseline explosion', () => {
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['Boom'], commitStats: { today: 0, last7Days: 600, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['Boom'], commitStats: { today: 0, last7Days: 5, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    const sig = result.trending.find(s => s.name === 'Boom');
+    expect(sig).toBeDefined();           // prev=5 meets baseline -> trends
+    expect(sig!.changePercent).toBe(999); // raw ~11900% clamped
+  });
+
+  it('still trends a tag with a real baseline and moderate growth', () => {
+    const current = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['RealTrend'], commitStats: { today: 0, last7Days: 30, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const previous = makeSnapshot([
+      makeRepo({ name: 'a', enrichedTags: ['RealTrend'], commitStats: { today: 0, last7Days: 10, last30Days: 0, last90Days: 0, recentCommits: [] } }),
+    ]);
+    const result = computeTrendSignals(current, previous);
+    const sig = result.trending.find(s => s.name === 'RealTrend');
+    expect(sig).toBeDefined();
+    expect(sig!.changePercent).toBe(200);
   });
 
   it('filters out system tags (Forked, Active, etc.)', () => {


### PR DESCRIPTION
## Summary
Hardens `detect-trends` for the post-thaw transition. When commit stats are refreshed, the prior ~7 days of `library.json` snapshots are still all-zero, so `computeTrendSignals` computed huge growth percentages off a zero base (e.g. `0→20` = `+2000%`) and dumped every active tag into **trending** with absurd numbers — exactly the "+22800%" artifact. The #308 all-zero-*current* guard didn't cover the zero-*previous* case.

## Fix
- A tag only enters **trending** if `previous.count >= TREND_BASELINE` (5); low-baseline tags with `current > 5` are routed to **emerging** (branch checked first). Trending percentages now always have a meaningful denominator.
- Displayed `changePercent` clamped to `[-100, 999]` (raw value still used for bucket conditions) so the UI never shows nonsense.

## Why now
Prereq for triggering the frontend "Refresh Library Data" workflow post-thaw — without it, the regenerated `trends.json` would show garbage trending numbers during the ~7-day window while historical snapshots catch up.

## Test plan
- [x] `jest tests/unit/detectTrends.test.ts` — 17 pass incl. new: zero-baseline→emerging, baseline gate, clamp to 999, real-baseline trend, tightened emerging assertion
- [x] TrendsPage suites pass; `tsc --noEmit` clean
- [x] Codex review: APPROVE (implementation; one stale-test note addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)